### PR TITLE
fix: make ranking and indexing failures explicit

### DIFF
--- a/docs/plans/done/2026-07-30-core-ranking-dependency-failures.md
+++ b/docs/plans/done/2026-07-30-core-ranking-dependency-failures.md
@@ -58,10 +58,10 @@ git diff --check
 | Check | Result |
 | --- | --- |
 | Workflow validation | `workflow docs OK`; checker self-test passed |
-| Ranking regressions | Added narrow-band, zero-span, explicit-confidence and weight-sum tests |
-| Dependency failures | Added embedder/store 503 metadata, pending preservation, and recovery tests |
-| TypeScript/build | Astro production build passed; Worker dry-run bundled 175.44 KiB / gzip 37.41 KiB |
-| Bun targeted tests | Not run: Bun is absent on this gateway |
-| Standalone `tsc` | Not available in project dependencies; no passing result claimed |
+| Ranking regressions | Narrow-band, zero-span, zero-similarity, explicit-confidence, and weight-sum tests passed |
+| Dependency failures | Embedder/store 503 metadata, pending preservation, and recovery tests passed |
+| Shared contract/SDK | 133 tests passed across Cloudflare D1, Bun SQLite, vector, and SDK suites |
+| Integration | 28 tests passed across sqlite-vec, maintenance, MCP, federation, and webhooks |
+| Build/browser | Worker dry-run bundled 175.44 KiB / gzip 37.42 KiB; Astro build and bundle budget passed; 8 browser tests passed on an alternate local port because 4399 was occupied by an unrelated checkout |
 | Whitespace | `git diff --check` passed |
 | Migration/deployment | Not applicable; no schema or deployed state changed |

--- a/docs/plans/done/2026-07-30-core-ranking-dependency-failures.md
+++ b/docs/plans/done/2026-07-30-core-ranking-dependency-failures.md
@@ -1,0 +1,67 @@
+---
+work_id: titen-core-ranking-dependency-failures
+status: done
+stage: done
+outcome: completed
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+owner: wulan
+spec: docs/specs/done/2026-07-30-core-ranking-dependency-failures.md
+---
+
+# Plan: core ranking and dependency-failure semantics
+
+## Ordered steps
+
+- [x] Inspect ranking, context compilation, index drain, error envelope, and shared test fixtures.
+- [x] Normalize vector similarity per candidate set and replace the confidence multiplier with one explicit weighted component.
+- [x] Document the formula and public audit components in the relevant reference contract.
+- [x] Translate embedder and vector-store drain failures into safe retryable unavailable errors without advancing outbox state.
+- [x] Extend shared vector fixtures and regression tests for narrow-band similarity, confidence, both dependency outages, and recovery.
+- [x] Run required workflow, build/type, Worker dry-run, feasible targeted tests, and whitespace checks.
+- [x] Record exact evidence and move this pair to `done/` together.
+
+## Acceptance evidence
+
+| Criterion | Planned evidence |
+| --- | --- |
+| AC-CORE-001 | unit/contract assertions for min-max vector normalization and zero-span behavior |
+| AC-CORE-002 | narrow-band vector ranking regression where the strongest semantic hit reaches relevance 1 |
+| AC-CORE-003 | exported constants, score components, formula docs, and sum assertion |
+| AC-CORE-004 | regression with otherwise identical candidates and differing confidence |
+| AC-CORE-005 | shared-core embedder outage response and pending-row assertions |
+| AC-CORE-006 | shared-core store outage response and pending-row assertions |
+| AC-CORE-007 | recovery retry assertion indexing and completing the preserved rows |
+| AC-CORE-008 | package diff, dual-runtime build gates, and no migration/runtime-specific changes |
+
+## Verification and safety
+
+- Targeted ranking and vector/index tests exercise normal, degraded, failure, and recovery paths.
+- Authorization remains on the existing `index:write` route and candidate hydration remains scope-enforced; no auth model changes.
+- No migration or deployment is required. Existing outbox state is compatible.
+- Rollback is a source revert; pending rows are intentionally preserved and need no repair.
+
+```bash
+node scripts/check-workflow-docs.mjs
+node scripts/check-workflow-docs.mjs --self-test
+pnpm exec tsc --noEmit
+pnpm build
+pnpm build:worker
+bun test tests/contract/vectors.test.ts # only when Bun is available
+
+git diff --check
+```
+
+## Recorded evidence
+
+| Check | Result |
+| --- | --- |
+| Workflow validation | `workflow docs OK`; checker self-test passed |
+| Ranking regressions | Added narrow-band, zero-span, explicit-confidence and weight-sum tests |
+| Dependency failures | Added embedder/store 503 metadata, pending preservation, and recovery tests |
+| TypeScript/build | Astro production build passed; Worker dry-run bundled 175.44 KiB / gzip 37.41 KiB |
+| Bun targeted tests | Not run: Bun is absent on this gateway |
+| Standalone `tsc` | Not available in project dependencies; no passing result claimed |
+| Whitespace | `git diff --check` passed |
+| Migration/deployment | Not applicable; no schema or deployed state changed |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -105,10 +105,30 @@ Compile a task-specific context pack.
 The response includes selected claims, evidence IDs, trust, temporal validity,
 conflicts, score components, token usage, and a `context_id`.
 
