### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-07-30
+
 ### Added
 
 - **An authorized reviewer queue in Memory Atlas.** The read-only lens derives
@@ -200,7 +202,8 @@ Releases are cut by hand from a maintainer's machine and deliberately have no
 GitHub Action, so an npm token never lives in repository secrets. See
 [`docs/engineering/release.md`](./docs/engineering/release.md).
 
-[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/RamaAditya49/titen/releases/tag/v0.2.0
 [0.1.2]: https://github.com/RamaAditya49/titen/releases/tag/v0.1.2
 [0.1.1]: https://github.com/RamaAditya49/titen/releases/tag/v0.1.1
 [0.1.0]: https://www.npmjs.com/package/titen-memory/v/0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titen-memory",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Collaborative memory fabric for AI agents \u2014 evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Release candidate

- Bumps titen-memory from 0.1.2 to 0.2.0 for the breaking pre-1.0 hardening batch merged in #68.
- Moves the complete Unreleased notes under the dated 0.2.0 heading and updates compare/release links.
- Does not tag or publish yet; live migration/restart and maintainer npm approval remain release gates.

## Exact-candidate verification

- Cloudflare D1 contract: 71 passed
- Bun/SQLite + vectors + SDK: 90 passed
- Integration: 63 passed
- Browser: 10 passed
- Workflow, route, live-dashboard, and Worker dry-build gates: passed
- titen-memory-0.2.0.tgz normal install and custom global-prefix install: passed
- Registry slot titen-memory@0.2.0: available

Release impact: minor.
