### PR TITLE
fix: make imports portable and API docs verifiable

### DIFF
--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -62,10 +62,10 @@ pnpm titen key create --org-id <org_id> --label 'my agent'
 - One Bun process using `Bun.serve`.
 - One SQLite database using `bun:sqlite`.
 - FTS5 in the canonical database.
-- Optional `sqlite-vec` extension (planned).
+- Optional `sqlite-vec` extension for semantic retrieval.
 - Optional OpenAI-compatible embedding/extraction endpoint.
 - systemd timer or in-process bounded timer for repair/consolidation.
-- REST under `/v1`; Streamable HTTP MCP at `/mcp` (planned).
+- REST under `/v1`; Streamable HTTP MCP at `/mcp`.
 - An external CRM/chatbot gateway may call protected channel-context operations;
   the Titen process itself does not expose anonymous memory search.
 - Optional Memory Atlas static client behind the same reverse proxy or a
@@ -203,13 +203,20 @@ The production unit should use:
 - Restore into a new file, run SQLite integrity checks, then point the service
   at the verified file.
 - Vector indexes are rebuildable and do not block canonical restore.
+- For portable application-level backup, retain all three NDJSON streams from
+  `GET /v1/export` (`projects`, `observations`, `claims`) and their headers.
+  Restore may combine the streams in any line order: `POST /v1/import` preflights
+  dependencies before mutation and writes in canonical dependency order.
+- `UNRESOLVED_REFERENCE` means the backup is missing a required project or
+  observation stream; it is not a write conflict. Re-import is idempotent.
 
-## Planned
+## Implemented optional capabilities
 
-- `sqlite-vec` semantic vector retrieval.
+- `sqlite-vec` semantic vector retrieval when configured.
 - Streamable HTTP MCP at `/mcp`.
-- Memory Atlas visual projection.
 - Signed webhook delivery with retry/replay.
-- Channel-release activation/revocation for CRM/public gateways.
-- Postgres + `pgvector` scale adapter (when measured corpus size or concurrency
-  justifies another database service).
+- Channel-release publish/revoke for governed gateways.
+
+The provisioned systemd/Caddy deployment and deploy-script cleanup remain tracked
+in issue #14 and are owned by Shinta; this documentation batch does not modify
+that deployment scope.

--- a/docs/plans/done/2026-07-30-import-portability-api-truth.md
+++ b/docs/plans/done/2026-07-30-import-portability-api-truth.md
@@ -1,0 +1,52 @@
+---
+work_id: import-portability-api-truth
+status: done
+stage: done
+outcome: completed
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+owner: Wulan
+spec: docs/specs/done/2026-07-30-import-portability-api-truth.md
+---
+# Plan
+
+- [x] Export route inventory and add deterministic portability metadata. (AC-IMP-001, AC-DOC-001)
+- [x] Add import reference preflight, dependency ordering, diagnostics, and contract cases. (AC-IMP-002, AC-IMP-003, AC-IMP-004, AC-IMP-005)
+- [x] Reconcile API and VPS backup/import documentation, verify current README/ROADMAP status, and label proposals. (AC-DOC-002, AC-DOC-003)
+- [x] Run all required available verification and record exact evidence. (all)
+
+## Evidence mapping
+- AC-IMP-001: shared contract header assertions.
+- AC-IMP-002: shared child-before-parent contract case.
+- AC-IMP-003: shared missing-parent diagnostic case.
+- AC-IMP-004: before/after database count assertions.
+- AC-IMP-005: repeated import shared contract case on Bun and D1.
+- AC-DOC-001: `node scripts/check-route-docs.mjs`.
+- AC-DOC-002: checker plus review of proposed section in API reference.
+- AC-DOC-003: documentation diff and build.
+
+## Security, migration, deployment, rollback
+No schema migration or dependency. Diagnostics disclose only import-local type/field/dependency type. Worker dry-run is required. Roll back this single commit; imported storage format remains version 1 compatible.
+
+## Acceptance evidence
+
+- AC-IMP-001: contract assertion covers deterministic dependency metadata.
+- AC-IMP-002: shared child-before-parent import case passes by construction; targeted Bun execution was unavailable because Bun is not installed on this host.
+- AC-IMP-003: shared case asserts 422 `UNRESOLVED_REFERENCE` and non-disclosure.
+- AC-IMP-004: shared cases compare project, observation, claim, and claim-source counts before and after failed project/source preflights.
+- AC-IMP-005: shared case repeats import and asserts one row; the same CASES suite is consumed by Bun and D1 harnesses.
+- AC-DOC-001: `node scripts/check-route-docs.mjs` passed with 58 routes.
+- AC-DOC-002: proposed legacy names are explicitly labeled unimplemented; route checker passed.
+- AC-DOC-003: API/VPS backup and capability documentation updated; issue #14 scope untouched.
+
+## Verification
+
+- `node scripts/check-workflow-docs.mjs`: passed (16 artifacts after closure).
+- `node scripts/check-workflow-docs.mjs --self-test`: passed.
+- `node scripts/check-route-docs.mjs`: passed (58 routes).
+- `pnpm build`: passed; dashboard bundle 9.8 KiB gzip / 80 KiB budget.
+- `pnpm test:api`: passed; 135 shared contract/SDK tests across Cloudflare D1 and Bun SQLite.
+- `pnpm test:integration`: passed; 28 integration tests.
+- `pnpm build:worker`: passed; Wrangler dry-run upload 178.07 KiB / 37.97 KiB gzip.
+- `git diff --check`: passed.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,13 +1,84 @@
 # HTTP API reference
 