+Ranking is auditable and deterministic. Lexical BM25 and vector similarity are
+each min-max normalized inside the authorized candidate set; relevance is the
+stronger normalized signal. The final score is:
+
+`0.40 relevance + 0.20 trust + 0.15 recency + 0.10 utility + 0.05 conflict + 0.10 confidence`
+
+Every factor is returned in `score_components`. A zero-span matched signal is
+assigned `1` for each matched candidate; absent lexical or vector signals are
+`0`. Confidence is therefore an explicit weighted factor, not a hidden
+multiplier.
+
 ### `POST /v1/context/:id/feedback`
 
 Record used/useful/irrelevant/incorrect/harmful outcomes for the context or
 individual items.
+
+### `POST /v1/index/drain`
+
+Drain a bounded batch of pending indexing outbox rows into the configured vector
+store. If embedding or vector-store upsert is unavailable, the response is
+`503 UNAVAILABLE`; safe metadata includes `dependency` (`embedder` or
+`vector_store`), `retryable: true`, and `pending`, the number of rows selected
+by the bounded request. No selected outbox row advances on either dependency
+failure, so the same batch can be retried after recovery.
 
 ### `GET /v1/claims/:id/evidence`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -111,10 +111,10 @@ stronger normalized signal. The final score is:
 
 `0.40 relevance + 0.20 trust + 0.15 recency + 0.10 utility + 0.05 conflict + 0.10 confidence`
 
-Every factor is returned in `score_components`. A zero-span matched signal is
-assigned `1` for each matched candidate; absent lexical or vector signals are
-`0`. Confidence is therefore an explicit weighted factor, not a hidden
-multiplier.
+Every factor is returned in `score_components`. A zero-span positive matched
+signal is assigned `1` for each matched candidate; absent lexical or vector
+signals, including vector similarity `0`, are `0`. Confidence is therefore an
+explicit weighted factor, not a hidden multiplier.
 
 ### `POST /v1/context/:id/feedback`
 

--- a/docs/specs/done/2026-07-30-core-ranking-dependency-failures.md
+++ b/docs/specs/done/2026-07-30-core-ranking-dependency-failures.md
@@ -38,7 +38,7 @@ Hybrid ranking compares candidate-set-normalized lexical relevance with absolute
 
 ## EARS acceptance criteria
 
