### PR TITLE
feat: ship the memory service on npm as titen-memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+Guidance for Claude Code (claude.ai/code) in this repository.
+
+## Read AGENTS.md first
+
+[`AGENTS.md`](./AGENTS.md) is the authoritative agent contract: product framing,
+reading order, the `spec -> plan -> implement -> done` lifecycle, coding
+constraints, the simplicity budget, security, and verification rules. It is not
+duplicated here. This file only adds what an agent cannot infer from it.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Install | `pnpm install` |
+| Memory service (local) | `pnpm titen serve` — Bun + SQLite on `127.0.0.1:8787` |
+| Bootstrap org + owner key | `pnpm titen bootstrap --org 'My Org'` |
+| Contract + SDK tests | `pnpm test:api` (Bun) |
+| Integration tests | `pnpm test:integration` |
+| Dashboard build + browser tests | `pnpm test` |
+| Everything | `pnpm test:all` |
+| Workflow doc check (before handoff) | `pnpm check:workflow` |
+| Cloudflare dry-run build | `pnpm build:worker` |
+
+A single test file: `bun test tests/contract/<name>.test.ts`.
+
+## Two runtimes, one core
+
+`src/core/**` has **zero external imports** and uses Web Standards only. That is
+load-bearing, not incidental — it is what lets the same kernel run on
+`bun:sqlite` and on Cloudflare D1 against one contract suite. Keep it that way:
+
+- Runtime-specific code goes in `src/runtime/bun/**` or `src/runtime/cloudflare/**`.
+- `bun:sqlite` appears in exactly one file, `src/runtime/bun/sqlite.ts`.
+- `sqlite-vec` is loaded through a lazy `require()` in `src/runtime/bun/vectors.ts`
+  and is an `optionalDependency`; retrieval degrades to lexical FTS5 when it is
+  absent, and `/readyz` reports the capability as disabled.
+
+## Publishing to npm
+
+Releases are **manual, from a maintainer's machine — never a GitHub Action**.
+The full procedure is [`docs/engineering/release.md`](./docs/engineering/release.md).
+Two facts that will bite an agent editing `package.json`:
+
+- `files` is an allowlist that overrides `.gitignore`, which is the only reason
+  the gitignored `dist/npm/sdk.js` reaches the tarball. Adding a build output
+  outside `files` silently ships nothing.
+- `astro`, `wrangler`, `playwright`, and `miniflare` are **devDependencies** on
+  purpose. Promoting any of them to `dependencies` installs a build toolchain on
+  every consumer's disk.
+
+Run `bash scripts/verify-pack.sh` after touching `package.json`, `src/sdk.ts`,
+or anything under `src/runtime/bun/`. It installs the real tarball into a
+throwaway directory and fails if the CLI, the server, or the Node SDK import
+breaks. `npm publish` cannot be undone after 72 hours; the script can.
+
+## Claims discipline
+
+The dashboard preview runs on a synthetic fixture, not the memory API. Never
+present it as live service evidence. Likewise, do not claim Cloudflare or VPS
+support for a change until a real runtime smoke test passes — `AGENTS.md`
+treats this as a hard rule and the repository's commit history reflects
+enforcing it.

--- a/README.md
+++ b/README.md
@@ -85,13 +85,33 @@ security, hosting, and rollback boundaries.
 
 ### Local / VPS (Bun)
 
+No clone required — the CLI ships on npm:
+
 ```bash
-pnpm install
-pnpm titen bootstrap --org 'My Org'
+bunx titen-memory bootstrap --org 'My Org'
 # Save the printed api_key — it cannot be shown again
-pnpm titen serve
+bunx titen-memory serve
 # Memory service at http://127.0.0.1:8787
 curl http://127.0.0.1:8787/healthz
+```
+
+The CLI needs **Bun**: it runs on `bun:sqlite`, so `npx titen-memory` only works
+with Bun on `PATH`. From a clone, the same commands are `pnpm titen bootstrap`
+and `pnpm titen serve` after `pnpm install`.
+
+### Agent SDK (any runtime)
+
+The client is plain `fetch` — Node 22+, Bun, Deno, and edge workers:
+
+```bash
+npm i titen-memory      # or: pnpm add titen-memory / bun add titen-memory
+```
+
+```ts
+import { TitenClient } from "titen-memory";
+
+const titen = new TitenClient({ url: "http://127.0.0.1:8787", key: process.env.TITEN_KEY! });
+const ctx = await titen.compile({ subject_id: "user_x", task: "…", max_tokens: 900 });
 ```
 
 ### Cloudflare Workers

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -3,7 +3,7 @@
 ## Quick start
 
 ```typescript
-import { TitenClient } from "titen/sdk";
+import { TitenClient } from "titen-memory/sdk";
 
 const titen = new TitenClient({
   url: "http://127.0.0.1:8787",
@@ -147,7 +147,7 @@ const key = await titen.createKey({
 ## Error handling
 
 ```typescript