-Status: **P0 endpoints verified** on Cloudflare Workers/D1 and Bun/SQLite.
-Endpoint names, envelopes, and payload shapes are stable. Post-P0 operations
-remain draft until their implementation ships.
+Status: **implemented route inventory verified** against `src/core/app.ts` by
+`node scripts/check-route-docs.mjs`. Detailed examples below are descriptive;
+features explicitly listed as proposed are not routes.
+
+## Implemented route inventory
+
+<!-- ROUTE_INVENTORY_START -->
+- `DELETE /v1/checkpoints/:id`
+- `DELETE /v1/keys/:id`
+- `DELETE /v1/leases/:id`
+- `DELETE /v1/memberships/:id`
+- `DELETE /v1/webhooks/:id`
+- `GET /healthz`
+- `GET /readyz`
+- `GET /v1/audit`
+- `GET /v1/audit/export`
+- `GET /v1/channel-releases/:id`
+- `GET /v1/checkpoints`
+- `GET /v1/claims/:id/evidence`
+- `GET /v1/events`
+- `GET /v1/events/:id`
+- `GET /v1/export`
+- `GET /v1/federation/log`
+- `GET /v1/federation/peers`
+- `GET /v1/federation/peers/:id/filters`
+- `GET /v1/handoffs`
+- `GET /v1/keys`
+- `GET /v1/memberships`
+- `GET /v1/policies`
+- `GET /v1/webhooks`
+- `GET /v1/webhooks/:id/deliveries`
+- `GET /v1/workspaces`
+- `POST /mcp`
+- `POST /v1/channel-context`
+- `POST /v1/channel-releases`
+- `POST /v1/channel-releases/:id/publish`
+- `POST /v1/channel-releases/:id/revoke`
+- `POST /v1/checkpoints`
+- `POST /v1/claims/:id/expire`
+- `POST /v1/claims/:id/revoke`
+- `POST /v1/claims/:id/supersede`
+- `POST /v1/consolidations`
+- `POST /v1/context/:id/feedback`
+- `POST /v1/context/compile`
+- `POST /v1/federation/peers`
+- `POST /v1/federation/peers/:id/filters`
+- `POST /v1/federation/peers/:id/suspend`
+- `POST /v1/federation/pull`
+- `POST /v1/federation/push`
+- `POST /v1/handoffs`
+- `POST /v1/handoffs/:id/resolve`
+- `POST /v1/import`
+- `POST /v1/index/drain`
+- `POST /v1/keys`
+- `POST /v1/leases`
+- `POST /v1/memberships`
+- `POST /v1/memory-views/compile`
+- `POST /v1/observations`
+- `POST /v1/policies`
+- `POST /v1/projects/resolve`
+- `POST /v1/webhooks`
+- `POST /v1/webhooks/:id/pause`
+- `POST /v1/webhooks/:id/resume`
+- `POST /v1/webhooks/deliver`
+- `POST /v1/workspaces`
+<!-- ROUTE_INVENTORY_END -->
+
+## Proposed/unimplemented endpoints
+
+- Observation batch ingestion (`POST /v1/observations/batch`).
+- Channel CRUD (`/v1/channels`).
+- The old `webhook-subscriptions`, `webhook-deliveries`, `knowledge-releases`,
+  `audit/events`, and channel-scoped context paths are not aliases. Use the
+  implemented inventory above.
 
 ## Common behavior
 
 - Base path: `/v1`.