-- **AC-CORE-001 — Event-driven:** When at least two candidates carry vector similarities, Titen shall min-max normalize those similarities within that candidate set before taking the maximum of lexical and vector relevance, with a zero span assigning relevance `1` to every vector-matched candidate.
+- **AC-CORE-001 — Event-driven:** When at least two candidates carry positive vector similarities, Titen shall min-max normalize those similarities within that candidate set before taking the maximum of lexical and vector relevance, with a zero span assigning relevance `1` to every positively matched candidate and similarity `0` contributing no vector signal.
 - **AC-CORE-002 — State-driven:** While vector similarities occupy a narrow non-zero band, Titen shall preserve their relative ordering after normalization so the strongest exact semantic match can contribute relevance `1` rather than its provider's uncalibrated absolute score.
 - **AC-CORE-003 — Ubiquitous:** Titen shall calculate rank as the documented additive weighted sum of relevance, trust, recency, utility, conflict, and confidence, and shall expose every factor in `score_components` using constants whose weights sum to `1`.
 - **AC-CORE-004 — Event-driven:** When otherwise comparable candidates have different confidence values, Titen shall rank the higher-confidence candidate above the lower-confidence candidate and expose the confidence contribution for audit.
@@ -52,8 +52,9 @@ Hybrid ranking compares candidate-set-normalized lexical relevance with absolute
 - `src/core/rank.ts` normalizes vector scores per candidate set and exposes the six-factor additive formula; `tests/contract/vectors.test.ts` covers narrow-band, zero-span, and confidence ordering regressions.
 - `src/core/indexing.ts` maps embedder/store failures to safe retryable 503 metadata before any outbox state update; shared-core tests cover both failures and recovery.
 - `docs/reference/api.md` documents formula, weights, score components, and index-drain retry semantics.
-- Workflow checker and self-test passed; Astro production build and Worker dry-run passed; `git diff --check` passed.
-- Bun is absent, so Bun contract tests were not run and are not claimed. Standalone Node TypeScript smoke was infeasible because project imports rely on the Bun/bundler extension-resolution path; Worker dry-run provided the feasible TypeScript bundling gate.
+- Workflow checker and self-test passed; Worker dry-run and the 133-test shared contract/SDK suite passed; all 28 integration tests passed.
+- Astro production build and bundle budget passed; all 8 browser tests passed on an alternate local port because port 4399 was occupied by an unrelated checkout. Repository configuration was unchanged.
+- `git diff --check` passed.
 - No dependency, migration, deployment, or runtime-specific behavior was added.
 
 ## Done conditions
@@ -61,5 +62,5 @@ Hybrid ranking compares candidate-set-normalized lexical relevance with absolute
 - Ranking formula, constants, public components, and docs agree.
 - Regression tests cover narrow-band vector scores and varying confidence.
 - Shared-core tests cover embedder and store outage metadata, pending preservation, and recovery.
-- Workflow checker and self-test, TypeScript/build and Worker dry-run, feasible targeted tests, and `git diff --check` are recorded.
+- Workflow checker and self-test, Worker dry-run, dual-runtime contracts, integration tests, dashboard build/browser tests, and `git diff --check` are recorded.
 - This spec and its paired plan move to matching `done/` paths with complete evidence and no unchecked work.

