### PR TITLE
docs: sharpen Titen positioning and maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,25 @@
 </p>
 
 > [!NOTE]
-> Titen's P0 memory service is operational on both Cloudflare Workers/D1 and
-> Bun/SQLite. The Level 5 evidence loop (observe → claim → compile → feedback)
-> is verified by 32 contract tests on each runtime. Vector retrieval and model
-> consolidation remain planned; lexical FTS5 serves all retrieval today.
+> The service and collaboration contracts are implemented and verified locally
+> on Bun/SQLite and workerd/D1. The dashboard is an interactive synthetic-data
+> prototype. See the [evidence-based maturity matrix](./docs/ROADMAP.md#maturity-matrix)
+> for the exact boundary of each claim.
 
-Titen is a lightweight, open-source **Level 6 collaborative memory fabric**
-built on a **Level 5 evidence-grounded memory kernel**. It helps personal,
-company, and enterprise agents share context and coordinate work without
-collapsing evidence, private perspectives, decisions, and task state into one
-untrusted vector store.
+When 2–10 agents share a project, they often repeat research, act on stale
+context, collide on the same task, or lose decisions during handoff. **Titen
+turns their evidence, decisions, work state, and feedback into scoped,
+traceable context so the next agent can continue instead of starting over.**
 
-Titen is designed to make agents more effective, faster, stable under partial
-failure, and increasingly useful at managing memory. It does this through an
-evidence-to-context feedback lifecycle—not by treating RAG or a vector database
-as the complete memory system.
+The first product focus is a small team running a researcher, writer, operator,
+and reviewer. Titen preserves source evidence, compiles only authorized context,
+and makes ownership, handoffs, and disagreements explicit. It is self-hostable
+on Bun/SQLite or Cloudflare-compatible infrastructure and does not require a
+vector database.
+
+Titen calls the evidence-grounded context kernel **Level 5** and the
+collaboration layer **Level 6**. Those labels are optional product vocabulary,
+not prerequisites for understanding or adopting the product.
 
 ## Why Titen
 
@@ -148,14 +152,15 @@ The level model is Titen's product vocabulary, not an industry standard.
 | 3     | Typed memory tiers and relationships                                      |
 | 4     | Automatic extraction, consolidation, and forgetting                       |
 | **5** | **Evidence-grounded, temporal context compilation with outcome feedback** |
-| **6** | **Collaborative memory, governance, and optional federation**             |
+| **6** | **Collaborative memory, governance, and signed event exchange**           |
 
 Level 4 manages stored memories. Level 5 decides what one agent should see for
-its next action. Level 6 adds the shared identity, visibility, coordination,
-governance, and federation needed by teams of agents.
+its next action. Level 6 adds shared identity, visibility, coordination, and
+governance. The current cross-deployment feature exchanges signed events;
+canonical recallable-memory federation remains planned.
 
 ```text
-Level 6   identify → share → coordinate → hand off → govern → federate
+Level 6   identify → share → coordinate → hand off → govern → exchange signed events
                                    │
 Level 5     observe → derive claims → compile context → act → feedback
                                    │
@@ -276,10 +281,12 @@ citations and explicit uncertainty.
 
 ## Roadmap boundary
 
-The Level 6 roadmap adds permissioned, observer-specific memory between agents,
-including disagreement and consensus. The first collaboration release stays on
-one Titen deployment. Federation waits for a proven multi-region or data
-boundary need.
+The Level 6 collaboration layer adds permissioned, observer-specific memory
+between agents, including disagreement and explicit resolution. Signed
+federation event exchange is implemented for cross-deployment transport.
+Federating canonical recallable memory—including destination-side ingestion,
+indexing, authorization, and recall semantics—remains planned and waits for a
+proven multi-region or data-boundary need.
 
 Enterprise governance adds versioned channel knowledge releases. Public-facing
 chatbots remain external gateways: they retrieve only active releases for their

--- a/docs/FRD.md
+++ b/docs/FRD.md
@@ -61,7 +61,7 @@ The minimum useful path must work without an LLM or vector database.
 | v0.1    | complete Level 5 kernel, optional consolidation, temporal/conflict lifecycle, evidence inspection, private checkpoints, API-key lifecycle, export/import                                              | one agent can remember, verify, resume, and move its data safely                   |
 | v0.2    | identities and memberships, visibility, shared checkpoints, leases, handoffs, observer-specific claims, audit, stateless MCP, events/webhooks, read-only Memory Atlas, progressive dashboard boundary | two agents collaborate and operators diagnose memory without private-data leakage  |
 | v0.3    | roles and policy, approvals, channel knowledge releases, retention/legal hold, identity boundary, audit/recovery, governance Atlas lenses                                                             | company and enterprise policy, release, channel-isolation, and recovery tests pass |
-| v1      | governed federation                                                                                                                                                                                   | authorized scopes exchange events without losing provenance or conflicts           |
+| v1      | signed federation event exchange                                                                                                                                                                      | authorized scopes exchange signed events without losing provenance or conflicts    |
 
 No feature in a later release is required to implement an earlier gate.
 
@@ -937,7 +937,12 @@ Acceptance:
 - backup and audit export contain no credentials or embeddings;
 - a failed restore cannot overwrite the currently active canonical store.
 
-## 13. Federation feature
+## 13. Signed federation event exchange and planned memory federation
+
+The current feature boundary is signed, filtered event transport. Remote events
+do not become destination canonical claims, indexes, or recallable context by
+virtue of exchange. Canonical recallable-memory federation is planned and must
+define destination ingestion, authorization, lifecycle, and recall separately.
 
 ### FED-001 — Governed event exchange
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,6 +1,6 @@
 # Titen product requirements document
 
-- Status: product baseline; static synthetic dashboard implemented, memory service planned
+- Status: product baseline; see the evidence-based maturity matrix in [ROADMAP](./ROADMAP.md#maturity-matrix)
 - Product direction: Level 6 collaborative memory fabric
 - Kernel: Level 5 evidence-grounded context memory
 - Target runtimes: Cloudflare Workers and Bun on a VPS
@@ -12,8 +12,9 @@
 Titen helps AI agents remember and work together. It stores immutable evidence,
 derives temporal claims, compiles task-specific context, and records whether
 that context helped. A collaboration layer adds private, team, and organization
-visibility plus checkpoints, leases, handoffs, policy, audit, and optional
-federation.
+visibility plus checkpoints, leases, handoffs, policy, and audit. Signed
+federation event exchange is available; canonical recallable-memory federation
+remains planned.
 An enterprise release layer lets authorized CRM/chatbot gateways serve reviewed
 knowledge snapshots without exposing canonical memory.
 
@@ -35,16 +36,38 @@ Existing agent memory commonly fails in four ways:
 The result is duplicated work, conflicting actions, accidental data sharing,
 and confident reuse of untrusted memory.
 
-## 3. Users
+## 3. Beachhead user and canonical scenario
 
-| User                   | Need                                                        | Default deployment                |
-| ---------------------- | ----------------------------------------------------------- | --------------------------------- |
-| Individual             | Persistent private agent context across sessions            | Bun/SQLite or Worker/D1           |
-| Small team             | Shared project knowledge and parallel agent handoffs        | One Titen deployment              |
-| Company                | Workspace isolation, roles, audit, and retention            | Managed Worker or private VPS     |
-| CRM/chatbot operator   | Approved customer knowledge plus isolated customer context  | Authorized gateway + Titen        |
-| Enterprise             | Governance, data boundaries, regional nodes, and federation | Multiple governed deployments     |
-| Agent framework author | Stable HTTP/MCP memory and coordination primitives          | Embedded client or remote service |
+The beachhead is a **small team running 2–10 agents** on one project. They
+already feel context drift, duplicate research or execution, fragile handoffs,
+and conflicts between stale or differently sourced claims. Individual,
+company, enterprise, CRM, and framework users remain valid secondary personas,
+but they do not define the initial product story.
+
+The canonical scenario has four roles:
+
+1. a **researcher** records source-backed findings and unresolved uncertainty;
+2. a **writer** compiles a bounded, cited context pack and produces a draft;
+3. an **operator** claims the delivery task, records execution evidence, and
+   hands off the outcome;
+4. a **reviewer** traces claims to evidence, preserves or resolves conflicts,
+   and records feedback for later recall.
+
+The scenario succeeds when the writer and operator reuse the research without
+repeating it, no two agents silently own the same task, the reviewer can trace
+recalled claims and conflicts, and a handoff can be resumed from explicit state.
+Measure duplicate-work rate, successful handoff rate, lease-conflict rate,
+evidence coverage of recalled claims, context usefulness, and time-to-resume.
+
+### Comparison guidance
+
+- **Raw files/logs** are simple and inspectable, but callers must implement
+  scoping, freshness, conflict handling, packing, and coordination themselves.
+- **A vector database** improves semantic candidate search, but similarity is
+  not provenance, authorization, temporal validity, task ownership, or truth.
+- **Simpler memory libraries** are a better fit for one agent that only needs
+  persistence and recall. Titen earns its complexity when several agents need
+  evidence-grounded context plus coordination and explicit handoffs.
 
 ## 4. Jobs to be done
 
@@ -115,8 +138,8 @@ and confident reuse of untrusted memory.
 - channel, audience, approval, redaction, validity, and revocation policy for
   customer-facing knowledge;
 - governed Scope Preview and Knowledge Release lenses for authorized operators;
-- governed federation between deployments when required by region or data
-  ownership.
+- governed signed event exchange between deployments when required by region or
+  data ownership; canonical recallable-memory federation remains planned.
 
 ## 7. Functional requirements
 
@@ -413,7 +436,8 @@ planned area in documentation is not implementation evidence.
 - identity-provider interface when enterprise work starts;
 - exact signed customer-assertion format and issuer/key-rotation contract at
   v0.3;
-- federation transport after a real multi-node requirement exists;
+- transport/orchestration and canonical recallable-memory federation semantics
+  after a real multi-node requirement exists;
 - measured Memory Atlas server-side caps after the authorized reference fixture
   exists;
 - the first post-Atlas dashboard area, selected only after its operator journey

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,192 +1,83 @@
-# Titen roadmap
+# Titen roadmap and maturity
 
 Release ordering does not replace the
-[requirements workflow](./engineering/requirements-workflow.md). A complex
-roadmap item enters implementation only after an EARS work spec and paired plan
-exist; it reaches done only after evidence is recorded and both artifacts close
-together.
+[requirements workflow](./engineering/requirements-workflow.md). Product
+requirements, roadmap intent, implementation, and verification are different
+claims. This page is the canonical status source; other documents link here
+instead of using phase checkmarks.
 
-The roadmap is ordered by risk. A phase starts only after the previous gate
-passes on both Cloudflare and VPS.
+## Status vocabulary
 
-Dashboard delivery follows the progressive area map in
-[DESIGN](./DESIGN.md). A backend feature may ship headlessly before its
-operator UI; the static reference shell may show a planned area's plain label,
-but only completed capability-backed areas become controls or routes.
+- **Implemented** — code or documentation exists in this repository.
+- **Verified locally** — reproducible repository tests pass against local or
+  emulated runtimes.
+- **Verified live** — a documented check passed against provisioned external
+  infrastructure.
+- **Interactive prototype** — usable UI behavior backed by synthetic data, not
+  a live service.
+- **Planned** — intended behavior without completed implementation evidence.
+- **Out of scope** — deliberately excluded from the current product boundary.
 
-The static Astro dashboard listed under v0.2 has landed early as an isolated
-synthetic preview. It does not satisfy the v0.2 memory-service, authorization,
-live Atlas, collaboration, or dual-runtime gates below.
+A row may list more than one status where, for example, implementation is
+locally verified but has no live deployment evidence.
 
-## P0 — dual-runtime spike ✓
+## Maturity matrix
 
-**Status: verified.** 32 contract tests pass on both Cloudflare Workers/D1 and
-Bun/SQLite. Worker bundle: 68.90 KiB / 16.67 KiB gzip. Loop p50: 12 ms (Bun),
-45.6 ms (D1). Storage: ~45 KiB per loop. Bun RSS: ~152 MiB. Data survives
-restart and fresh-isolate cold start on both runtimes.
+| Capability | Status | Concrete evidence | Boundary |
+| --- | --- | --- | --- |
+| Evidence kernel: observe, claim, compile, feedback | Implemented; Verified locally | [P0 done spec](./specs/done/2026-07-29-p0-dual-runtime-vertical-spike.md), [contract tests](../tests/contract/) | Shared suite covers Bun/SQLite and local workerd/D1; this is not a live Cloudflare claim. |
+| Temporal claims, checkpoints, SDK, optional hybrid retrieval | Implemented; Verified locally | [agent guide](./agent-guide.md), [contract tests](../tests/contract/), [integration tests](../tests/integration/) | FTS works without vectors; live Vectorize/Workers AI is not verified. |
+| Identities, visibility, leases, handoffs, MCP, events, Atlas compiler | Implemented; Verified locally | [collaboration architecture](./architecture/collaboration.md), [API reference](./reference/api.md), [contract tests](../tests/contract/) | Local/emulated runtime evidence only. |
+| Enterprise policy, releases, and audit | Implemented; Verified locally | [FRD governance requirements](./FRD.md), [contract tests](../tests/contract/) | No claim of a provisioned enterprise deployment. |
+| Memory Atlas dashboard | Interactive prototype | [dashboard guide](./dashboard.md), [browser tests](../tests/) | Checked-in UI uses a synthetic fixture; it is not evidence of live API integration. |
+| Containerized Bun service with `embeddinggemma` | Verified live | [evaluation record](./testing/EVALS.md), [end-to-end script](../scripts/e2e.ts) | Evidence covers the recorded container run, not systemd/VPS packaging or Cloudflare. |
+| Signed federation event exchange | Implemented; Verified locally | [collaboration federation boundary](./architecture/collaboration.md#signed-federation-event-exchange), [contract tests](../tests/contract/) | Exchanges filtered signed events and cursors. It does not make remote memory canonically recallable. |
+| Canonical recallable-memory federation | Planned | [FRD federation feature](./FRD.md#13-signed-federation-event-exchange-and-planned-memory-federation), [collaboration boundary](./architecture/collaboration.md#signed-federation-event-exchange) | Destination ingestion, authorization, indexing, lifecycle, and recall semantics require new work and evidence. |
+| Real Cloudflare deployment; live Vectorize/Workers AI | Planned | [Cloudflare guide](./deployment/cloudflare.md) | Configuration and local emulation are not live deployment evidence. |
+| Provisioned VPS systemd/Caddy install | Planned | [VPS guide](./deployment/vps.md) | Container execution does not verify the systemd and reverse-proxy path. |
+| Agent loop/orchestrator, graph database, global consensus | Out of scope | [PRD non-goals](./PRD.md#12-non-goals) | Titen records coordination and keeps SQL canonical. |
 
-Verified path:
+## Release sequence
 
-1. append an observation;
-2. resolve an explicit project reference;
-3. materialize one evidence-linked claim;
-4. compile a bounded context pack;
-5. record feedback;
-6. inspect claim evidence;
-7. manage API keys;
-8. export/import canonical JSONL;
-9. run the same 32-case contract on Worker/D1 and Bun/SQLite.
+### P0 — evidence kernel
 
-Gate (all passed):
+The first slice establishes canonical observations, evidence-linked claims,
+bounded context compilation, feedback, authentication, JSONL portability, and
+the same local contract on Bun/SQLite and workerd/D1.
 
-- identical external behavior on both runtimes;
-- tenant isolation, cross-org, cross-subject, and private-visibility checks pass;
-- no mandatory vector database, LLM, queue, Redis, Postgres, ORM, or
-  `nodejs_compat`;
-- measured bundle, latency, memory, and storage footprint documented.
+### v0.1 — memory lifecycle
 
-## v0.1 — Level 5 kernel ✓
+Adds temporal supersession, expiring checkpoints, the Agent SDK, and optional
+hybrid retrieval with FTS-only degradation.
 
-**Status: verified.** 39 contract tests pass on both runtimes. Temporal
-supersession (supersede, revoke, expire), checkpoints with TTL, optional vector
-retrieval interface, Agent SDK, and lifecycle docs ship. FTS5 retrieval works
-alone; hybrid FTS+vector activates when an embedding provider is configured.
+### v0.2 — collaboration
 
-Delivered:
+Adds identities and memberships, scoped visibility, leases, handoffs,
+observer-specific conflicts, MCP, durable metadata events, and Memory Atlas
+view compilation. The dashboard remains a separate synthetic-data prototype.
 
-- observations, claims, claim sources, and temporal supersession;
-- hybrid FTS plus optional vector retrieval (interface ready, graceful degradation);
-- context compiler with token budget and trust metadata;
-- checkpoints and outcome feedback;
-- API-key authentication and subject/agent/run scopes;
-- JSONL export/import;
-- Agent SDK (`titen/sdk`) and agent lifecycle documentation;
-- Cloudflare and VPS deployment guides;
-- contract, security, and multilingual retrieval tests (39 cases, both runtimes).
+### v0.3 — governance
 
-## v0.2 — Level 6 collaboration ✓
+Adds role/policy enforcement, approved channel releases, audience-scoped
+context, and audit export.
 
-**Status: verified.** 47 contract tests pass on both runtimes. Collaboration
-plane (workspaces, memberships, leases, handoffs), stateless MCP tools,
-event polling, and Memory Atlas view compiler ship.
+### v1 transport — signed federation event exchange
 
-Delivered:
+The current module registers peers, filters outbound events, advances cursors,
+verifies signatures, preserves replay conflicts, and supports suspension and
+revocation. Network scheduling remains an operator/orchestrator concern.
 
-- human, agent, service, workspace, and organization identities;
-- private, team, and organization visibility;
-- shared checkpoints, idempotent leases, and handoffs;
-- observer-specific claims and preserved conflicts;
-- stateless MCP tools at `/mcp` (JSON-RPC 2.0) for context, remember,
-  feedback, checkpoint, lease, and handoff;
-- durable metadata events and cursor-based polling (`GET /v1/events`);
-- Memory Atlas view compiler (`POST /v1/memory-views/compile`) with
-  evidence_trace, neighborhood, conflict_freshness, and scope_preview lenses;
-- Astro dashboard preview at `/dashboard/` with synthetic fixture;
-- single-deployment company mode.
+### Future — canonical recallable-memory federation
 
-## v0.3 — enterprise governance ✓
-
-**Status: verified.** 47 contract tests pass on both runtimes. Enterprise
-governance adds role/policy enforcement, channel releases with audience-scoped
-context, and audit logging with NDJSON export.
-
-Delivered:
-
-- role and policy enforcement (retention, approval_required, visibility_default,
-  trust_ceiling policies);
-- operator-managed channel releases with draft → active → revoked lifecycle;
-- channel context query for CRM/chatbot gateways (only active release items);
-- customer assertion storage for signed JWT validation;
-- audit log with cursor-based listing and NDJSON export for compliance;
-- backup-friendly canonical JSONL export/import (from P0).
+A future slice may define how remote evidence becomes destination canonical
+records, how destination policy authorizes it, how indexes are rebuilt, and
+how compiled context cites and resolves remote lifecycle/conflicts. It must not
+be inferred from event transport and needs its own requirements and runtime
+verification.
 
 ## Dashboard expansion rule
 
-After the first Atlas slice, dashboard areas are selected one bounded operator
-journey at a time:
-
-1. Memory may add Memories and Context after authorized list/detail contracts
-   stabilize;
-2. Collaboration may add Work after checkpoint, lease, and handoff contracts
-   pass;
-3. Operations may add Audit & Events and System after their metadata and
-   recovery boundaries pass;
-4. Administration may add Access after key, identity, membership, and
-   visibility management behavior passes;
-5. Governance may add Approvals & Releases no earlier than v0.3.
-
 An area has no interactive control or route until its backend capability,
 authorization, current-build availability, EARS UI work item, and
-failure/rollback evidence are complete. The approved static reference shell may
-show its non-interactive label without claiming the capability has shipped.
-Categories and tags remain filters; webhooks remain inside Audit & Events;
-export/recovery remains inside System; Settings waits for an explicit browser
-account/session contract.
-
-## Verification status
-
-Every phase above is marked complete against automated tests. This section
-records what those tests do and do not cover, so a reader can tell proven
-behavior from written behavior.
-
-Proven by execution:
-
-- the dual-runtime contract suite on Bun/SQLite and Cloudflare/D1 via workerd;
-- signed webhook delivery to a real HTTP receiver, including independent
-  signature verification, a rejecting receiver, and an unreachable destination;
-- federation between two independent deployments over real HTTP, including
-  peer-signature enforcement, replay conflict, and policy filtering;
-- `sqlite-vec` nearest-neighbour search with the real prebuilt extension;
-- the published SDK against a running service;
-- `deploy/backup.sh` executed end to end, with the restored copy verified and
-  accepted by the service;
-- the dashboard reading `POST /v1/memory-views/compile` from a live deployment
-  (`pnpm verify:dashboard-live`);
-- **a containerized deployment against a real embedding model.** Built with
-  podman on Fedora 44, running `embeddinggemma` through Ollama at 768
-  dimensions. `scripts/e2e.ts` drove the whole loop over HTTP against the
-  container: semantic recall retrieved a claim sharing *zero* keywords with the
-  query, ranked it above a decoy (relevance 0.4978 against 0.4806, the same
-  order as the model's own cosine of 0.4907 against 0.4162), and memory survived
-  a container restart. Index drain 134.9 ms, context compile p50 104.8 ms,
-  embedding 106.4 ms, image 623 MB.
-
-Not proven, and not claimed:
-
-- **A real Cloudflare deployment.** `wrangler.jsonc` still carries a placeholder
-  `database_id`. Everything Cloudflare-side is verified against workerd and local
-  D1 through Miniflare, plus `wrangler deploy --dry-run`. A first real deploy
-  needs an account, a D1 database, and one smoke run against the deployed URL.
-- **A real VPS install via systemd.** The units, Caddyfile, and monitor script
-  are written but have never run on a provisioned host under the `titen` user.
-  The service itself has now run containerized on a real remote machine with a
-  real embedding model, so what remains unproven is specifically the systemd and
-  reverse-proxy wiring, not the service.
-- **Vectorize and Workers AI.** The Cloudflare vector adapter has no test,
-  because it needs live bindings. Its Bun counterpart is covered by unit tests,
-  by the real-extension integration test, and by the containerized end-to-end
-  run against `embeddinggemma`.
-- **Retry escalation over time.** Webhook backoff schedules the next attempt and
-  that is asserted; no test advances a clock through all five attempts to a
-  `failed` terminal state.
-
-## v1 — federation ✓
-
-**Status: implemented.** Federation module enables authorized event exchange
-between Titen deployments with per-scope replication cursors and policy
-filtering. 47 contract tests pass on both runtimes.
-
-Delivered:
-
-- federation peer registration with hashed shared secrets;
-- per-peer directional filters (resource type, kinds, subjects, trust floor);
-- cursor-based pull (local events matching peer filters);
-- push with conflict preservation (existing IDs kept, conflicts logged);
-- federation log for observability;
-- suspend/revoke peer lifecycle.
-
-Design notes: actual network transport to remote peers is an operational
-concern (cron job, queue worker, or external orchestrator). The API provides
-the complete data model, filter logic, and conflict handling. CRDTs and
-consensus services are not added until a real multi-node deployment
-demonstrates the need.
+failure/rollback evidence are complete. The approved static shell may show a
+non-interactive label without claiming the capability shipped.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -11,6 +11,24 @@ const titen = new TitenClient({
 });
 ```
 
+## Canonical team scenario
+
+For the beachhead team of 2–10 agents, use one shared project and distinct
+credentials for a researcher, writer, operator, and reviewer:
+
+1. the researcher observes source-backed findings;
+2. the writer compiles cited context and records the draft outcome;
+3. the operator acquires a lease, executes, checkpoints progress, and hands off;
+4. the reviewer inspects evidence and conflicts, then records feedback.
+
+A successful run has no repeated research, no silent duplicate owner, a
+resumable handoff, and evidence-linked context the reviewer can audit. Track
+handoff completion, lease conflicts, duplicate work, evidence coverage,
+context usefulness, and time-to-resume. Raw files remain suitable when the team
+can manage these guarantees itself; a vector database is only a retrieval
+index; simpler memory is preferable for a single agent that needs persistence
+without collaboration controls.
+
 ## Lifecycle
 
 An agent's memory loop:

--- a/docs/architecture/collaboration.md
+++ b/docs/architecture/collaboration.md
@@ -167,13 +167,18 @@ Enterprise capabilities are layered onto the same model:
 SSO, SCIM, and policy language are integration boundaries, not mandatory kernel
 dependencies.
 
-## Federation
+## Signed federation event exchange
 
-Federation synchronizes authorized events between Titen deployments. It is
-required only when one deployment cannot satisfy ownership, region, or network
-boundaries.
+The implemented federation feature exchanges authorized, signed event records
+between Titen deployments. It is a transport and conflict-observation boundary,
+not canonical recallable-memory federation. Receiving an event does not by
+itself ingest the remote observation or claim into the destination canonical
+store, authorize it for recall, index it, or make it appear in compiled context.
+Those canonical federation semantics remain **Planned** and require a separate
+work item. Event exchange is needed only when one deployment cannot satisfy
+ownership, region, or network boundaries.
 
-Initial constraints:
+Event-exchange constraints:
 
 - append events and advance per-scope cursors;
 - filter by source policy before transmission;

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -47,6 +47,7 @@ flowchart TB
     M --> WAI[Workers AI]
     M --> OAI[OpenAI-compatible HTTP]
     E --> W[Optional signed webhooks]
+    E --> F[Signed federation event exchange]
 ```
 
 ## Component responsibilities
@@ -61,6 +62,7 @@ flowchart TB
 | Dashboard client   | progressively shipped operator interface               | domain authority  |
 | Memory Atlas       | bounded authorized read-only projections               | canonical storage |
 | Event delivery     | post-commit events, retries, signed webhooks           | agent selection   |
+| Federation exchange | signed filtered event transport and cursors           | canonical remote recall |
 | SQL adapter        | canonical transactions, FTS, hydration, outbox         | semantic policy   |
 | Vector adapter     | rebuildable embedding index                            | canonical content |
 | Model gateway      | embeddings and optional structured extraction          | storage           |
@@ -87,14 +89,16 @@ compatible embedding model at write and query time.
 
 ## Repository state and target runtime shape
 
-The current checkout contains one static Astro dashboard, local assets,
-Playwright tests, workflow checks, and product/engineering documentation. The
-dashboard uses a frozen synthetic fixture and has no memory-service dependency.
+The current checkout contains the memory kernel, authenticated REST/MCP app,
+SQL migrations, Cloudflare and Bun entrypoints, and a shared dual-runtime
+contract suite. Their precise verification boundary is centralized in the
+[roadmap maturity matrix](../ROADMAP.md#maturity-matrix).
 
-The memory kernel, authenticated REST/MCP app, SQL migrations, Cloudflare/Bun
-entrypoints, and dual-runtime contract tests do not exist yet. P0 creates only
-the files required by its accepted vertical-spike work item. Split files or add
-adapters only after a measured ownership, size, or runtime boundary requires it.
+The Astro dashboard is an interactive prototype backed by a frozen synthetic
+fixture. Live dashboard/API integration is separate evidence and must not be
+inferred from the preview. Signed federation event exchange is implemented;
+turning remote events into authorized, indexed, recallable canonical memory is
+planned.
 
 ## Write path
 
@@ -192,7 +196,8 @@ remain source-tool calls instead of stale knowledge releases.
   unavailable areas have no route or control, even when the approved shell shows
   their non-interactive labels.
 - Expired lease/checkpoint never becomes a durable fact.
-- Federation failure never changes the local canonical event history.
+- Signed event-exchange failure never changes local canonical event history;
+  remote events do not become recallable canonical memory implicitly.
 
 ## Dependency budget
 


### PR DESCRIPTION
## Summary

- reframe the README around the small-team multi-agent problem and outcome
- define a canonical researcher-writer-operator-reviewer adoption scenario
- replace roadmap phase checkmarks with an evidence-based maturity matrix
- distinguish signed federation event exchange from planned recallable-memory federation

## Classification

Simple documentation/product-boundary change. No runtime, API, persistence, authorization, or migration behavior changes.

## Verification

- `node scripts/check-workflow-docs.mjs`
- `node scripts/check-workflow-docs.mjs --self-test`
- relative Markdown link validation
- `pnpm build`
- dashboard bundle check: 9.8 KiB gzip / 80 KiB budget
- `git diff --check`

Closes #25
Closes #26
Closes #27
Closes #30