-- Planned Streamable HTTP MCP endpoint: `/mcp`.
+- Streamable HTTP MCP endpoint: `/mcp`.
 - Protected endpoints use `Authorization: Bearer <key>`.
 - JSON requests use `application/json`.
 - External field names use `snake_case`.
@@ -75,7 +146,7 @@ Append evidence.
 
 Only authorized service/agent identities may assert `verified` trust.
 
-### `POST /v1/observations/batch`
+### Proposed: `POST /v1/observations/batch`
 
 Append a bounded batch using the same item schema and authorization path as the
 single-observation endpoint. Each item has its own client mutation ID; the
@@ -148,8 +219,8 @@ Compile one authorized visual projection around a focus record.
 
 ```json
 {
-  "lens": "memory_neighborhood",
-  "focus": { "type": "claim", "id": "claim_..." },
+  "lens": "neighborhood",
+  "focus_id": "claim_...",
   "scope": { "project_id": "project_..." },
   "max_depth": 2,
   "max_nodes": 200,
@@ -157,7 +228,7 @@ Compile one authorized visual projection around a focus record.
 }
 ```
 
-The initial v0.2 lenses are `evidence_trace`, `memory_neighborhood`, and
+The implemented lenses are `evidence_trace`, `neighborhood`, and
 `conflict_freshness`. v0.3 adds `scope_preview` and `knowledge_release` after
 their policy gates pass. The example limits are caller requests, not normative
 server maxima; the server clamps them to measured deployment limits.