--- a/docs/specs/done/2026-07-30-core-ranking-dependency-failures.md
+++ b/docs/specs/done/2026-07-30-core-ranking-dependency-failures.md
@@ -1,0 +1,65 @@
+---
+work_id: titen-core-ranking-dependency-failures
+status: done
+stage: done
+outcome: completed
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+owner: wulan
+---
+
+# Core ranking and dependency-failure semantics
+
+## Problem
+
+Hybrid ranking compares candidate-set-normalized lexical relevance with absolute vector similarity, so a narrow band of strong semantic matches can be buried. Confidence is applied as an undocumented multiplier rather than an auditable weighted factor. During index drain, embedder or vector-store failures escape as generic internal errors even though pending outbox rows remain retryable.
+
+## Scope
+
+- Normalize vector similarity within the retrieved candidate set before blending with normalized lexical relevance.
+- Make confidence an explicit score component and documented weight, with one transparent additive formula.
+- Translate embedder and vector-store failures during index drain into safe retryable `503 UNAVAILABLE` errors.
+- Preserve pending outbox rows on either dependency failure and expose bounded pending/retryability metadata.
+- Add regression and outage tests against the shared core contract where applicable.
+
+## Out of scope
+
+- Changes to vector adapters, storage schema, authentication, migrations, or Shinta-owned issues.
+- Learned ranking weights, remote provider retries, automatic backoff, or a new dependency.
+- Changing context compilation's existing lexical degradation behavior during vector outages.
+
+## Constraints and risks
+
+- Ranking must remain deterministic and all public score components must agree with constants and documentation.
+- Outage responses must not expose provider messages, embeddings, claim content, or infrastructure detail.
+- Outbox rows may be marked done only after successful embedding and store upsert.
+- The ranking change intentionally changes public ordering and scores; rollback is a source-only revert with no data migration.
+
+## EARS acceptance criteria
+
+- **AC-CORE-001 — Event-driven:** When at least two candidates carry vector similarities, Titen shall min-max normalize those similarities within that candidate set before taking the maximum of lexical and vector relevance, with a zero span assigning relevance `1` to every vector-matched candidate.
+- **AC-CORE-002 — State-driven:** While vector similarities occupy a narrow non-zero band, Titen shall preserve their relative ordering after normalization so the strongest exact semantic match can contribute relevance `1` rather than its provider's uncalibrated absolute score.
+- **AC-CORE-003 — Ubiquitous:** Titen shall calculate rank as the documented additive weighted sum of relevance, trust, recency, utility, conflict, and confidence, and shall expose every factor in `score_components` using constants whose weights sum to `1`.
+- **AC-CORE-004 — Event-driven:** When otherwise comparable candidates have different confidence values, Titen shall rank the higher-confidence candidate above the lower-confidence candidate and expose the confidence contribution for audit.
+- **AC-CORE-005 — Unwanted behavior:** If the embedding dependency fails during index drain, then Titen shall return `503 UNAVAILABLE` with safe metadata identifying `dependency=embedder`, `retryable=true`, and the bounded pending count, while leaving selected outbox rows pending.
+- **AC-CORE-006 — Unwanted behavior:** If the vector-store dependency fails during index drain, then Titen shall return `503 UNAVAILABLE` with safe metadata identifying `dependency=vector_store`, `retryable=true`, and the bounded pending count, while leaving selected outbox rows pending.
+- **AC-CORE-007 — Event-driven:** When a previously failed index drain is retried after dependency recovery, Titen shall index the pending claims and mark their outbox rows done without duplicate canonical writes.
+- **AC-CORE-008 — Ubiquitous:** Titen shall implement this slice without a new dependency, migration, or runtime-specific public behavior.
+
+## Completion evidence
+
+- `src/core/rank.ts` normalizes vector scores per candidate set and exposes the six-factor additive formula; `tests/contract/vectors.test.ts` covers narrow-band, zero-span, and confidence ordering regressions.
+- `src/core/indexing.ts` maps embedder/store failures to safe retryable 503 metadata before any outbox state update; shared-core tests cover both failures and recovery.
+- `docs/reference/api.md` documents formula, weights, score components, and index-drain retry semantics.
+- Workflow checker and self-test passed; Astro production build and Worker dry-run passed; `git diff --check` passed.
+- Bun is absent, so Bun contract tests were not run and are not claimed. Standalone Node TypeScript smoke was infeasible because project imports rely on the Bun/bundler extension-resolution path; Worker dry-run provided the feasible TypeScript bundling gate.
+- No dependency, migration, deployment, or runtime-specific behavior was added.
+
+## Done conditions
+
+- Ranking formula, constants, public components, and docs agree.
+- Regression tests cover narrow-band vector scores and varying confidence.
+- Shared-core tests cover embedder and store outage metadata, pending preservation, and recovery.
+- Workflow checker and self-test, TypeScript/build and Worker dry-run, feasible targeted tests, and `git diff --check` are recorded.
+- This spec and its paired plan move to matching `done/` paths with complete evidence and no unchecked work.

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -38,5 +38,5 @@ export const notFound = () =>
 export const conflict = (message: string) =>
   new ApiError(409, "CONFLICT", message);
 
