### PR TITLE
docs: standardize contributor workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,13 @@
 - Runtime(s): <!-- Cloudflare / VPS / shared / docs -->
 - Security or data migration: <!-- none or explain -->
 - API compatibility: <!-- compatible or explain -->
+- Release impact: <!-- none / patch / minor while below 1.0.0 -->
+
+## Changelog and README
+
+- Changelog: <!-- updated under Unreleased / not needed because ... -->
+- README: <!-- updated / not needed because ... -->
+- Detailed docs: <!-- paths updated / observable behavior unchanged -->
 
 ## Workflow
 
@@ -26,6 +33,8 @@
 ## Checklist
 
 - [ ] Change is scoped to one logical concern.
+- [ ] Branch was rebased onto current `origin/main` before final review.
+- [ ] Pull request title is a valid Conventional Commit squash subject.
 - [ ] The change followed `spec -> plan -> implement -> done`.
 - [ ] Complex work has paired EARS spec/plan artifacts under `done/` before this
       pull request is marked complete.
@@ -34,5 +43,10 @@
 - [ ] Non-trivial behavior has a regression or contract test.
 - [ ] Cross-scope authorization was considered.
 - [ ] Documentation matches observable behavior.
+- [ ] Release impact is classified; ordinary work does not bump the package or
+      create a tag.
+- [ ] Notable user-facing work updates `CHANGELOG.md` under `Unreleased`.
+- [ ] `README.md` and `docs/README.md` are aligned when public usage or current
+      implementation status changes.
 - [ ] No credentials or private memory data are included.
 - [ ] Rollback/compatibility impact is documented when relevant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,20 @@ work are always complex. Complex work requires paired active spec/plan files
 with EARS acceptance criteria. Simple work may keep the same four stages inline
 in its issue or pull request.
 
+## Branches and parallel work
+
+- Branch from the latest `origin/main` and use `<type>/<short-scope>`, where
+  `type` is `feat`, `fix`, `docs`, `test`, `refactor`, or `chore`.
+- Keep one logical concern and one owner per branch. Do not share a working
+  branch; dependent work uses separate pull requests that declare their base
+  and merge order.
+- Contributors change `main` through pull requests. Direct pushes are reserved
+  for maintainer emergency reverts and must leave a follow-up issue or pull
+  request record.
+- Rebase onto current `origin/main` before final review, resolve conflicts on
+  the topic branch, and rerun affected checks. If the resulting diff changes,
+  request review again.
+
 ## Repository stage
 
 The memory service remains in product-definition/P0 preparation. The repository
@@ -58,7 +72,8 @@ that every relative Markdown link points to an existing file.
 ## Commit and pull request style
 
 Use Conventional Commit prefixes such as `feat:`, `fix:`, `docs:`, `test:`,
-`refactor:`, and `chore:`.
+`refactor:`, and `chore:`. Use the same format for the pull request title; it
+becomes the commit subject when the pull request is squash-merged.
 
 A pull request should state:
 
@@ -74,6 +89,44 @@ Before marking a pull request complete, close its workflow: record evidence for
 every acceptance ID, resolve all plan checkboxes, and move a complex spec/plan
 pair to `done/` together. Cancelled or superseded work also moves to `done/`
 with a concrete closure reason.