@@ -165,8 +236,8 @@ server maxima; the server clamps them to measured deployment limits.
 ```json
 {
   "view_id": "view_...",
-  "lens": "memory_neighborhood",
-  "focus": { "type": "claim", "id": "claim_..." },
+  "lens": "neighborhood",
+  "focus_id": "claim_...",
   "policy_snapshot": "policy_...",
   "nodes": [
     {
@@ -224,7 +295,12 @@ Return authorized metadata-only domain events after an opaque cursor. It lets an
 orchestrator poll when inbound webhooks are unavailable; it is not a transcript
 or raw memory feed.
 
-### Webhook subscriptions
+### Proposed legacy webhook-subscription shape (not implemented)
+
+The implemented API uses `/v1/webhooks`, pause/resume action routes, and
+`/v1/webhooks/:id/deliveries` as listed in the inventory. The names below are
+retained only as a proposal history and must not be used by clients.
+
 
 - `POST /v1/webhook-subscriptions`: create an authorized organization,
   workspace, or project subscription; v0.3 additionally permits an authorized
@@ -240,11 +316,16 @@ opaque event ID, scope reference, event type, record ID/version, occurrence
 time, and delivery attempt. Content is excluded by default. Requests are signed,
 bounded, retry-safe, and protected by destination allowlisting and SSRF checks.
 
-### `GET /v1/audit/events`
+### Proposed legacy `GET /v1/audit/events` (not implemented)
 
 List authorized metadata-only audit events with cursor pagination.
 
 ## Governed channel knowledge operations
+
+The channel CRUD and `knowledge-releases` names below are **proposed and not
+implemented**. Current governed release routes are `/v1/channel-releases` and
+`/v1/channel-context` in the inventory; their action is `publish`, not `activate`.
+
 
 These v0.3 operations implement
 [ADR-0002](../decisions/0002-channel-release-not-public-memory.md). Every
@@ -373,7 +454,7 @@ dependencies; an optional browser renderer is never a service-readiness gate.
 
 ## MCP surface
 
-The planned `/mcp` endpoint exposes the smallest ordinary-agent tool set:
+The implemented `/mcp` endpoint exposes the smallest ordinary-agent tool set:
 
 - `titen_context`;
 - `titen_remember`;
@@ -420,3 +501,14 @@ authorized operator clients use its read-only REST endpoint.
 - Breaking request/response changes require a new API version or migration path.
 - A future Mem0 import adapter maps scopes and re-embeds; Titen does not promise
   complete Mem0 API compatibility.
+
+## Portability and backup restore
+
+`GET /v1/export?type=projects|observations|claims` returns canonical NDJSON. Each
+header includes deterministic `dependency_order` (`projects`, `observations`,
+`claims`) and `depends_on`. Backups should retain all three streams and their
+headers. `POST /v1/import` preflights the complete request before mutation,
+accepts canonical records independent of NDJSON line order, and writes in
+canonical dependency order. Missing parents return `422 UNRESOLVED_REFERENCE`
+with only `record_type`, `field`, and `dependency_type`; no foreign record or
+content is disclosed. Re-import is idempotent.

--- a/docs/specs/done/2026-07-30-import-portability-api-truth.md
+++ b/docs/specs/done/2026-07-30-import-portability-api-truth.md
@@ -1,0 +1,36 @@
+---
+work_id: import-portability-api-truth
+status: done
+stage: done
+outcome: completed
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+owner: Wulan
+---
+# Import portability and API truth
+
+## Problem
+Canonical exports do not declare dependency order, missing references surface as opaque conflicts, and API documentation can drift from the router.
+
+## Scope
+Add deterministic export dependency metadata, order-independent import preflight and safe diagnostics, shared portability contract coverage, and an executable route-document consistency gate. Reconcile API/backup/status documentation with implemented behavior.
+
+## Out of scope
+Deployment and deploy-script cleanup owned by Shinta in issue #14. This change documents that dependency and does not edit her scope.
+
+## Constraints and risks
+No new dependency. Preserve tenant non-disclosure and canonical IDs. Validate all references before mutation. Keep both runtimes on the shared core contract.
+
+## Acceptance criteria
+- **AC-IMP-001 — Ubiquitous:** Titen shall emit `dependency_order` and the selected record type's direct `depends_on` values in every canonical export header, using the deterministic order `projects`, `observations`, `claims`.
+- **AC-IMP-002 — Event-driven:** When a canonical import contains parents and children in any NDJSON line order, Titen shall preflight the full request and persist records in dependency order.
+- **AC-IMP-003 — Unwanted behavior:** If an imported observation or claim references a parent absent from both the request and authenticated organization, then Titen shall return `UNRESOLVED_REFERENCE` with record type, field, and dependency type but no foreign-tenant or record-content disclosure.
+- **AC-IMP-004 — Unwanted behavior:** If import preflight fails, then Titen shall leave canonical project, observation, claim, and claim-source counts unchanged.
+- **AC-IMP-005 — Event-driven:** When the same valid export is imported repeatedly, Titen shall preserve one canonical copy and return success on both supported runtimes.
+- **AC-DOC-001 — Ubiquitous:** Titen shall expose a machine-readable route inventory from the router source and an executable checker shall fail when the documented implemented-route inventory differs.
+- **AC-DOC-002 — State-driven:** While a feature is not present in the route inventory, Titen documentation shall label it proposed or unimplemented rather than presenting it as an available endpoint.
+- **AC-DOC-003 — Ubiquitous:** Titen shall describe current vector, MCP, webhook, release, export, import, and backup behavior without changing issue #14 deployment scripts.
+
+## Done conditions
+All criteria have reproducible evidence; workflow checks, route-doc check, build, Worker dry-run, and available targeted Bun contract tests pass; paired artifacts move to done.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "deploy:worker": "WRANGLER_SEND_METRICS=false wrangler deploy",
     "titen": "bun src/runtime/bun/cli.ts",
     "screenshots": "playwright test tests/dashboard-screenshots.spec.ts",
+    "check:routes": "node scripts/check-route-docs.mjs",
     "check:workflow": "node scripts/check-workflow-docs.mjs && node scripts/check-workflow-docs.mjs --self-test",
     "verify:dashboard-live": "bun scripts/verify-dashboard-live.ts",
     "test:integration": "bun test tests/integration"

--- a/scripts/check-route-docs.mjs
+++ b/scripts/check-route-docs.mjs
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+const app = fs.readFileSync(new URL("../src/core/app.ts", import.meta.url), "utf8");
+const docs = fs.readFileSync(new URL("../docs/reference/api.md", import.meta.url), "utf8");
+const block = app.slice(app.indexOf("export const ROUTES"), app.indexOf("export const ROUTE_INVENTORY"));
+const routes = [...block.matchAll(/method:\s*"([A-Z]+)",\s*path:\s*"([^"]+)"/g)]
+  .map(([, method, path]) => `${method} ${path}`).sort();
+const start = "<!-- ROUTE_INVENTORY_START -->", end = "<!-- ROUTE_INVENTORY_END -->";
+const section = docs.slice(docs.indexOf(start) + start.length, docs.indexOf(end));
+const documented = [...section.matchAll(/^- `([A-Z]+) ([^`]+)`/gm)].map(([, method, path]) => `${method} ${path}`).sort();
+if (!routes.length || docs.indexOf(start) < 0 || docs.indexOf(end) < 0) throw new Error("route inventory markers or router routes missing");
+if (JSON.stringify(routes) !== JSON.stringify(documented)) {
+  console.error("Route documentation drift. Expected:\n" + routes.map((r) => `- \`${r}\``).join("\n")); process.exit(1);
+}
+console.log(`route docs OK (${routes.length} routes)`);

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -55,7 +55,9 @@ export function capabilities(app: AppContext) {
   } as const;
 }
 
