### PR TITLE
docs: write down which version to publish, and from where

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to Titen are recorded here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-While the version stays below `1.0.0`, a **minor** bump may carry a breaking
-change — any entry that does will say so under **Changed** and name the
-migration.
+
+Titen is in `0.x`: per SemVer clause 4, the public API is not yet stable. Below
+`1.0.0` a **minor** bump carries breaking changes and a **patch** carries
+everything else — any breaking entry appears under **Changed** and names the
+migration. Released versions live on npm under `latest`; prereleases
+(`0.2.0-rc.1`) under `next`. `main` may be ahead of both; see
+[versioning and channels](./docs/engineering/release.md#versioning-and-channels).
 
 The published npm package is [`titen-memory`](https://www.npmjs.com/package/titen-memory).
 The **CLI command is `titen`** regardless; see [Package name](#package-name).

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -18,6 +18,69 @@ release GitHub Action and adding one is a decision, not a chore: the npm token
 would then live in repository secrets, and a compromised workflow could publish
 on its own. Publishing by hand keeps the credential on one machine.
 
+## Versioning and channels
+
+**Titen stays on `0.x` until the API stops moving.** SemVer clause 4 is explicit:
+*"Major version zero (0.y.z) is for initial development. Anything MAY change at
+any time."* That is an accurate description of Titen today — model-driven claim
+extraction is still planned and consolidation is deterministic. `1.0.0` is a
+promise of stability, not a maturity badge; cut it when breaking changes stop,
+not when the project feels finished.
+
+While below `1.0.0`:
+
+| Change | Bump | Example |
+| --- | --- | --- |
+| Breaking — removed route, changed response shape, renamed field | **minor** | `0.1.2` → `0.2.0` |
+| Feature, fix, docs, packaging | **patch** | `0.1.1` → `0.1.2` |
+
+There is no major bump before `1.0.0`. `^0.1.0` does not match `0.2.0`, so the
+minor slot is the only breaking-change signal consumers get.
+
+### Two dist-tags, not three
+
+| Tag | Command | What it is |
+| --- | --- | --- |
+| `latest` | `npm i titen-memory` | The current deliberate release. What everyone gets. |
+| `next` | `npm i titen-memory@next` | Optional prerelease for early feedback. |
+
+Prereleases are named `0.2.0-rc.1`, `0.2.0-rc.2`. Skip `alpha` and `beta`: a
+three-stage pipeline is ceremony a single-maintainer project will not honour,
+and an unused stage is worse than no stage because it implies a gate nobody
+runs.
+
+**A prerelease must be published with `--tag next`:**
+
+```bash
+npm version 0.2.0-rc.1
+npm publish --tag next        # WITHOUT --tag it becomes `latest` for everyone
+```
+
+SemVer clause 11.3 gives `0.2.0-rc.1 < 0.2.0`, and `^0.1.0` will not resolve a
+prerelease — but do not rely on that. The dist-tag is the real guard; the range
+rules are a backstop.
+
+Promote a prerelease without republishing:
+
+```bash
+npm dist-tag add titen-memory@0.2.0 latest
+```
+
+### Merging is not releasing
+
+Every merged issue fix lands on `main` under `## [Unreleased]` in
+[`CHANGELOG.md`](../../CHANGELOG.md). **`main` is always the truth; npm `latest`
+is the last deliberate cut.** They are allowed to differ, and usually do.
+
+Publishing on every merge would burn version numbers on changes nobody asked
+for, and every one of them is permanent — npm allows unpublish only within 72
+hours. Batch merges until there is a reason to ship: a fix someone is waiting
+on, a coherent set of changes, or a prerelease worth feedback.
+
+So, when asked *which version do we use* — `main` for development, `@latest`
+for anyone consuming Titen, `@next` only when a change needs testing before it
+reaches `latest`.
+
 ## What ships
 
 `package.json#files` is an allowlist, so the tarball is 41 files / ~73 kB:


### PR DESCRIPTION
Closes the open question: with issues being fixed and merged continuously, which
version do we ship and when? There was no stated answer, so it would have been
decided differently each time.

## Stay on 0.x

[SemVer clause 4](https://semver.org/#spec-item-4): *"Major version zero (0.y.z)
is for initial development. Anything MAY change at any time."* That describes
Titen accurately today — model-driven claim extraction is still planned.
`1.0.0` is a promise that breaking changes have stopped, not a maturity badge.

| Change | Bump |
| --- | --- |
| Breaking — removed route, changed response shape, renamed field | **minor** (`0.1.2` → `0.2.0`) |
| Feature, fix, docs, packaging | **patch** (`0.1.1` → `0.1.2`) |

`^0.1.0` does not match `0.2.0`, so the minor slot is the only breaking-change
signal consumers get.

## Two dist-tags, not three

| Tag | Command | What it is |
| --- | --- | --- |
| `latest` | `npm i titen-memory` | Current deliberate release |
| `next` | `npm i titen-memory@next` | Prerelease — `0.2.0-rc.1` |

Alpha and beta are deliberately omitted. A three-stage pipeline is ceremony a
single-maintainer project will not honour, and an unused stage is worse than no
stage: it implies a gate nobody runs.

The doc calls out that a prerelease **must** carry `--tag next`, because
forgetting it silently makes an untested build `latest` for every consumer, and
npm only permits unpublish within 72 hours.

## Merging is not releasing

Merged fixes accumulate under `## [Unreleased]`. **`main` is the truth; npm
`latest` is the last deliberate cut.** They are allowed to differ. Publishing per
merge burns permanent version numbers on changes nobody is waiting for.

## Sources

- [Semantic Versioning 2.0.0](https://semver.org/) — clauses 4, 9, 11.3
- [npm-dist-tag](https://docs.npmjs.com/cli/dist-tag/)
- [React versioning policy](https://react.dev/community/versioning-policy) — the Latest/Canary split this deliberately simplifies
- [semantic-release: distribution channels](https://semantic-release.gitbook.io/semantic-release/recipes/release-workflow/distribution-channels)