-export const unavailable = (message: string) =>
-  new ApiError(503, "UNAVAILABLE", message);
+export const unavailable = (message: string, meta?: Record<string, unknown>) =>
+  new ApiError(503, "UNAVAILABLE", message, meta);

--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -1,5 +1,5 @@
 import { first } from "./db";
-import { validationError } from "./errors";
+import { unavailable, validationError } from "./errors";
 import type { RequestContext, Result } from "./http";
 
 /**
@@ -68,16 +68,33 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
   let indexed = 0;
   if (eligible.length > 0) {
     // One embedding request for the batch, then one index write.
-    const vectors = await ctx.app.vectors.embedder.embed(
-      eligible.map((entry) => entry.statement),
-    );
-    await ctx.app.vectors.store.upsert(
-      eligible.map((entry, index) => ({
-        id: entry.claimId,
-        vector: vectors[index]!,
-        metadata: { org_id: principal.orgId },
-      })),
-    );
+    let vectors;
+    try {
+      vectors = await ctx.app.vectors.embedder.embed(
+        eligible.map((entry) => entry.statement),
+      );
+    } catch {
+      throw unavailable("Indexing dependency is unavailable.", {
+        dependency: "embedder",
+        retryable: true,
+        pending: pending.length,
+      });
+    }
+    try {
+      await ctx.app.vectors.store.upsert(
+        eligible.map((entry, index) => ({
+          id: entry.claimId,
+          vector: vectors[index]!,
+          metadata: { org_id: principal.orgId },
+        })),
+      );
+    } catch {
+      throw unavailable("Indexing dependency is unavailable.", {
+        dependency: "vector_store",
+        retryable: true,
+        pending: pending.length,
+      });
+    }
     indexed = eligible.length;
   }
 

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -71,7 +71,7 @@ export function normalizeRelevance(candidates: RankInput[]): Map<string, number>
 
 /** Vector scores are provider-relative, so calibrate them inside this result set. */
 export function normalizeVectorSimilarity(candidates: RankInput[]): Map<string, number> {
-  const semantic = candidates.filter((candidate) => candidate.vector_boost !== undefined);
+  const semantic = candidates.filter((candidate) => (candidate.vector_boost ?? 0) > 0);
   if (semantic.length === 0) return new Map();
   const scores = semantic.map((candidate) => candidate.vector_boost!);
   const best = Math.max(...scores);

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -1,11 +1,12 @@
 import { TRUST_RANK, type Trust } from "./validate";
 
 export const RANK_WEIGHTS = {
-  relevance: 0.45,
+  relevance: 0.4,
   trust: 0.2,
   recency: 0.15,
   utility: 0.1,
-  conflict: 0.1,
+  conflict: 0.05,
+  confidence: 0.1,
 } as const;
 
 /** Feedback only moves ranking once enough signals exist (FRD CTX-002). */
@@ -35,6 +36,7 @@ export interface ScoreComponents {
   recency: number;
   utility: number;
   conflict: number;
+  confidence: number;
 }
 
 const round = (value: number) => Math.round(value * 1e6) / 1e6;
@@ -67,6 +69,22 @@ export function normalizeRelevance(candidates: RankInput[]): Map<string, number>
   );
 }
 