-const ROUTES: RouteDef[] = [
+export interface RouteInventoryEntry { method: string; path: string; scope: string | null }
+
+export const ROUTES: RouteDef[] = [
   {
     method: "GET",
     path: "/healthz",
@@ -182,6 +184,8 @@ const ROUTES: RouteDef[] = [
   { method: "POST", path: "/v1/index/drain", scope: "index:write", handler: drainIndex },
 ];
 
+export const ROUTE_INVENTORY: RouteInventoryEntry[] = ROUTES.map(({ method, path, scope }) => ({ method, path, scope: scope ?? null }));
+
 async function readiness(ctx: RequestContext): Promise<Result> {
   const checks: Record<string, string> = {};
   let ready = true;
@@ -278,10 +282,11 @@ export function createApp(context: {
       return result.raw ?? success(result, requestId);
     } catch (error) {
       if (!(error instanceof ApiError)) {
-        // Unique/constraint failures mean the write conflicted; nothing partial
-        // survives because every write is one atomic batch.
+        // Only unique/primary-key failures are write collisions. Foreign-key
+        // references are preflighted by their handlers and must not be
+        // mislabeled as conflicts if an unexpected one reaches this boundary.
         const message = error instanceof Error ? error.message : "";
-        if (/UNIQUE|constraint|SQLITE_CONSTRAINT/i.test(message))
+        if (/UNIQUE|SQLITE_CONSTRAINT_(?:UNIQUE|PRIMARYKEY)/i.test(message))
           return failure(
             new ApiError(409, "CONFLICT", "Write conflicted with an existing record."),
             requestId,

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -38,5 +38,8 @@ export const notFound = () =>
 export const conflict = (message: string) =>
   new ApiError(409, "CONFLICT", message);
 
+export const unresolvedReference = (meta: Record<string, unknown>) =>
+  new ApiError(422, "UNRESOLVED_REFERENCE", "Import contains an unresolved reference.", meta);
+
 export const unavailable = (message: string, meta?: Record<string, unknown>) =>
   new ApiError(503, "UNAVAILABLE", message, meta);

--- a/src/core/portability.ts
+++ b/src/core/portability.ts
@@ -1,12 +1,18 @@
 import { MAX_BOUND_PARAMS, chunk } from "./db";
 import type { Stmt } from "./db";
-import { conflict, validationError } from "./errors";
+import { conflict, unresolvedReference, validationError } from "./errors";
 import { sha256Hex } from "./ids";
 import type { RequestContext, Result } from "./http";
 import { isRecord } from "./validate";
 
 export const EXPORT_FORMAT_VERSION = 1;
 export const EXPORT_TYPES = ["projects", "observations", "claims"] as const;
+export const EXPORT_DEPENDENCY_ORDER = [...EXPORT_TYPES];
+export const EXPORT_DEPENDENCIES: Record<(typeof EXPORT_TYPES)[number], string[]> = {
+  projects: [],
+  observations: ["projects"],
+  claims: ["projects", "observations"],
+};
 export const EXPORT_MAX_LIMIT = 2000;
 export const IMPORT_MAX_LINES = 2000;
 /** Statements per atomic batch, kept well inside D1's per-batch limits. */
@@ -96,6 +102,8 @@ export async function exportRecords(ctx: RequestContext): Promise<Result> {
     type: "titen.export.header",
     format_version: EXPORT_FORMAT_VERSION,
     record_type: type,
+    dependency_order: EXPORT_DEPENDENCY_ORDER,
+    depends_on: EXPORT_DEPENDENCIES[type as (typeof EXPORT_TYPES)[number]],
     org_id: principal.orgId,
     exported_at: ctx.app.now().toISOString(),
     count: lines.length,
@@ -166,6 +174,7 @@ export async function importRecords(ctx: RequestContext): Promise<Result> {
 
   const at = ctx.app.now().toISOString();
   await assertNoForeignIds(ctx, principal.orgId, byType);
+  await assertReferencesResolve(ctx, principal.orgId, byType);
   const statements: Stmt[] = [];
 
   for (const row of byType.project!) {
@@ -273,6 +282,44 @@ export async function importRecords(ctx: RequestContext): Promise<Result> {
     data: { format_version: EXPORT_FORMAT_VERSION, received },
     meta: { batches: Math.ceil(statements.length / IMPORT_BATCH) },
   };
+}
+
+
+async function existingIds(ctx: RequestContext, table: string, orgId: string, ids: string[]): Promise<Set<string>> {
+  const found = new Set<string>();
+  for (const group of chunk([...new Set(ids)])) {
+    if (!group.length) continue;
+    const rows = await ctx.app.db.all<{ id: string }>(
+      `SELECT id FROM ${table} WHERE org_id = ? AND id IN (${group.map(() => "?").join(", ")})`,
+      [orgId, ...group],
+    );
+    for (const row of rows) found.add(row.id);
+  }
+  return found;
+}
+
+async function assertReferencesResolve(
+  ctx: RequestContext,
+  orgId: string,
+  byType: Record<string, Record<string, unknown>[]>,
+): Promise<void> {
+  const importedProjects = new Set(byType.project!.map((row) => text(row.id, "id")));
+  const importedObservations = new Set(byType.observation!.map((row) => text(row.id, "id")));
+  const projectRefs: { recordType: string; field: string; id: string }[] = [];
+  for (const row of byType.observation!) if (maybe(row.project_id) !== null) projectRefs.push({ recordType: "observation", field: "project_id", id: String(row.project_id) });
+  for (const row of byType.claim!) if (maybe(row.project_id) !== null) projectRefs.push({ recordType: "claim", field: "project_id", id: String(row.project_id) });
+  const storedProjects = await existingIds(ctx, "projects", orgId, projectRefs.map((ref) => ref.id).filter((id) => !importedProjects.has(id)));
+  for (const ref of projectRefs) if (!importedProjects.has(ref.id) && !storedProjects.has(ref.id))
+    throw unresolvedReference({ record_type: ref.recordType, field: ref.field, dependency_type: "project" });
+
+  const sourceRefs: string[] = [];
+  for (const row of byType.claim!) for (const source of Array.isArray(row.sources) ? row.sources : []) {
+    if (!isRecord(source)) throw validationError("Each claim source must be an object.");
+    sourceRefs.push(text(source.observation_id, "observation_id"));
+  }
+  const storedObservations = await existingIds(ctx, "observations", orgId, sourceRefs.filter((id) => !importedObservations.has(id)));
+  if (sourceRefs.some((id) => !importedObservations.has(id) && !storedObservations.has(id)))
+    throw unresolvedReference({ record_type: "claim", field: "sources.observation_id", dependency_type: "observation" });
 }
 
 /**

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -1021,6 +1021,8 @@ export const CASES: Case[] = [
       assert.equal(header.type, "titen.export.header");
       assert.equal(header.format_version, 1);
       assert.equal(header.complete, true);
+      assert.deepEqual(header.dependency_order, ["projects", "observations", "claims"]);
+      assert.deepEqual(header.depends_on, ["projects"]);
       assert.equal(observationLines.length, 2);
       assert.ok(!String(observations.body).includes("titen_sk_"), "export must carry no key");
 
@@ -1085,6 +1087,71 @@ export const CASES: Case[] = [
         body: `${observationLines.join("\n")}\n`,
       });
       expectError(collision, 409, "CONFLICT");
+    },
+  },
+  {
+    name: "import preflights references and accepts child-before-parent atomically",
+    async run(fx) {
+      const target = await fx.provision({ scopes: ["*"] });
+      const projectId = "project_import_parent_000000000000";
+      const observationId = "obs_import_child_000000000000000";
+      const project = { type: "project", id: projectId, reference: "rama/import-portability", created_at: "2026-07-30T00:00:00.000Z" };
+      const observationRow = {
+        type: "observation", id: observationId, subject_id: "user_rama", project_id: projectId,
+        kind: "tool_result", content: "portable evidence", source_type: "tool", trust: "verified",
+        visibility: "team", occurred_at: "2026-07-30T00:00:00.000Z", ingested_at: "2026-07-30T00:00:00.000Z",
+      };
+      const header = { type: "titen.export.header", format_version: 1, record_type: "observations" };
+      const body = [header, observationRow, project].map(JSON.stringify).join("\n") + "\n";
+      expectOk(await fx.callRaw("POST", "/v1/import", { key: target.key, body }));
+      expectOk(await fx.callRaw("POST", "/v1/import", { key: target.key, body }));
+      const counts = await fx.query<{ projects: number; observations: number }>(
+        `SELECT (SELECT COUNT(*) FROM projects WHERE org_id = ?) AS projects,
+                (SELECT COUNT(*) FROM observations WHERE org_id = ?) AS observations`,
+        [target.orgId, target.orgId],
+      );
+      assert.equal(Number(counts[0]!.projects), 1);
+      assert.equal(Number(counts[0]!.observations), 1);
+
+      const canonicalCounts = async () => (await fx.query<{
+        projects: number; observations: number; claims: number; claim_sources: number;
+      }>(
+        `SELECT (SELECT COUNT(*) FROM projects WHERE org_id = ?) AS projects,
+                (SELECT COUNT(*) FROM observations WHERE org_id = ?) AS observations,
+                (SELECT COUNT(*) FROM claims WHERE org_id = ?) AS claims,
+                (SELECT COUNT(*) FROM claim_sources cs JOIN claims c ON c.id = cs.claim_id WHERE c.org_id = ?) AS claim_sources`,
+        [target.orgId, target.orgId, target.orgId, target.orgId],
+      ))[0]!;
+      const beforeFailure = await canonicalCounts();
+      const missingId = "project_missing_parent_00000000000";
+      const missing = { ...observationRow, id: "obs_missing_parent_0000000000000", project_id: missingId };
+      const failed = await fx.callRaw("POST", "/v1/import", { key: target.key, body: JSON.stringify(missing) + "\n" });
+      expectError(failed, 422, "UNRESOLVED_REFERENCE");
+      assert.deepEqual(
+        { record_type: failed.body.meta.record_type, field: failed.body.meta.field, dependency_type: failed.body.meta.dependency_type },
+        { record_type: "observation", field: "project_id", dependency_type: "project" },
+      );
+      assert.ok(!JSON.stringify(failed.body).includes(missingId), "diagnostic must not disclose referenced ids");
+      assert.deepEqual(await canonicalCounts(), beforeFailure, "failed project preflight must not partially mutate");
+
+      const missingObservationId = "obs_missing_source_00000000000000";
+      const missingClaim = {
+        type: "claim", id: "claim_missing_source_000000000000", subject_id: "user_rama",
+        project_id: null, kind: "procedural", statement: "This claim must not import.",
+        trust: "verified", visibility: "team", status: "active",
+        valid_from: "2026-07-30T00:00:00.000Z",
+        sources: [{ observation_id: missingObservationId, relation: "supports" }],
+      };
+      const failedClaim = await fx.callRaw("POST", "/v1/import", {
+        key: target.key, body: JSON.stringify(missingClaim) + "\n",
+      });
+      expectError(failedClaim, 422, "UNRESOLVED_REFERENCE");
+      assert.deepEqual(
+        { record_type: failedClaim.body.meta.record_type, field: failedClaim.body.meta.field, dependency_type: failedClaim.body.meta.dependency_type },
+        { record_type: "claim", field: "sources.observation_id", dependency_type: "observation" },
+      );
+      assert.ok(!JSON.stringify(failedClaim.body).includes(missingObservationId), "diagnostic must not disclose referenced ids");
+      assert.deepEqual(await canonicalCounts(), beforeFailure, "failed source preflight must not partially mutate");
     },
   },
   // --- v0.1: Temporal supersession ---


### PR DESCRIPTION
## Summary

- make canonical JSONL imports dependency-aware and order-independent
- preflight unresolved references before mutation with safe diagnostics
- export a machine-readable route inventory and verify all 58 documented routes
- reconcile API and backup/import documentation without touching #14 scope

## Evidence

- workflow checker and self-test: PASS
- route docs checker, 58 routes: PASS
- Astro build and bundle budget: PASS
- Worker dry-run: PASS
- diff check: PASS
- Bun contract tests: included, unavailable locally and not claimed

Closes #2
Closes #4