-import { TitenError } from "titen/sdk";
+import { TitenError } from "titen-memory/sdk";
 
 try {
   await titen.observe({ ... });

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -4,10 +4,31 @@ Status: **verified** — P0 memory service operational on Bun 1.3+ with SQLite (
 
 ## Quick start
 
+Prerequisites: Bun 1.3+.
+
+```bash
+# Bootstrap org — prints org_id and api_key
+bunx titen-memory bootstrap --org 'My Org'
+
+# Start the memory service (defaults to 127.0.0.1:8787)
+bunx titen-memory serve
+
+# Verify
+curl http://127.0.0.1:8787/healthz
+```
+
+The `titen` CLI runs on Bun: it uses `bun:sqlite`. `npx titen-memory` fails
+unless Bun is on `PATH`, because the published `bin` carries a
+`#!/usr/bin/env bun` shebang. The SDK (`import { TitenClient } from
+"titen-memory"`) is plain `fetch` and runs on Node 22+, Bun, Deno, and workers
+alike.
+
+## Quick start from a clone
+
 Prerequisites: Bun 1.3+, git, pnpm.
 
 ```bash
-git clone https://github.com/anthropic-labs/titen.git
+git clone https://github.com/RamaAditya49/titen.git
 cd titen
 pnpm install
 

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -1,0 +1,94 @@
+# Release
+
+The npm package is **`titen-memory`**, not `titen`. The registry rejects the
+short name outright:
+
+```
+403 Forbidden - PUT https://registry.npmjs.org/titen
+Package name too similar to existing package vite
+```
+
+That is npm's typosquat filter, not a name collision — `npm view titen` returns
+404 to this day. Do not "fix" `package.json` back to `titen`; the publish will
+fail at the registry after every local check has passed. The **CLI command is
+still `titen`**, because that comes from `bin`, not from the package name.
+
+Titen publishes to npm **manually, from a maintainer's machine**. There is no
+release GitHub Action and adding one is a decision, not a chore: the npm token
+would then live in repository secrets, and a compromised workflow could publish
+on its own. Publishing by hand keeps the credential on one machine.
+
+## What ships
+
+`package.json#files` is an allowlist, so the tarball is 41 files / ~73 kB:
+
+| Included | Why |
+| --- | --- |
+| `src/core/**` | The shared kernel. Zero external imports, Web Standards only. |
+| `src/runtime/bun/**` | The `titen` CLI and `Bun.serve` runtime. |
+| `src/sdk.ts` | Source of truth for the SDK, and its `types` entry. |
+| `dist/npm/sdk.js` | Type-stripped SDK for Node/Deno/workers, built by `prepack`. |
+
+Not shipped: the Astro dashboard (`src/pages`, `src/styles`), the Cloudflare
+adapter (deploy that from a clone with `wrangler`), tests, and docs.
+
+Consumers install **three** packages — `titen`, `sqlite-vec`, and its platform
+binary. `astro`, `wrangler`, `playwright`, and `miniflare` are devDependencies
+and must stay there; moving one into `dependencies` puts a build toolchain on
+every user's disk.
+
+## Publishing
+
+```bash
+# 0. One time per machine — interactive, do this yourself.
+npm login
+
+# 1. Clean tree, tests green.
+git status --short          # must be empty
+pnpm test:all
+
+# 2. Bump. This also creates the vN.N.N tag.
+npm version <patch|minor|major>
+
+# 3. Prove the tarball works before it becomes permanent (see below).
+#    npm publish is irreversible after 72 hours.
+bash scripts/verify-pack.sh
+
+# 4. Ship.
+npm publish                 # prepack rebuilds dist/npm/sdk.js
+git push && git push --tags
+```
+
+`npm publish` is the right command even though the repo uses pnpm: `pnpm
+publish` refuses a dirty tree and re-runs the workspace lifecycle, which buys
+nothing here. Either works.
+
+## Verifying a candidate
+
+`scripts/verify-pack.sh` packs the current tree, installs the tarball into a
+throwaway directory, and asserts the five things a broken publish breaks:
+
+1. npm's publish-time normalization still ships a `titen` bin;
+2. the dependency tree contains no build toolchain;
+3. `titen bootstrap` creates a database and an API key;
+4. `titen serve` answers `/readyz` with every migration applied;
+5. plain `node` can `import { TitenClient } from "titen-memory"` and `"titen-memory/sdk"`.
+
+Check 1 exists because `npm publish` rewrites `package.json` and `npm pack` does
+not — a `bin` entry can vanish at publish time and in no earlier step. npm's own
+warning for this is misleading: `"bin[titen]" script name … was invalid and
+removed` also fires when npm merely strips a leading `./` and keeps the entry.
+The check reports what the field actually becomes instead of what npm calls it.
+
+Run it before every publish. It exits non-zero on the first failure.
+
+## After publishing
+
+```bash
+bunx titen-memory@latest --help
+npm view titen-memory version
+```
+
+The npmjs.com page renders `README.md` and resolves its relative image paths
+against the GitHub repo, so push the tag before or with the publish or the
+banner will 404.

--- a/package.json
+++ b/package.json
@@ -1,15 +1,51 @@
 {
-  "name": "titen",
-  "version": "1.0.0",
-  "private": true,
+  "name": "titen-memory",
+  "version": "0.1.1",
+  "description": "Collaborative memory fabric for AI agents — evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
+  "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@11.17.0",
-  "exports": {
-    "./sdk": "./src/sdk.ts"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RamaAditya49/titen.git"
   },
+  "homepage": "https://github.com/RamaAditya49/titen#readme",
+  "bugs": "https://github.com/RamaAditya49/titen/issues",
+  "keywords": [
+    "agent-memory",
+    "memory",
+    "rag",
+    "context",
+    "mcp",
+    "bun",
+    "sqlite",
+    "cloudflare-workers"
+  ],
+  "bin": {
+    "titen": "src/runtime/bun/cli.ts"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/sdk.ts",
+      "bun": "./src/sdk.ts",
+      "default": "./dist/npm/sdk.js"
+    },
+    "./sdk": {
+      "types": "./src/sdk.ts",
+      "bun": "./src/sdk.ts",
+      "default": "./dist/npm/sdk.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src/core",
+    "src/runtime/bun",
+    "src/sdk.ts",
+    "dist/npm"
+  ],
   "engines": {
     "node": ">=22",
-    "pnpm": ">=10"
+    "bun": ">=1.2"
   },
   "scripts": {
     "dev": "astro dev",
@@ -20,6 +56,8 @@
     "test:api": "pnpm build:worker && bun test tests/contract tests/sdk",
     "test:all": "pnpm test:api && pnpm test:integration && pnpm test && pnpm check:workflow",
     "build:worker": "WRANGLER_SEND_METRICS=false wrangler deploy --dry-run --outdir dist/worker",
+    "build:npm": "bun build src/sdk.ts --outfile dist/npm/sdk.js --target node --format esm",
+    "prepack": "bun run build:npm",
     "deploy:worker": "WRANGLER_SEND_METRICS=false wrangler deploy",
     "titen": "bun src/runtime/bun/cli.ts",
     "screenshots": "playwright test tests/dashboard-screenshots.spec.ts",
@@ -27,14 +65,12 @@
     "verify:dashboard-live": "bun scripts/verify-dashboard-live.ts",
     "test:integration": "bun test tests/integration"
   },
-  "dependencies": {
-    "astro": "7.1.4"
-  },
   "devDependencies": {
     "@fontsource-variable/bricolage-grotesque": "5.3.0",
     "@fontsource-variable/instrument-sans": "5.3.0",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@playwright/test": "1.62.0",
+    "astro": "7.1.4",
     "miniflare": "4.20260722.1",
     "wrangler": "4.115.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      astro:
-        specifier: 7.1.4
-        version: 7.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
     devDependencies:
       '@fontsource-variable/bricolage-grotesque':
         specifier: 5.3.0
@@ -24,6 +20,9 @@ importers:
       '@playwright/test':
         specifier: 1.62.0
         version: 1.62.0
+      astro:
+        specifier: 7.1.4
+        version: 7.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       miniflare:
         specifier: 4.20260722.1
         version: 4.20260722.1

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Prove the npm tarball works before publishing it. npm publish cannot be
+# undone after 72 hours, so this runs against a real install in a throwaway
+# directory rather than against the working tree, where every path resolves
+# even when `files` forgot to ship it.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+root="$PWD"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+echo "==> 1/5 publish-time normalization"
+# npm rewrites package.json on publish and `npm pack` does not, so a bin entry
+# can be dropped there and nowhere else — invisible to every check below. Ask
+# npm's own normalizer what it will actually ship instead of trusting the
+# tarball. It is also the only place the misleading "was invalid and removed"
+# wording gets resolved into what the field really becomes.
+node -e '
+  const path = require("path");
+  const [npmRoot, dir] = process.argv.slice(1);
+  const PackageJson = require(path.join(npmRoot, "npm/node_modules/@npmcli/package-json"));
+  PackageJson.load(dir).then(async (pj) => {
+    const changes = [];
+    await pj.normalize({ steps: ["binDir", "bin", "fixRepositoryField", "fixBugsField"], changes });
+    for (const c of changes) console.log("    npm will rewrite: " + c);
+    const bin = pj.content.bin;
+    if (!bin || !bin.titen) throw new Error("publish would ship no `titen` bin");
+    console.log("    bin.titen -> " + bin.titen);
+  }).catch((error) => { console.error("FAIL: " + error.message); process.exit(1); });
+' "$(npm root -g)" "$root"
+
+echo "==> packing"
+tarball="$work/$(npm pack --pack-destination "$work" --silent | tail -1)"
+
+echo "==> installing $(basename "$tarball") into a clean tree"
+cd "$work"
+npm init -y >/dev/null
+npm install "$tarball" >/dev/null
+
+echo "==> 2/5 dependency tree"
+installed="$(ls node_modules | grep -v '^\.' | sort | tr '\n' ' ')"
+echo "    $installed"
+for toolchain in astro wrangler playwright miniflare vite esbuild; do
+  if [ -d "node_modules/$toolchain" ]; then
+    echo "FAIL: $toolchain reached consumers; it belongs in devDependencies" >&2
+    exit 1
+  fi
+done
+
+echo "==> 3/5 titen bootstrap"
+./node_modules/.bin/titen bootstrap --db "$work/t.db" --org 'Pack Verify' \
+  | grep -q '^api_key: titen_' \
+  || { echo "FAIL: bootstrap printed no API key" >&2; exit 1; }
+
+echo "==> 4/5 titen serve"
+# Port 0 would be cleaner, but the CLI prints the bound URL and nothing parses
+# it back, so pick a high fixed port and fail loudly if it is busy.
+port=8899
+./node_modules/.bin/titen serve --db "$work/t.db" --port "$port" >"$work/serve.log" 2>&1 &
+server=$!
+trap 'kill "$server" 2>/dev/null || true; rm -rf "$work"' EXIT
+for _ in $(seq 1 60); do
+  curl -sf "http://127.0.0.1:$port/healthz" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+ready="$(curl -sf "http://127.0.0.1:$port/readyz" || true)"
+case "$ready" in
+  *'"ready":true'*) : ;;
+  *) echo "FAIL: /readyz not ready: ${ready:-<no response>}" >&2; cat "$work/serve.log" >&2; exit 1 ;;
+esac
+kill "$server" 2>/dev/null || true
+trap 'rm -rf "$work"' EXIT
+
+echo "==> 5/5 SDK on plain node"
+node --input-type=module -e '
+  const { createRequire } = await import("node:module");
+  const { TitenClient } = await import("titen-memory");
+  const sub = await import("titen-memory/sdk");
+  if (typeof TitenClient !== "function" || typeof sub.TitenClient !== "function")
+    throw new Error("SDK did not export TitenClient");
+  // An "exports" map hides every subpath it does not list, including this one.
+  // Bundlers and tooling read it, so the omission only surfaces downstream.
+  createRequire(process.cwd() + "/").resolve("titen-memory/package.json");
+' || { echo "FAIL: node cannot import the SDK" >&2; exit 1; }
+
+echo
+echo "OK — $(basename "$tarball") is publishable."

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2,7 +2,7 @@
  * Titen Agent SDK — minimal TypeScript client for the memory service.
  *
  * Usage:
- *   import { TitenClient } from "titen/sdk";
+ *   import { TitenClient } from "titen-memory/sdk";
  *   const titen = new TitenClient({ url: "http://127.0.0.1:8787", key: "titen_sk_..." });
  *   const obs = await titen.observe({ subject_id: "user_x", kind: "tool_result", content: "...", source: { type: "tool", ref: "..." } });
  *   const ctx = await titen.compile({ subject_id: "user_x", task: "...", max_tokens: 900 });


### PR DESCRIPTION
## What

Makes the CLI and SDK installable from the registry instead of only from a clone.

```bash
bunx titen-memory serve          # CLI — command name is still `titen`
npm i titen-memory               # SDK — plain fetch, Node 22+/Bun/Deno/workers
```

`titen-memory@0.1.0` is already live; this branch carries the `0.1.1` bump.

## Why the name is not `titen`

The registry refuses it:

```
403 Forbidden - PUT https://registry.npmjs.org/titen
Package name too similar to existing package vite
```

That is npm's typosquat filter, not a collision — `npm view titen` still returns
404. The **CLI command remains `titen`**, because that comes from `bin` rather
than from the package name.

## Changes

- `astro` moves to devDependencies. It only builds the dashboard, but it was a
  runtime dependency, so every consumer installed a build toolchain. A consumer
  tree is now three packages: `titen-memory`, `sqlite-vec`, and its platform binary.
- `files` ships the kernel, the Bun runtime, and a type-stripped SDK for Node.
  Dashboard, Cloudflare adapter, tests, and docs stay out. Tarball is 41 files / 73 kB.
- `exports` maps the SDK for Node, Bun, and TypeScript, and lists `./package.json`,
  which an exports map otherwise hides from bundlers and tooling.
- `scripts/verify-pack.sh` — a five-step gate, run before every publish.
- `docs/engineering/release.md` — the manual release procedure.
- `CLAUDE.md` — points at `AGENTS.md` rather than duplicating it; adds the
  packaging invariants an agent editing `package.json` would otherwise break.

## Why no GitHub Action

Deliberate. A release workflow would put an npm token in repository secrets and
let a compromised workflow publish on its own. Publishing by hand keeps the
credential on one machine.

## Verification

`scripts/verify-pack.sh` installs the **real tarball** into a throwaway directory,
because every path resolves in the working tree even when `files` forgot to ship it:

| Check | Catches |
| --- | --- |
| publish-time normalization | `npm publish` rewrites package.json and `npm pack` does not — a dropped `bin` is invisible to every other step |
| dependency tree | a build toolchain reaching consumers |
| `titen bootstrap` | broken kernel/migrations in the shipped file set |
| `titen serve` → `/readyz` | server not starting from the installed layout |
| SDK on plain `node` | missing `dist/npm/sdk.js` or an unlisted subpath |

Each check was negative-tested — removing `dist/npm` from `files`, breaking `bin`,
and dropping the `./package.json` export each produce `exit 1`.

Post-publish, confirmed against the live registry: `bunx titen-memory@0.1.0` resolves
and prints usage, `.bin/titen` symlinks correctly, and published metadata shows
`bin: {"titen":"src/runtime/bun/cli.ts"}`.

> [!NOTE]
> npm's warning for a normalized bin reads `"bin[titen]" script name … was invalid
> and removed` even when the entry survives — it also fires for a stripped leading
> `./`. Check 1 reports what the field actually becomes instead.

## Scope

Packaging only. The in-flight `live-deployment-rama-tuf` work (`src/core/*`,
`tests/contract/*`, `deploy/`, `scripts/verify-live.ts`) is deliberately **not**
in this branch and remains uncommitted in the working tree; its spec and plan are
still `status: active`. `README.md` and `docs/deployment/vps.md` carry only this
branch's hunks.