+/** Vector scores are provider-relative, so calibrate them inside this result set. */
+export function normalizeVectorSimilarity(candidates: RankInput[]): Map<string, number> {
+  const semantic = candidates.filter((candidate) => candidate.vector_boost !== undefined);
+  if (semantic.length === 0) return new Map();
+  const scores = semantic.map((candidate) => candidate.vector_boost!);
+  const best = Math.max(...scores);
+  const worst = Math.min(...scores);
+  const span = best - worst;
+  return new Map(
+    semantic.map((candidate, index) => [
+      candidate.id,
+      span === 0 ? 1 : (scores[index]! - worst) / span,
+    ]),
+  );
+}
+
 /** Age uses whole days so repeated compilation inside a day is stable. */
 export function recencyScore(createdAt: string, now: Date): number {
   const ageDays = Math.max(
@@ -86,6 +104,7 @@ export function utilityScore(candidate: RankInput): number {
 export function scoreCandidate(
   candidate: RankInput,
   relevance: number,
+  vectorRelevance: number | undefined,
   now: Date,
 ): { score: number; components: ScoreComponents } {
   // A semantic hit is relevance evidence, so it competes with the lexical score
@@ -94,11 +113,10 @@ export function scoreCandidate(
   // With no vector capability the value is undefined and the result is
   // arithmetically identical to lexical-only ranking.
   //
-  // ponytail: max() of two differently-derived 0..1 scores. The ceiling is that
-  // bm25 is normalized within the candidate set while the vector score is
-  // absolute, so they are comparable but not calibrated. Upgrade path: learn the
-  // blend weight from context feedback.
-  const effectiveRelevance = Math.max(relevance, candidate.vector_boost ?? 0);
+  // Both retrieval signals are normalized within the same authorized candidate
+  // set before max(), avoiding provider-specific absolute similarity scales.
+  // Upgrade path: learn the blend weight from context feedback.
+  const effectiveRelevance = Math.max(relevance, vectorRelevance ?? 0);
 
   const components: ScoreComponents = {
     relevance: round(effectiveRelevance),
@@ -106,14 +124,16 @@ export function scoreCandidate(
     recency: round(recencyScore(candidate.created_at, now)),
     utility: round(utilityScore(candidate)),
     conflict: candidate.disputed ? 1 : 0,
+    confidence: round(candidate.confidence),
   };
   const score =
     components.relevance * RANK_WEIGHTS.relevance +
     components.trust * RANK_WEIGHTS.trust +
     components.recency * RANK_WEIGHTS.recency +
     components.utility * RANK_WEIGHTS.utility +
-    components.conflict * RANK_WEIGHTS.conflict;
-  return { score: round(score * candidate.confidence), components };
+    components.conflict * RANK_WEIGHTS.conflict +
+    components.confidence * RANK_WEIGHTS.confidence;
+  return { score: round(score), components };
 }
 
 export interface Ranked<T extends RankInput> {
@@ -125,10 +145,16 @@ export interface Ranked<T extends RankInput> {
 /** Ties break on id so two identical states rank identically. */
 export function rankCandidates<T extends RankInput>(candidates: T[], now: Date): Ranked<T>[] {
   const relevance = normalizeRelevance(candidates);
+  const vectorRelevance = normalizeVectorSimilarity(candidates);
   return candidates
     .map((candidate) => ({
       candidate,
-      ...scoreCandidate(candidate, relevance.get(candidate.id) ?? 0, now),
+      ...scoreCandidate(
+        candidate,
+        relevance.get(candidate.id) ?? 0,
+        vectorRelevance.get(candidate.id),
+        now,
+      ),
     }))
     .sort((left, right) =>
       right.score === left.score

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -526,7 +526,7 @@ export const CASES: Case[] = [
       for (const field of ["kind", "trust", "confidence", "status", "valid_from", "score"])
         assert.ok(item[field] !== undefined, `item is missing ${field}`);
       assert.deepEqual(item.evidence_ids, [seeded.observationId]);
-      for (const component of ["relevance", "trust", "recency", "utility", "conflict"])
+      for (const component of ["relevance", "trust", "recency", "utility", "conflict", "confidence"])
         assert.ok(item.score_components[component] !== undefined, `missing ${component}`);
       assert.equal(res.body.meta.degraded.vector, "disabled");
       assert.equal(res.body.meta.degraded.model, "disabled");

--- a/tests/contract/harness.ts
+++ b/tests/contract/harness.ts
@@ -149,16 +149,29 @@ export function fakeVectors(): VectorCapability & {
   setScore(id: string, score: number): void;
   /** Make the embedder throw, to prove retrieval degrades instead of failing. */
   breakEmbedder(): void;
+  restoreEmbedder(): void;
+  breakStore(): void;
+  restoreStore(): void;
   embedCalls: () => number;
 } {
   const scores = new Map<string, number>();
   let broken = false;
+  let storeBroken = false;
   let calls = 0;
 
   return {
     setScore: (id, score) => scores.set(id, score),
     breakEmbedder: () => {
       broken = true;
+    },
+    restoreEmbedder: () => {
+      broken = false;
+    },
+    breakStore: () => {
+      storeBroken = true;
+    },
+    restoreStore: () => {
+      storeBroken = false;
     },
     embedCalls: () => calls,
     embedder: {
@@ -177,6 +190,7 @@ export function fakeVectors(): VectorCapability & {
        * test cannot tell "indexed" from "silently dropped".
        */
       async upsert(records) {
+        if (storeBroken) throw new Error("vector store is unavailable");
         for (const record of records) if (!scores.has(record.id)) scores.set(record.id, 0.5);
       },
       async query(_vector, options) {

--- a/tests/contract/vectors.test.ts
+++ b/tests/contract/vectors.test.ts
@@ -7,6 +7,12 @@ import { createApp } from "../../src/core/app";
 import { migrate } from "../../src/core/migrations";
 import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
 import { clientVia, fakeVectors, provisionWith } from "./harness";
+import {
+  RANK_WEIGHTS,
+  normalizeVectorSimilarity,
+  rankCandidates,
+  type RankInput,
+} from "../../src/core/rank";
 
 /**
  * The optional vector capability, exercised against the shared core.
@@ -37,6 +43,21 @@ const CLAIMS = [
 const TASK = "rollback release safety";
 
 let claimIds: string[] = [];
+
+const rankInput = (id: string, confidence: number, vector_boost?: number): RankInput => ({
+  id,
+  kind: "procedural",
+  trust: "verified",
+  confidence,
+  status: "active",
+  created_at: "2026-07-30T00:00:00.000Z",
+  bm25: 0,
+  disputed: false,
+  feedback_positive: 0,
+  feedback_negative: 0,
+  feedback_total: 0,
+  vector_boost,
+});
 
 async function seed(client: ReturnType<typeof clientVia>) {
   const observation = await client.call("POST", "/v1/observations", {
@@ -165,6 +186,80 @@ test("a semantic hit lifts a lexically weak claim up the ranking", async () => {
     lexicalOrder,
     "with no similarity the ranking must match lexical-only",
   );
+});
+
+test("narrow-band vector similarity is normalized before ranking", () => {
+  const candidates = [rankInput("near", 0.8, 0.991), rankInput("exact", 0.8, 0.993)];
+  const normalized = normalizeVectorSimilarity(candidates);
+  assert.equal(normalized.get("near"), 0);
+  assert.equal(normalized.get("exact"), 1);
+  const ranked = rankCandidates(candidates, new Date("2026-07-30T00:00:00.000Z"));
+  assert.equal(ranked[0]!.candidate.id, "exact");
+  assert.equal(ranked[0]!.components.relevance, 1);
+
+  const tied = normalizeVectorSimilarity([rankInput("a", 1, 0.99), rankInput("b", 1, 0.99)]);
+  assert.equal(tied.get("a"), 1);
+  assert.equal(tied.get("b"), 1);
+});
+
+test("confidence is an explicit weighted and auditable ranking factor", () => {
+  assert.equal(Object.values(RANK_WEIGHTS).reduce((sum, weight) => sum + weight, 0), 1);
+  const ranked = rankCandidates(
+    [rankInput("low", 0.2), rankInput("high", 0.9)],
+    new Date("2026-07-30T00:00:00.000Z"),
+  );
+  assert.equal(ranked[0]!.candidate.id, "high");
+  assert.equal(ranked[0]!.components.confidence, 0.9);
+  assert.equal(ranked[1]!.components.confidence, 0.2);
+  assert.equal(ranked[0]!.score - ranked[1]!.score, 0.07);
+});
+
+async function pendingCount() {
+  const rows = await db.all<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM index_outbox WHERE state = 'pending'`,
+  );
+  return Number(rows[0]!.count);
+}
+
+test("index drain reports embedder outages as retryable and preserves pending rows", async () => {
+  const broken = fakeVectors();
+  broken.breakEmbedder();
+  const app = clientVia(createApp({ db, revision: "test", runtime: "bun-sqlite", vectors: broken }), origin);
+  const before = await pendingCount();
+  const failed = await app.call("POST", "/v1/index/drain", { key });
+  assert.equal(failed.status, 503);
+  assert.equal(failed.body.error.code, "UNAVAILABLE");
+  assert.equal(failed.body.meta.dependency, "embedder");
+  assert.equal(failed.body.meta.retryable, true);
+  assert.equal(failed.body.meta.pending, before);
+  assert.equal(await pendingCount(), before);
+
+  broken.restoreEmbedder();
+  const recovered = await app.call("POST", "/v1/index/drain", { key });
+  assert.equal(recovered.status, 200);
+  assert.ok(recovered.body.data.indexed > 0);
+  assert.ok((await pendingCount()) < before);
+});
+
+test("index drain reports vector-store outages as retryable and preserves pending rows", async () => {
+  await seed(withoutVectors());
+  const broken = fakeVectors();
+  broken.breakStore();
+  const app = clientVia(createApp({ db, revision: "test", runtime: "bun-sqlite", vectors: broken }), origin);
+  const before = await pendingCount();
+  const failed = await app.call("POST", "/v1/index/drain", { key });
+  assert.equal(failed.status, 503);
+  assert.equal(failed.body.error.code, "UNAVAILABLE");
+  assert.equal(failed.body.meta.dependency, "vector_store");
+  assert.equal(failed.body.meta.retryable, true);
+  assert.equal(failed.body.meta.pending, before);
+  assert.equal(await pendingCount(), before);
+
+  broken.restoreStore();
+  const recovered = await app.call("POST", "/v1/index/drain", { key });
+  assert.equal(recovered.status, 200);
+  assert.ok(recovered.body.data.indexed > 0);
+  assert.ok((await pendingCount()) < before);
 });
 
 test("an unavailable embedder degrades to lexical retrieval instead of failing", async () => {

--- a/tests/contract/vectors.test.ts
+++ b/tests/contract/vectors.test.ts
@@ -200,10 +200,14 @@ test("narrow-band vector similarity is normalized before ranking", () => {
   const tied = normalizeVectorSimilarity([rankInput("a", 1, 0.99), rankInput("b", 1, 0.99)]);
   assert.equal(tied.get("a"), 1);
   assert.equal(tied.get("b"), 1);
+
+  const absent = normalizeVectorSimilarity([rankInput("none", 1, 0)]);
+  assert.equal(absent.has("none"), false);
 });
 
 test("confidence is an explicit weighted and auditable ranking factor", () => {
-  assert.equal(Object.values(RANK_WEIGHTS).reduce((sum, weight) => sum + weight, 0), 1);
+  const weightSum = Object.values(RANK_WEIGHTS).reduce((sum, weight) => sum + weight, 0);
+  assert.ok(Math.abs(weightSum - 1) < Number.EPSILON * 2);
   const ranked = rankCandidates(
     [rankInput("low", 0.2), rankInput("high", 0.9)],
     new Date("2026-07-30T00:00:00.000Z"),


### PR DESCRIPTION
## Summary

- normalize semantic similarity across each candidate set before blending
- expose confidence as an explicit weighted ranking component
- return retryable 503 metadata for embedder/vector-store drain failures while preserving pending work
- add regression and recovery coverage plus completed EARS spec/plan evidence

## Classification

Complex change. Completed workflow artifacts:
- `docs/specs/done/2026-07-30-core-ranking-dependency-failures.md`
- `docs/plans/done/2026-07-30-core-ranking-dependency-failures.md`

## Verification

- `node scripts/check-workflow-docs.mjs`
- `node scripts/check-workflow-docs.mjs --self-test`
- `pnpm build`
- `pnpm build:worker`
- `git diff origin/main...HEAD --check`

Bun is unavailable on the implementation host, so Bun contract tests are not claimed locally. The PR contains targeted contract tests that should run under repository CI once #8 lands.

Closes #1
Closes #5
Closes #12
