### PR TITLE
fix: report background repair ownership honestly

### DIFF
--- a/docs/plans/done/2026-07-30-readiness-background-repair.md
+++ b/docs/plans/done/2026-07-30-readiness-background-repair.md
@@ -1,0 +1,41 @@
+---
+work_id: readiness-background-repair
+status: done
+stage: done
+outcome: completed
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+owner: CADIS
+spec: docs/specs/done/2026-07-30-readiness-background-repair.md
+---
+# Plan
+
+- [x] Thread scheduler ownership through the existing application context.
+- [x] Derive Bun readiness from the exact timer-creation condition and mark Cloudflare scheduling external.
+- [x] Add dual-runtime disabled/external contract assertions and a real Bun enabled-timer integration assertion.
+- [x] Document the configuration-derived states and the issue #11 freshness boundary.
+- [x] Run the aggregate local gate, package dry-run, workflow checks, and diff check.
+- [x] Record evidence and move this pair to `done`.
+
+## Acceptance evidence mapping
+
+- AC-RBR-001: Bun maintenance integration test.
+- AC-RBR-002: Bun/SQLite readiness contract case.
+- AC-RBR-003: workerd/D1 readiness contract case.
+- AC-RBR-004: shared capabilities implementation, contract assertions, and source inspection proving no readiness network call.
+
+## Security, deployment, and rollback
+
+No credential, migration, network probe, or maintenance behavior changes. Rollback removes the three-state context field and its assertions; canonical data is unaffected.
+
+## Verification evidence
+
+- Worker dry-run: PASS, 178.47 KiB upload / 38.07 KiB gzip.
+- Dual-runtime API/SDK suite: 135 pass, 0 fail on a clean full run; the focused workerd/D1 readiness case also passes independently.
+- Bun integration suite: 42 pass, 0 fail, including a real timer reporting `enabled` while automatic indexing succeeds.
+- Live dashboard verifier: PASS; Astro build/browser: 10 pass; bundle 10.4 KiB gzip / 80 KiB.
+- Workflow checker and self-test: PASS for 20 artifacts.
+- `pnpm pack --dry-run`: PASS for `titen-memory@0.1.1`.
+- `git diff --check origin/main...HEAD`: PASS.
+- Repeated aggregate attempts also exposed the pre-existing Miniflare restart timeout/poisoned-stub cascade described in prior review; no retry, timeout, or assertion suppression was added. The same full suite passed cleanly once and all changed-path assertions pass independently.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -448,6 +448,13 @@ derived cache/vector or release-status maintenance job is stale.
   vector capability when enabled, outbox health, and release FTS plus
   customer-assertion verifier readiness when channel serving is enabled.
 
+`capabilities.background_repair` is configuration-derived: `enabled` means the
+Bun process created its in-process maintenance timer, `disabled` means Bun did
+not create one, and `external` means Cloudflare expects an external Cron Trigger
+that the request isolate cannot observe. It does not claim a recent successful
+pass; issue #11 tracks evidence-based scheduler freshness. Readiness performs no
+model or scheduler network probe.
+
 When Memory Atlas is disabled, it does not affect liveness/readiness. When
 enabled, readiness checks only the server-side compiler's canonical
 dependencies; an optional browser renderer is never a service-readiness gate.

--- a/docs/specs/done/2026-07-30-readiness-background-repair.md
+++ b/docs/specs/done/2026-07-30-readiness-background-repair.md
@@ -1,0 +1,38 @@
+---
+work_id: readiness-background-repair
+status: done
+stage: done
+outcome: completed
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+owner: CADIS
+---
+# Readiness background-repair capability
+
+## Problem
+
+`GET /readyz` always reports background repair as disabled even when the Bun maintenance timer is running, so operators cannot distinguish self-draining and manually drained deployments.
+
+## Scope
+
+Report the scheduler ownership already selected by each runtime: `enabled` for an actual Bun in-process timer, `disabled` when Bun creates no timer, and `external` for Cloudflare's scheduled-handler boundary. Keep the model field tied to the configured embedding provider rather than the vector store label.
+
+## Out of scope
+
+Scheduler freshness evidence, Cloudflare Cron provisioning, model network probes, migrations, and changes to maintenance behavior. Issue #11 tracks evidence-based freshness separately.
+
+## Constraints and risks
+
+Readiness stays network-free and non-blocking. The value must mirror the exact condition that creates the Bun timer. Cloudflare must not claim it can observe Cron configuration.
+
+## Acceptance criteria
+
+- **AC-RBR-001 — State-driven:** While the Bun runtime has created its in-process maintenance timer, Titen shall report `background_repair: enabled` from `GET /readyz`.
+- **AC-RBR-002 — State-driven:** While the Bun runtime has not created a maintenance timer, Titen shall report `background_repair: disabled`.
+- **AC-RBR-003 — State-driven:** While running on Cloudflare, Titen shall report `background_repair: external` because scheduler configuration is outside the Worker request runtime.
+- **AC-RBR-004 — Ubiquitous:** Titen shall derive the readiness model capability from the configured embedding provider and shall make no network call on the readiness path.
+
+## Done conditions
+
+The shared contract passes on Bun/SQLite and workerd/D1, an integration test proves a real Bun timer reports enabled, the API reference documents all states and their limits, workflow checks pass, and the paired artifacts move to `done`.

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -42,6 +42,8 @@ export interface AppContext {
   runtime: string;
   /** Optional vector capability. Absent means FTS-only retrieval. */
   vectors?: VectorCapability;
+  /** Ownership of background indexing and webhook repair for this runtime. */
+  backgroundRepair: "enabled" | "disabled" | "external";
 }
 
 /** Capabilities are reported honestly based on what's configured. */
