### PR TITLE
chore: prepare v0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,48 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 Nothing yet.
 
+## [0.1.2] — 2026-07-30
+
+### Added
+
+- **A five-minute small-team golden path.** The documented researcher, writer,
+  operator, and reviewer flow uses four scoped keys and the public SDK to prove
+  evidence, conflicting claims, context, checkpoint, lease, handoff, feedback,
+  citations, and freshness against a real Bun/SQLite service.
+- **Optional loopback live dashboard data.** Conflict & Freshness can read one
+  subject-scoped Atlas view through a same-origin adapter that keeps the Titen
+  key server-side. Static serving rejects traversal, encoded/backslash/NUL, and
+  symlink escapes; every other dashboard lens stays visibly synthetic.
+- **More SDK coverage.** The published client now exposes the shipped
+  checkpoint, lease, handoff, evidence, and Atlas-view operations used by the
+  golden path.
+- **One canonical live verifier.** `pnpm verify:live` replaces the duplicate
+  script name and remains explicit about requiring a provisioned deployment.
+
+### Fixed
+
+- **Semantic ranking now works with real narrow-band cosine scores.** Vector
+  similarity is normalized inside the authorized candidate set and confidence
+  is an explicit weighted component, so a semantically correct lower-confidence
+  claim no longer ranks last behind lexical decoys.
+- **Index dependency outages are retryable.** Embedder and vector-store failures
+  return bounded `503 UNAVAILABLE` metadata while leaving pending outbox work
+  intact.
+- **Canonical imports are order-independent within a request.** Imports preflight
+  missing parents before mutation, accept child-before-parent lines atomically,
+  and return `UNRESOLVED_REFERENCE` instead of mislabeling a missing dependency
+  as a conflict.
+- **Readiness reports background repair honestly.** Bun reports whether its
+  maintenance timer was actually created; Cloudflare reports external scheduler
+  ownership without pretending the request isolate can observe Cron state.
+
+### Changed
+
+- The API reference is verified against the router's 58 implemented routes and
+  clearly separates proposed endpoints from callable ones.
+- Dashboard screenshots, mobile disclosure, and the capability matrix identify
+  synthetic, locally verified, and planned regions consistently.
+
 ## [0.1.1] — 2026-07-30
 
 ### Fixed
@@ -95,6 +137,7 @@ Releases are cut by hand from a maintainer's machine and deliberately have no
 GitHub Action, so an npm token never lives in repository secrets. See
 [`docs/engineering/release.md`](./docs/engineering/release.md).
 
-[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/RamaAditya49/titen/releases/tag/v0.1.2
 [0.1.1]: https://github.com/RamaAditya49/titen/releases/tag/v0.1.1
 [0.1.0]: https://www.npmjs.com/package/titen-memory/v/0.1.0

--- a/docs/plans/active/2026-07-30-release-0-1-2.md
+++ b/docs/plans/active/2026-07-30-release-0-1-2.md
@@ -1,0 +1,33 @@
+---
+work_id: release-0-1-2
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+review_after: 2026-08-13
+owner: CADIS
+spec: docs/specs/active/2026-07-30-release-0-1-2.md
+---
+# Plan
+
+- [x] Write the 0.1.2 changelog entry and package version without changing product behavior.
+- [x] Run workflow, build, API/SDK, integration, live-dashboard, browser, package dry-run, and installed-tarball gates.
+- [ ] Commit, open, and merge the release candidate with the required attribution trailer.
+- [ ] Tag the exact merged commit and verify Actions remains disabled.
+- [ ] Start `npm publish`, hand the interactive approval URL to the maintainer, and verify registry `latest` after approval.
+- [ ] Create and smoke the changelog-derived GitHub release.
+- [ ] Record final evidence and move this pair to `done` in a terminal follow-up change.
+
+## Acceptance evidence mapping
+
+- AC-RLS-001: package metadata, changelog section, and compare links.
+- AC-RLS-002: reproducible local gate output and `scripts/verify-pack.sh` against the candidate.
+- AC-RLS-003: main/tag commit IDs plus live repository Actions permission.
+- AC-RLS-004: npm publish completion, registry version, and dist-tags without credential output.
+- AC-RLS-005: GitHub release URL/body and public npm/CLI smoke.
+
+## Security, deployment, and rollback
+
+No service deployment or migration. Before npm publication, rollback is branch/PR closure. After publication, npm is not treated as reversible; a defective release requires a new patch. GitHub release/tag cleanup alone is not a package rollback.

--- a/docs/specs/active/2026-07-30-release-0-1-2.md
+++ b/docs/specs/active/2026-07-30-release-0-1-2.md
@@ -1,0 +1,40 @@
+---
+work_id: release-0-1-2
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-07-30
+updated: 2026-07-30
+review_after: 2026-08-13
+owner: CADIS
+---
+# Release 0.1.2
+
+## Problem
+
+`main` contains a coherent compatible batch after `v0.1.1`: ranking and dependency-failure fixes, portable imports and verified API inventory, one canonical live verifier, a scoped golden path and loopback dashboard adapter, and honest background-repair readiness. npm `latest` still serves 0.1.1.
+
+## Scope
+
+Cut patch release 0.1.2 manually from the exact verified `main` commit, publish its changelog-derived GitHub release, and publish `titen-memory@0.1.2` under `latest` through npm's maintainer approval flow.
+
+## Out of scope
+
+GitHub Actions, automated publishing, Cloudflare deployment, unmerged backlog issues, and any feature or API change beyond the already merged batch.
+
+## Constraints and risks
+
+npm publication is effectively permanent. The tarball, tag, GitHub release, package version, and registry version must identify the same commit. Credentials and approval tokens must never be logged or committed.
+
+## Acceptance criteria
+
+- **AC-RLS-001 — Event-driven:** When release 0.1.2 is prepared, Titen shall move the compatible changes since v0.1.1 into a dated changelog section and set the package version to 0.1.2.
+- **AC-RLS-002 — Unwanted behavior:** If a required local, workflow, tarball-install, CLI, readiness, SDK, or package-content gate fails, then Titen shall not publish the candidate.
+- **AC-RLS-003 — Ubiquitous:** Titen shall tag and publish the exact verified main commit and shall keep GitHub Actions disabled.
+- **AC-RLS-004 — Event-driven:** When npm requests interactive approval, Titen shall expose only the approval URL, wait for the maintainer, and then verify registry version and `latest` dist-tag as 0.1.2.
+- **AC-RLS-005 — Event-driven:** When npm publication succeeds, Titen shall create the v0.1.2 GitHub release from the 0.1.2 changelog section and verify the public release and package pages.
+
+## Done conditions
+
+Every mapped gate passes, the v0.1.2 tag/GitHub release/npm package agree, related public smoke succeeds, no PR remains open, and this pair moves to `done` with exact evidence.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titen-memory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Collaborative memory fabric for AI agents \u2014 evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- set `titen-memory` to `0.1.2`
- publish the dated changelog section and compare links
- keep the complex release workflow active until npm and GitHub publication finish

## Verification

- Worker dry build passed
- contract/API/SDK: 135/135 passed serially (avoids a verified Bun/Miniflare concurrent-runner restart race)
- integration: 42/42 passed
- live dashboard verifier passed
- browser: 10/10 passed on `PLAYWRIGHT_PORT=45881` because local port 4399 belongs to another process
- workflow checker and self-test passed
- `pnpm pack --dry-run` passed
- `bash scripts/verify-pack.sh` passed all five installed-tarball checks

Release impact: patch

Co-Authored-By: CADIS <agent@cadis.digital>