### PR TITLE
ci: add repository regression guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify (Node 22 / Bun 1.2)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.17.0
+
+      - name: Setup Bun 1.2
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.20
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check workflow documents
+        run: pnpm check:workflow
+
+      - name: Build dashboard
+        run: pnpm build
+
+      - name: Run API contract tests
+        run: pnpm test:api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.17.0
+
       - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.17.0
 
       - name: Setup Bun 1.2
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 11.17.0
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Setup Bun 1.2
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.2.20
 
@@ -51,6 +51,9 @@ jobs:
 
       - name: Run API contract tests
         run: pnpm test:api
+
+      - name: Run integration tests
+        run: pnpm test:integration
 
       - name: Run browser tests
         run: pnpm test:browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,11 @@ jobs:
       - name: Build dashboard
         run: pnpm build
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Run API contract tests
         run: pnpm test:api
+
+      - name: Run browser tests
+        run: pnpm test:browser

--- a/docs/plans/active/2026-07-30-ci-guardrail.md
+++ b/docs/plans/active/2026-07-30-ci-guardrail.md
@@ -14,8 +14,8 @@ spec: docs/specs/active/2026-07-30-ci-guardrail.md
 # Plan: CI guardrail
 
 - [ ] Add `.github/workflows/ci.yml` with pull-request and `main` push triggers.
-- [ ] Pin Node 22/Bun 1.2 setup and use the committed lockfile.
-- [ ] Run workflow docs, build, and API checks as separate steps.
+- [ ] Pin GitHub Actions to immutable SHAs, pin Node 22/Bun 1.2 tooling, and use the committed lockfile.
+- [ ] Run workflow docs, API/SDK, integration, build, and browser checks as separate steps.
 - [ ] Validate YAML and run local equivalent gates where tooling is available.
 - [ ] Move paired artifacts to `done/` after evidence is captured.
 
@@ -25,6 +25,7 @@ spec: docs/specs/active/2026-07-30-ci-guardrail.md
 - AC-CI-002: GitHub Actions `set -e`/failed-step semantics and local failure gate review.
 - AC-CI-003: lockfile-based install command and no secret references inspection.
 - AC-CI-004: separate named workflow steps plus local command evidence.
+- AC-CI-005: workflow inspection confirms every third-party action uses a full commit SHA.
 
 ## Risks and rollback
 

--- a/docs/plans/active/2026-07-30-ci-guardrail.md
+++ b/docs/plans/active/2026-07-30-ci-guardrail.md
@@ -1,0 +1,31 @@
+---
+work_id: ci-guardrail
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+review_after: 2026-08-13
+owner: shintaaurelia
+spec: docs/specs/active/2026-07-30-ci-guardrail.md
+---
+
+# Plan: CI guardrail
+
+- [ ] Add `.github/workflows/ci.yml` with pull-request and `main` push triggers.
+- [ ] Pin Node 22/Bun 1.2 setup and use the committed lockfile.
+- [ ] Run workflow docs, build, and API checks as separate steps.
+- [ ] Validate YAML and run local equivalent gates where tooling is available.
+- [ ] Move paired artifacts to `done/` after evidence is captured.
+
+## Acceptance mapping
+
+- AC-CI-001: workflow trigger and setup inspection.
+- AC-CI-002: GitHub Actions `set -e`/failed-step semantics and local failure gate review.
+- AC-CI-003: lockfile-based install command and no secret references inspection.
+- AC-CI-004: separate named workflow steps plus local command evidence.
+
+## Risks and rollback
+
+Risk is limited to CI configuration; rollback is reverting the workflow commit. No deployment or credential mutation is performed.