@@ -49,8 +51,8 @@ export function capabilities(app: AppContext) {
   return {
     fts: "enabled",
     vector: app.vectors ? "enabled" : "disabled",
-    model: app.vectors ? "enabled" : "disabled",
-    background_repair: "disabled",
+    model: app.vectors?.embedder ? "enabled" : "disabled",
+    background_repair: app.backgroundRepair,
     export_import: "enabled",
   } as const;
 }
@@ -224,6 +226,7 @@ export function createApp(context: {
   revision?: string;
   runtime: string;
   vectors?: VectorCapability;
+  backgroundRepair?: "enabled" | "disabled" | "external";
 }): (request: Request) => Promise<Response> {
   const app: AppContext = {
     db: context.db,
@@ -231,6 +234,7 @@ export function createApp(context: {
     revision: context.revision ?? "dev",
     runtime: context.runtime,
     vectors: context.vectors,
+    backgroundRepair: context.backgroundRepair ?? "disabled",
   };
 
   return async function handle(request: Request): Promise<Response> {

--- a/src/runtime/bun/server.ts
+++ b/src/runtime/bun/server.ts
@@ -43,11 +43,15 @@ export async function serve(options: ServeOptions) {
     embedDims: options.embedDims,
     embedApiKey: options.embedApiKey,
   });
+  const intervalMs = options.maintenanceIntervalMs ?? 15_000;
+  const backgroundRepair =
+    intervalMs > 0 && (vectors !== undefined || options.maintenanceIntervalMs !== undefined);
   const app = createApp({
     db,
     revision: options.revision ?? "dev",
     runtime: "bun-sqlite",
     vectors,
+    backgroundRepair: backgroundRepair ? "enabled" : "disabled",
   });
 
   // @ts-ignore - Bun global is provided by the runtime.
@@ -78,7 +82,6 @@ export async function serve(options: ServeOptions) {
    * searches nothing, and that was the behavior before this existed. Disable with
    * an interval of 0 when an external scheduler owns the work instead.
    */
-  const intervalMs = options.maintenanceIntervalMs ?? 15_000;
   let ticking = false;
   const tick = async () => {
     // Skip rather than queue: a slow model must not stack overlapping passes.
@@ -99,10 +102,7 @@ export async function serve(options: ServeOptions) {
       ticking = false;
     }
   };
-  const timer =
-    intervalMs > 0 && (vectors !== undefined || options.maintenanceIntervalMs !== undefined)
-      ? setInterval(tick, intervalMs)
-      : undefined;
+  const timer = backgroundRepair ? setInterval(tick, intervalMs) : undefined;
   // Never hold the process open on account of maintenance.
   timer?.unref?.();
 

--- a/src/runtime/cloudflare/worker.ts
+++ b/src/runtime/cloudflare/worker.ts
@@ -39,6 +39,8 @@ export default {
       revision: env.TITEN_REVISION ?? "dev",
       runtime: "cloudflare-d1",
       vectors,
+      // The request isolate cannot observe whether its external Cron Trigger exists.
+      backgroundRepair: "external",
     });
     return app(request);
   },

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -89,6 +89,10 @@ export const CASES: Case[] = [
       assert.equal(res.body.data.capabilities.fts, "enabled");
       assert.equal(res.body.data.capabilities.vector, "disabled");
       assert.equal(res.body.data.capabilities.model, "disabled");
+      assert.equal(
+        res.body.data.capabilities.background_repair,
+        fx.runtime === "cloudflare-d1" ? "external" : "disabled",
+      );
     },
   },
   {

--- a/tests/integration/maintenance.test.ts
+++ b/tests/integration/maintenance.test.ts
@@ -105,6 +105,13 @@ test("a written claim is indexed without anyone calling the drain endpoint", asy
   );
 });
 
+test("readiness reports the maintenance timer that is actually running", async () => {
+  const response = await fetch(`${running.url}/readyz`);
+  const body = (await response.json()) as any;
+  assert.equal(response.status, 200);
+  assert.equal(body.data.capabilities.background_repair, "enabled");
+});
+
 test("a claim that stopped being retrievable is retired, not embedded forever", async () => {
   const observation = await api("POST", "/v1/observations", {
     subject_id: "user_maint_retire",


### PR DESCRIPTION
## Summary

- derive Bun background-repair readiness from the exact condition that creates the maintenance timer
- report Cloudflare scheduler ownership as external rather than disabled
- derive model capability from the configured embedder
- document configuration-derived limits and keep evidence-based freshness in #11

## Verification

- Worker dry-run: PASS
- dual-runtime API and SDK: 135 pass, 0 fail on a clean full run
- focused workerd readiness: PASS
- integration: 42 pass, 0 fail, including a real active timer readiness assertion
- live dashboard verifier: PASS
- browser: 10 pass
- workflow checker and self-test: PASS for 20 artifacts
- npm pack dry-run and diff check: PASS

## Workflow

Completed paired EARS spec and plan are under docs/specs/done and docs/plans/done.

Closes #3