### PR TITLE
docs: add a changelog, and generate GitHub release notes from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+All notable changes to Titen are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the version stays below `1.0.0`, a **minor** bump may carry a breaking
+change — any entry that does will say so under **Changed** and name the
+migration.
+
+The published npm package is [`titen-memory`](https://www.npmjs.com/package/titen-memory).
+The **CLI command is `titen`** regardless; see [Package name](#package-name).
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.1.1] — 2026-07-30
+
+### Fixed
+
+- **`./package.json` is reachable again.** An `exports` map hides every subpath
+  it does not list, so `require("titen-memory/package.json")` failed with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED`. Bundlers and tooling read that file. It is
+  now listed explicitly, and `scripts/verify-pack.sh` fails if it stops
+  resolving.
+
+## [0.1.0] — 2026-07-30
+
+First published release. Titen was previously reachable only by cloning the
+repository.
+
+### Added
+
+- **`titen` CLI on the registry.** `bunx titen-memory serve` starts the memory
+  service with no clone and no build step. Also `bootstrap`, `migrate`,
+  `key create|list|revoke`, `backup`, and `schema`.
+- **Agent SDK for every runtime.** `import { TitenClient } from "titen-memory"`
+  is plain `fetch` — Node 22+, Bun, Deno, and edge workers. The `titen-memory/sdk`
+  subpath resolves to the same client.
+- **`scripts/verify-pack.sh`** — the release gate. It installs the real tarball
+  into a throwaway directory and exercises bootstrap, serve, and the SDK, because
+  every path resolves in a working tree even when `files` forgot to ship it.
+- **`docs/engineering/release.md`** — the manual release procedure.
+- **`CLAUDE.md`** — agent guidance that points at `AGENTS.md` instead of
+  restating it.
+
+### Changed
+
+- **`astro` moved to `devDependencies`.** It only builds the dashboard, but it
+  was declared as a runtime dependency, so installing Titen pulled a full build
+  toolchain onto every consumer's disk. A consumer tree is now three packages:
+  `titen-memory`, `sqlite-vec`, and its platform binary.
+
+### Notes
+
+- The tarball is 41 files / ~73 kB: the Web-Standards kernel, the Bun runtime,
+  and a type-stripped SDK for Node. The Astro dashboard, the Cloudflare adapter,
+  tests, and docs are not shipped — deploy the Worker from a clone.
+- `sqlite-vec` is an `optionalDependency` loaded lazily. Without it retrieval
+  degrades to lexical FTS5 and `/readyz` reports the vector capability as
+  disabled rather than failing.
+- **The CLI requires Bun** — it uses `bun:sqlite`, and the published `bin`
+  carries a `#!/usr/bin/env bun` shebang. `npx titen-memory` works only with Bun
+  on `PATH`. The SDK has no such constraint.
+- 0.1.0 carries no git tag. It was published from a staging tree assembled
+  before the packaging work was committed, and was superseded by 0.1.1 the same
+  day. Prefer 0.1.1.
+
+## Package name
+
+npm refuses to register `titen`:
+
+```
+403 Forbidden - PUT https://registry.npmjs.org/titen
+Package name too similar to existing package vite
+```
+
+That is npm's typosquat filter, not a collision — `npm view titen` still returns
+404. The package is therefore `titen-memory`. The **command stays `titen`**,
+because that comes from the `bin` field rather than from the package name:
+
+```console
+$ bunx titen-memory serve
+titen — self-hosted memory service
+```
+
+## Releasing
+
+Releases are cut by hand from a maintainer's machine and deliberately have no
+GitHub Action, so an npm token never lives in repository secrets. See
+[`docs/engineering/release.md`](./docs/engineering/release.md).
+
+[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/RamaAditya49/titen/releases/tag/v0.1.1
+[0.1.0]: https://www.npmjs.com/package/titen-memory/v/0.1.0

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -47,21 +47,43 @@ npm login
 git status --short          # must be empty
 pnpm test:all
 
-# 2. Bump. This also creates the vN.N.N tag.
+# 2. Write the entry FIRST, while the reasons are still in your head.
+#    Move CHANGELOG.md's [Unreleased] items under the new version heading,
+#    date it, and update the compare links at the bottom.
+$EDITOR CHANGELOG.md
+
+# 3. Bump. This commits package.json and creates the vN.N.N tag.
 npm version <patch|minor|major>
 
-# 3. Prove the tarball works before it becomes permanent (see below).
+# 4. Prove the tarball works before it becomes permanent (see below).
 #    npm publish is irreversible after 72 hours.
 bash scripts/verify-pack.sh
 
-# 4. Ship.
+# 5. Ship.
 npm publish                 # prepack rebuilds dist/npm/sdk.js
 git push && git push --tags
+
+# 6. Publish the GitHub release from the entry you already wrote.
+gh release create "v$(node -p 'require("./package.json").version')" \
+  --title "…" --notes-file <(scripts/changelog-section.sh)
 ```
 
 `npm publish` is the right command even though the repo uses pnpm: `pnpm
 publish` refuses a dirty tree and re-runs the workspace lifecycle, which buys
 nothing here. Either works.
+
+## Changelog and GitHub releases
+
+[`CHANGELOG.md`](../../CHANGELOG.md) is the single source for release notes;
+the GitHub release body is generated from it by
+[`scripts/changelog-section.sh`](../../scripts/changelog-section.sh) so the two
+can never drift. Do not hand-write a release body.
+
+Every published version needs a `vN.N.N` tag and a GitHub release. The one
+exception on record is **0.1.0**, published from a staging tree before the
+packaging work was committed — no commit represents it, so it has no tag.
+Do not retrofit one onto a later commit; that would point the tag at code the
+release never contained.
 
 ## Verifying a candidate
 

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Print one version's section of CHANGELOG.md, for `gh release create --notes-file`.
+# The changelog stays the single source of release notes, so a GitHub release
+# body cannot drift from it. Defaults to the version in package.json.
+#
+#   scripts/changelog-section.sh          # current version
+#   scripts/changelog-section.sh 0.1.0    # a specific one
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+version="${1:-$(node -p 'require("./package.json").version')}"
+
+section="$(awk -v v="$version" '
+  # Heading lines look like: ## [0.1.1] — 2026-07-30
+  index($0, "## [" v "]") == 1 { inside = 1; next }
+  inside && /^## / { exit }
+  inside { print }
+' CHANGELOG.md)"
+
+# Strip leading and trailing blank lines so the release body starts on content.
+section="$(printf '%s\n' "$section" | sed -e '/./,$!d' | tac | sed -e '/./,$!d' | tac)"
+
+if [ -z "$section" ]; then
+  echo "error: CHANGELOG.md has no section for version $version" >&2
+  exit 1
+fi
+
+printf '%s\n' "$section"


### PR DESCRIPTION
Two versions of `titen-memory` are on npm with no record of what changed between
them and no release on GitHub. This adds both, and wires them together so they
cannot drift.

## `CHANGELOG.md`

[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, covering 0.1.0
and 0.1.1. It also writes down the thing that will otherwise cost the next
person twenty minutes:

> npm refuses to register `titen` — `403 … Package name too similar to existing
> package vite`. That is the typosquat filter, not a collision; `npm view titen`
> still returns 404. The **command stays `titen`**, because that comes from `bin`.

## `scripts/changelog-section.sh`

Prints one version's section, so `gh release create --notes-file` reads from the
changelog instead of someone retyping it beside it:

```console
$ scripts/changelog-section.sh          # defaults to package.json version
$ scripts/changelog-section.sh 0.1.0    # or a specific one
$ scripts/changelog-section.sh 9.9.9
error: CHANGELOG.md has no section for version 9.9.9   # exit 1
```

## `docs/engineering/release.md`

The procedure now writes the changelog entry **before** `npm version`, while the
reasons are still fresh, and creates the GitHub release from that entry.

## Why 0.1.0 gets no tag

It was published from a staging tree assembled before the packaging work was
committed, so no commit contains it. Pointing `v0.1.0` at a later commit would
claim it shipped code it never had. The changelog records this and says to
prefer 0.1.1.

## Scope

Documentation and one script. No package or runtime code. The in-flight
`live-deployment-rama-tuf` work remains uncommitted in the working tree and is
not in this branch.