### PR TITLE
fix: send lifecycle version in live verifier

### DIFF
--- a/scripts/verify-live.ts
+++ b/scripts/verify-live.ts
@@ -12,7 +12,7 @@
  *   TITEN_KEY=titen_sk_... \
  *   TITEN_EMBED_BASE_URL=http://host:11434/v1 \
  *   TITEN_EMBED_MODEL=embeddinggemma \
- *   bun scripts/e2e.ts
+ *   bun scripts/verify-live.ts
  */
 import assert from "node:assert/strict";
 
@@ -272,6 +272,7 @@ step(4, "lifecycle, portability, restart durability");
 const supersededBy = claimIds[1]!;
 const superseded = await api("POST", `/v1/claims/${claimIds[0]}/supersede`, {
   superseded_by: supersededBy,
+  expected_version: 1,
   reason: "end-to-end run",
 });
 assert.equal(superseded.status, "superseded");


### PR DESCRIPTION
## Outcome

The v0.2.0 live verifier now sends the required claim expected_version during supersession and its usage comment names the current script.

This was found by the real rama-tuf schema-10 smoke after deployment. The pre-fix run reached lifecycle step 4 and failed with the expected 400 validation response; the patched script then completed all six stages against the live Bun/SQLite service and real embeddinggemma model.

Release impact: none beyond the existing 0.2.0 candidate.