+
+Maintainers merge only a current, approved pull request with resolved review
+threads and reproducible verification. Use **squash merge**, then delete the
+topic branch; never reuse a merged branch. Merge dependent pull requests from
+base to tip and rebase each remaining branch after its base lands.
+
+## Version, changelog, and README
+
+Every pull request declares one release impact using the
+[release policy](./docs/engineering/release.md#versioning-and-channels):
+
+| Impact  | Use when |
+| ------- | -------- |
+| `none`  | No published package or user-facing behavior changes |
+| `patch` | Compatible feature, fix, published documentation, or packaging changes |
+| `minor` | A breaking change while Titen remains below `1.0.0` |
+
+Ordinary pull requests do not edit `package.json#version`, create tags, or add a
+released changelog heading. Add notable user-facing changes under
+[`CHANGELOG.md#Unreleased`](./CHANGELOG.md#unreleased) in the same pull request;
+the release maintainer batches merged work and performs the version bump.
+
+Update `README.md` in the same pull request when verified, shipped behavior
+changes any of these public entry points:
+
+- installation, quick start, commands, configuration, or system requirements;
+- public API/SDK behavior, supported runtimes, compatibility, or deprecations;
+- feature availability, implementation status, screenshots, or visible flows;
+- package contents, project links, or contributor-facing instructions already
+  summarized by the README.
+
+Do not update the README for an internal refactor, test-only change, or planned
+capability with no shipped behavior. The README is a summary: update the
+authoritative API, deployment, or product document alongside it. A pull request
+that changes implementation status must rebase first and reconcile both
+`README.md` and `docs/README.md` so concurrent work cannot restore a stale claim.
+The README links to the stable npm package page; version-specific links belong
+in the changelog and GitHub Release, not in general documentation.
 
 ## Architecture decisions
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   <img alt="Status: P0 memory service" src="https://img.shields.io/badge/status-P0%20memory%20service-A9552A?style=flat&amp;labelColor=3E3630">
   <img alt="Cloudflare target" src="https://img.shields.io/badge/target-Cloudflare%20Workers-223A57?style=flat&amp;labelColor=3E3630">
   <img alt="VPS target" src="https://img.shields.io/badge/target-Bun%20%2B%20SQLite-223A57?style=flat&amp;labelColor=3E3630">
+  <a href="https://www.npmjs.com/package/titen-memory"><img alt="npm: titen-memory" src="https://img.shields.io/npm/v/titen-memory?style=flat&amp;labelColor=3E3630&amp;color=A9552A"></a>
+  <a href="https://www.npmjs.com/package/titen-memory"><img alt="npm downloads" src="https://img.shields.io/npm/dm/titen-memory?style=flat&amp;labelColor=3E3630&amp;color=223A57"></a>
+  <a href="https://www.npmjs.com/package/titen-memory"><img alt="npm unpacked size" src="https://img.shields.io/npm/unpacked-size/titen-memory?style=flat&amp;labelColor=3E3630&amp;color=223A57"></a>
+  <a href="https://github.com/RamaAditya49/titen/graphs/contributors"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/RamaAditya49/titen?style=flat&amp;labelColor=3E3630&amp;color=223A57"></a>
   <a href="./LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-171310?style=flat&amp;labelColor=3E3630"></a>
 </p>
 

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -32,7 +32,8 @@ While below `1.0.0`:
 | Change | Bump | Example |
 | --- | --- | --- |
 | Breaking — removed route, changed response shape, renamed field | **minor** | `0.1.2` → `0.2.0` |
-| Feature, fix, docs, packaging | **patch** | `0.1.1` → `0.1.2` |
+| Compatible feature, fix, published docs, packaging | **patch** | `0.1.1` → `0.1.2` |
+| Internal tests, refactors, contributor process | **none** | no release |
 
 There is no major bump before `1.0.0`. `^0.1.0` does not match `0.2.0`, so the
 minor slot is the only breaking-change signal consumers get.
@@ -71,6 +72,12 @@ npm dist-tag add titen-memory@0.2.0 latest
 Every merged issue fix lands on `main` under `## [Unreleased]` in
 [`CHANGELOG.md`](../../CHANGELOG.md). **`main` is always the truth; npm `latest`
 is the last deliberate cut.** They are allowed to differ, and usually do.
+
+Every pull request declares `none`, `patch`, or `minor`, but ordinary pull
+requests never run `npm version`, edit `package.json#version`, create a tag, or
+add a released changelog heading. They add notable user-facing changes only to
+`Unreleased`. At release time, the maintainer chooses the highest impact in the
+batch, moves those entries under the dated version, and performs one bump.
 
 Publishing on every merge would burn version numbers on changes nobody asked
 for, and every one of them is permanent — npm allows unpublish only within 72
@@ -147,6 +154,21 @@ exception on record is **0.1.0**, published from a staging tree before the
 packaging work was committed — no commit represents it, so it has no tag.
 Do not retrofit one onto a later commit; that would point the tag at code the
 release never contained.
+
+### Where published links live
+
+- `README.md` links once to the stable
+  [`titen-memory`](https://www.npmjs.com/package/titen-memory) package page. Its
+  npm badge reads the current registry version, so releases do not hard-code a
+  version there.
+- `CHANGELOG.md` keeps that stable package link near the top. Each released
+  version reference points to its GitHub Release, which carries the tag and
+  release notes.
+- Use `https://www.npmjs.com/package/titen-memory/v/<version>` only when exact
+  registry evidence is needed. Do not copy version-specific npm links into the
+  README, product docs, or deployment docs.
+- `package.json` remains the source for npm's repository, homepage, and issue
+  links; do not duplicate that metadata in release notes.
 
 ## Verifying a candidate
 


### PR DESCRIPTION
## Problem

Parallel contributors need one explicit rule for branch ownership, PR review,
merge order, release impact, and when README claims must change.

## Solution

Document the smallest shared workflow in the existing contributor and release
docs, require the decisions in the PR template, and expose verified dynamic npm
and contributor badges in the README.

## Impact

- Runtime(s): docs only
- Security or data migration: none
- API compatibility: compatible
- Release impact: none

## Changelog and README

- Changelog: not needed; no published package behavior changed
- README: updated with dynamic npm version/download/size and contributor badges
- Detailed docs: `CONTRIBUTING.md` and `docs/engineering/release.md`

## Workflow

- Classification: simple
- Spec: contributors can follow one observable branch/PR/merge/version/README policy
- Plan: update existing policy surfaces, verify links and workflow, push a topic branch
- Terminal outcome: completed

## Verification

- `node scripts/check-workflow-docs.mjs`
- `node scripts/check-workflow-docs.mjs --self-test`
- `git diff --check`
- all four dynamic badge endpoints returned HTTP 200
- `npm view titen-memory version` returned `0.1.1`

## Checklist

- [x] Change is scoped to one logical concern.
- [x] Branch is based on current `origin/main`.
- [x] Pull request title is a valid Conventional Commit squash subject.
- [x] The simple change followed `spec -> plan -> implement -> done` inline.
- [x] Documentation matches observable behavior.
- [x] Release impact is classified and no package version or tag was created.
- [x] Changelog omission is explained.
- [x] README and detailed release guidance are aligned.
- [x] No credentials or private memory data are included.
- [x] Rollback is the single squash commit.