--- a/docs/specs/active/2026-07-30-ci-guardrail.md
+++ b/docs/specs/active/2026-07-30-ci-guardrail.md
@@ -1,0 +1,38 @@
+---
+work_id: ci-guardrail
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+review_after: 2026-08-13
+owner: shintaaurelia
+---
+
+# CI guardrail
+
+## Problem
+
+The repository has no automated CI gate, so regressions can land without the documented build, workflow, and API checks running.
+
+## Scope
+
+Add a GitHub Actions workflow for supported Node/Bun tooling that installs dependencies from the lockfile and runs the repository's existing workflow, build, and API checks. Keep credentials and deployment mutations out of CI.
+
+## Out of scope
+
+Deployments, live service smoke tests requiring secrets, and changes to application behavior.
+
+## Acceptance criteria
+
+- **AC-CI-001 — Event-driven:** When a pull request or push targets `main`, Titen shall run a reproducible CI workflow on Ubuntu with Node 22 and Bun 1.2 tooling.
+- **AC-CI-002 — Unwanted behavior:** If dependency installation, workflow validation, build, or API checks fail, then Titen shall mark the CI run failed and prevent a passing check conclusion.
+- **AC-CI-003 — Ubiquitous:** Titen shall install dependencies from the committed lockfile and shall not require deployment credentials for the default CI path.
+- **AC-CI-004 — Event-driven:** When the CI workflow runs, Titen shall execute the repository workflow-doc check, production build, and API contract test command as separate observable steps.
+
+## Done conditions
+
+- Workflow is committed and scoped to pull requests/pushes on `main`.
+- Acceptance criteria have reproducible evidence.
+- Paired plan is moved to `docs/plans/done/` with evidence and this spec is moved to `docs/specs/done/`.

--- a/docs/specs/active/2026-07-30-ci-guardrail.md
+++ b/docs/specs/active/2026-07-30-ci-guardrail.md
@@ -18,7 +18,7 @@ The repository has no automated CI gate, so regressions can land without the doc
 
 ## Scope
 
-Add a GitHub Actions workflow for supported Node/Bun tooling that installs dependencies from the lockfile and runs the repository's existing workflow, build, and API checks. Keep credentials and deployment mutations out of CI.
+Add a GitHub Actions workflow for supported Node/Bun tooling that installs dependencies from the lockfile and runs the repository's existing workflow, API/SDK, integration, build, and browser checks. Keep credentials and deployment mutations out of CI.
 
 ## Out of scope
 
@@ -27,9 +27,10 @@ Deployments, live service smoke tests requiring secrets, and changes to applicat
 ## Acceptance criteria
 
 - **AC-CI-001 — Event-driven:** When a pull request or push targets `main`, Titen shall run a reproducible CI workflow on Ubuntu with Node 22 and Bun 1.2 tooling.
-- **AC-CI-002 — Unwanted behavior:** If dependency installation, workflow validation, build, or API checks fail, then Titen shall mark the CI run failed and prevent a passing check conclusion.
+- **AC-CI-002 — Unwanted behavior:** If dependency installation, workflow validation, API/SDK, integration, build, or browser checks fail, then Titen shall mark the CI run failed and prevent a passing check conclusion.
 - **AC-CI-003 — Ubiquitous:** Titen shall install dependencies from the committed lockfile and shall not require deployment credentials for the default CI path.
-- **AC-CI-004 — Event-driven:** When the CI workflow runs, Titen shall execute the repository workflow-doc check, production build, and API contract test command as separate observable steps.
+- **AC-CI-004 — Event-driven:** When the CI workflow runs, Titen shall execute the repository workflow-doc, API/SDK, integration, production build, and browser commands as separate observable steps.
+- **AC-CI-005 — Ubiquitous:** Titen shall pin third-party GitHub Actions to immutable commit SHAs while documenting their major release line.
 
 ## Done conditions
 


### PR DESCRIPTION
## Summary

- add pinned GitHub Actions guardrails for repository workflow, API/SDK, integration, build, and browser gates
- install the project package manager, Bun, and Chromium dependencies explicitly in CI
- keep live/model/container verification documented as manual-only where provisioned infrastructure is required

## Classification

Complex CI/reliability change. Spec and plan remain active until the workflow has run successfully and final evidence is recorded.

## Current local evidence

- workflow docs checker: passed
- workflow checker self-test: passed
- `git diff --check`: passed
- full build/API/browser evidence: pending this PR's GitHub Actions run

Closes #8
