### PR TITLE
fix: return principal identity from key creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+### Fixed
+
+- Key creation now returns the canonical `principal_id`, so SDK callers can use
+  a newly generated agent identity for handoffs without confusing it with the
+  credential's `key_id`.
+- Contributor setup now documents a temporary writable `HOME` and
+  `XDG_CONFIG_HOME` for pnpm/Wrangler checks in restricted containers.
+
 ## [0.2.0] — 2026-07-30
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,30 @@ pnpm check:workflow
 git diff --check
 ```
 
+### Restricted or read-only home directories
+
+pnpm and Wrangler need writable user data/configuration directories before
+Titen's checks can start. In an ephemeral container with an absent or read-only
+home, keep those tool writes outside the repository and scope the override to a
+subshell:
+
+```bash
+(
+  set -eu
+  titen_tool_home="$(mktemp -d)"
+  trap 'rm -rf -- "$titen_tool_home"' EXIT
+  export HOME="$titen_tool_home"
+  export XDG_CONFIG_HOME="$titen_tool_home/.config"
+  export WRANGLER_SEND_METRICS=false
+  mkdir -p "$XDG_CONFIG_HOME"
+
+  pnpm install
+  pnpm test:all
+)
+```
+
+This is contributor-tool setup, not a Titen runtime requirement.
+
 Use `pnpm dev` for local dashboard work and `pnpm screenshots` after a production
 build when an approved visual change needs refreshed README images. Also verify
 that every relative Markdown link points to an existing file.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -213,7 +213,12 @@ const key = await titen.createKey({
   max_trust: "asserted",
 });
 // key.api_key → store this, it won't be shown again
+// key.principal_id → use this as handoff.to_principal; key_id identifies the credential
 ```
+
+Titen returns the caller-supplied or generated `principal_id` at creation so
+the new agent can receive a handoff immediately. Do not use `key_id` as an agent
+identity.
 
 ## Error handling
 

--- a/docs/plans/active/2026-07-30-all-open-issues-release-hardening.md
+++ b/docs/plans/active/2026-07-30-all-open-issues-release-hardening.md
@@ -5,8 +5,8 @@ stage: implement
 outcome: pending
 complexity: complex
 created: 2026-07-30
-updated: 2026-07-30
-review_after: 2026-08-13
+updated: 2026-07-31
+review_after: 2026-08-14
 owner: CADIS
 spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
 ---
@@ -45,7 +45,7 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
   typed-route capability matrix.
 - [x] Make README repository references absolute and simplify pack verification
   to public behavior: pack, install, inspect README, and execute the installed bin.
-- [ ] Check in the verified loopback-only rootless deployment unit, reconcile or
+- [x] Check in the verified loopback-only rootless deployment unit, reconcile or
   remove unverified helpers/limits, document remote access choices, and repeat
   current image/vector/WAL/live evidence.
 - [x] Serialize or isolate the workerd restart fixture so the documented clean
@@ -53,16 +53,22 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
 - [x] Run focused adversarial/fault tests, `pnpm test:all`, browser on an available
   configured port, workflow checker+self-test, route/docs checks, Worker dry-run,
   normal/custom-prefix pack verification, and installed-tarball CLI/SDK smoke.
-- [ ] Request and execute the explicit operator window for the `rama-tuf` reboot;
+- [x] Request and execute the explicit operator window for the `rama-tuf` reboot;
   capture boot, service, health, data-preservation, journal, and full live evidence.
-- [ ] Commit with the required CADIS trailer, open/review/merge the PR, enumerate
-  exact branch/worktree cleanup targets, and remove only merged or superseded ones.
+- [ ] Commit the corrective diff with the required CADIS trailer, open, review,
+  and merge the PR; enumerate exact branch/worktree cleanup targets and remove
+  only merged or superseded ones.
 - [ ] Post a specific root-cause/fix/evidence comment to every cutoff issue before
   closing it; leave no issue silently closed and re-snapshot for late arrivals.
-- [ ] Prepare version `0.2.0` and changelog, verify the exact main commit, publish
+- [x] Prepare version `0.2.0` and changelog, verify the exact main commit, publish
   npm through the maintainer approval URL, create the matching GitHub release, and
   verify public registry, dist-tag, package README, CLI, tag, release, Actions-off,
   and zero-open-PR state.
+- [x] Reconcile #71 against the current lease contract, return `principal_id`
+  from key creation with dual-runtime coverage for #72, and add the smallest
+  sandbox HOME/XDG contributor guidance for #73.
+- [ ] Run focused and full regression gates, publish the exact verified `0.2.1`
+  patch to npm and GitHub, and smoke the public SDK/CLI artifact.
 - [ ] Record exact evidence, mark every item complete, and move this pair to
   `docs/specs/done/` and `docs/plans/done/` in the terminal evidence commit.
 
@@ -117,6 +123,38 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
 - AC-RH-026: invalid/same-origin/missing Origin cases, unsupported/current/legacy
   protocol headers, authenticated `GET /mcp` 405, tool annotation assertions,
   official host-source links, and a complete Ponytail marker ledger.
+- AC-RH-027: dual-runtime key-creation cases for caller-supplied and generated
+  principal IDs, plus SDK handoff setup using the returned identity.
+- AC-RH-028: contributor documentation check for an explicit temporary writable
+  tool home outside the repository, with no runtime code or dependency change.
+
+## Verification
+
+- Merged implementation/release commits: `3971e3a`, `2bcfdab`, and exact
+  release candidate `023fdd0fe2f78d9e67eb15ba66d35a4142e88b7a`.
+- Local gates: 71 D1, 90 Bun/vector/SDK, 63 integration, 10 browser, workflow
+  checker/self-test, route docs, dashboard adapter, Worker dry-build, and the
+  six-stage real-tarball verifier all passed.
+- Live gate: schema 10 and 4/4 wrapped federation secrets remained healthy;
+  the approved reboot changed boot ID, auto-started the rootless user service
+  with `NRestarts=0`, preserved 34 observations, 34 claims, 125 events and the
+  recorded event ID, produced no warning-or-higher boot journal entry, and
+  passed `scripts/verify-live.ts` with real `embeddinggemma` vectors.
+- Reconciliation progress: all original 34 cutoff issues were closed only after
+  individual explanatory comments. The late snapshot exposed #71-#73, which
+  remain subject to the corrective tasks above.
+  Remote branches contain only `main`; enumerated temporary worktrees and local
+  branches were removed without modifying the user's original dirty checkout.
+- Publication: tag `v0.2.0` resolves to `023fdd0`; npm `latest` resolves to
+  `0.2.0` with SHA-1 `fe6826cbdb3f0210fe3b4cf53ef51ec44ee04c55` and passed
+  clean registry SDK/CLI/README smokes; GitHub release
+  `https://github.com/RamaAditya49/titen/releases/tag/v0.2.0` is public.
+- Project policy remained intact: GitHub Actions stayed disabled and no
+  workflow was added as a release gate.
+- Late focused gates: the key response and handoff path passed 71 D1, 90
+  Bun/vector/SDK, and 63 integration tests. A clean temporary HOME/XDG setup
+  reached Wrangler's 221.73 KiB / 48.87 KiB dry-build successfully; workflow,
+  route-documentation, build, and diff checks passed.
 
 ## Security, migration, deployment, and rollback
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -68,6 +68,15 @@ features explicitly listed as proposed are not routes.
   `audit/events`, and channel-scoped context paths are not aliases. Use the
   implemented inventory above.
 
+## API keys
+
+`POST /v1/keys` accepts a label, scopes, and optional `max_trust`,
+`principal_id`, and `principal_kind`. Its one-time creation response includes
+the raw `api_key`, credential `key_id`, and the caller-supplied or generated
+`principal_id`. Use `principal_id` for handoff targets; `key_id` identifies the
+revocable credential and is not an agent identity. `GET /v1/keys` returns the
+same non-secret identity metadata but never returns the raw key.
+
 ## Webhook delivery
 
 `POST /v1/webhooks` accepts only a configured allowlisted HTTPS hostname. The

--- a/docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
+++ b/docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
@@ -5,34 +5,37 @@ stage: implement
 outcome: pending
 complexity: complex
 created: 2026-07-30
-updated: 2026-07-30
-review_after: 2026-08-13
+updated: 2026-07-31
+review_after: 2026-08-14
 owner: CADIS
 ---
 # All-open-issues release hardening
 
 ## Problem
 
-The public `0.1.2` surface has 34 open issues covering authorization, data
-integrity, runtime recovery, adapters, operator workflow, client safety,
-packaging, and deployment truth. Several features are advertised beyond their
-verified security boundary. The next release must resolve the open set from one
-fixed cutoff without hiding incomplete work behind issue closure.
+The public `0.1.2` surface and the terminal `0.2.0` snapshot exposed 37 issues
+covering authorization, data integrity, runtime recovery, adapters, operator
+workflow, client safety, packaging, and deployment truth. Several features are
+advertised beyond their verified security boundary. The next release must
+resolve the open set from one fixed cutoff without hiding incomplete work behind
+issue closure.
 
 ## Issue cutoff and classification
 
 The release cutoff is every issue open immediately before the release tag,
 starting with #9, #11, #13, #15-#18, #20-#24, #31-#41, #48, #54-#56,
-#59-#60, and #63-#67. New issues opened before tagging enter this spec through
-an updated issue matrix and acceptance mapping.
+#59-#60, #63-#67, and the late terminal snapshot #71-#73. New issues opened
+before tagging enter this spec through an updated issue matrix and acceptance
+mapping.
 
 The current batch groups the root causes as follows:
 
 - storage and recovery: #9, #11, #33, #40, #66;
-- authorization and integrity: #20-#22, #24, #35, #37-#39;
+- authorization and integrity: #20-#22, #24, #35, #37-#39, #71;
 - delivery security and durability: #23, #32, #41, #48;
 - retrieval and adapter parity: #31, #34, #36, #65;
-- CLI, SDK, and package safety: #54-#56, #59-#60, #63-#64, #67;
+- CLI, SDK, package, and contributor safety: #54-#56, #59-#60, #63-#64,
+  #67, #72-#73;
 - deployment evidence and test reliability: #13, #15-#18.
 
 ## Scope
@@ -58,7 +61,8 @@ The current batch groups the root causes as follows:
   root cause, fix or disposition, merged commit, and reproducible evidence.
 - Remove merged or explicitly obsolete branches after enumerating them; retain
   any branch or worktree with unique unabsorbed work.
-- Cut version `0.2.0`, publish the exact verified commit to npm and GitHub, and
+- Cut version `0.2.0`, then publish the minimum corrective `0.2.1` for valid
+  late-snapshot defects; publish exact verified commits to npm and GitHub and
   keep GitHub Actions disabled.
 
 ## Out of scope
@@ -194,12 +198,51 @@ The current batch groups the root causes as follows:
   it before tool execution; otherwise its stateless endpoint shall expose the
   current negotiated revision, safe tool annotations, and the required no-SSE
   `GET` response, while host-native packaging remains explicitly documented debt.
+- **AC-RH-027 — Event-driven:** When an authorized principal creates a key with
+  an explicit or generated principal identity, Titen shall return that
+  non-secret `principal_id` in the creation response so a caller can immediately
+  address handoffs without confusing it with `key_id`.
+- **AC-RH-028 — Optional feature:** Where contributors run pnpm, Wrangler, or
+  contract tests with a read-only or absent home directory, Titen shall document
+  the smallest temporary writable tool home outside the repository required to
+  reach the project checks without presenting it as a runtime requirement.
 
 ## Done conditions
 
 Every acceptance criterion has reproducible evidence; dual-runtime, integration,
 browser, workflow, package-install, migration/import fault, and applicable live
 smokes pass; all cutoff issues have explicit closure comments; no PR remains
-open; branch cleanup preserves unique work; the version/tag/GitHub/npm artifacts
-identify one commit; and this spec/plan pair moves to `done` with no unchecked
-work.
+open; branch cleanup preserves unique work; the final version/tag/GitHub/npm
+artifacts identify one commit; and this spec/plan pair moves to `done` with no
+unchecked work.
+
+## Progress evidence
+
+- PR #68 merged the issue hardening as `3971e3a`; PR #69 prepared version
+  `0.2.0` as `2bcfdab`; PR #70 corrected the live lifecycle verifier, leaving
+  the exact release candidate at `023fdd0fe2f78d9e67eb15ba66d35a4142e88b7a`.
+- The release candidate passed 71 Cloudflare D1, 90 Bun/vector/SDK, 63
+  integration, and 10 browser cases, plus workflow, route-documentation,
+  Worker dry-build, dashboard-adapter, normal install, plain-Node SDK, CLI, and
+  custom-prefix pack gates.
+- Live schema 10 migration preserved canonical data and wrapped all four
+  federation secrets. A real host reboot changed boot ID from
+  `7e6d5519-b2e6-43f4-be05-845be87c6b85` to
+  `221ce85e-cda2-4e00-a010-2e34e5d18bf1`; the rootless service returned
+  automatically with `NRestarts=0`, healthy schema/signing checks, unchanged
+  pre-reboot counts/event evidence, and a passing real-model live verifier.
+- Every one of the original 34 cutoff issues received a specific root-cause,
+  fix/disposition, and evidence comment before closure. Remote branch cleanup
+  left only `main`; temporary merged worktrees/branches were removed while the
+  user's original dirty checkout remained untouched.
+- Tag `v0.2.0` points to `023fdd0`. npm `latest` is `titen-memory@0.2.0` with
+  SHA-1 `fe6826cbdb3f0210fe3b4cf53ef51ec44ee04c55`; clean registry SDK/CLI,
+  side-effect-free help, and public README smokes passed. The matching GitHub
+  release is `https://github.com/RamaAditya49/titen/releases/tag/v0.2.0`.
+- The official-source host integration matrix is documented in
+  `docs/architecture/agent-integration.md`; speculative native adapters remain
+  explicit, trigger-based entries in `PONYTAIL-DEBT.md`.
+- The terminal snapshot then exposed #71-#73. Issue #71 is already fixed in
+  `0.2.0`; #72 is a valid response-contract omission and #73 is a valid
+  contributor-documentation gap. They remain active until individually
+  reconciled and the necessary `0.2.1` artifact is public.

--- a/src/core/keys.ts
+++ b/src/core/keys.ts
@@ -44,11 +44,12 @@ export async function createKey(ctx: RequestContext): Promise<Result> {
     ["human", "agent", "service"] as const,
     "agent",
   );
+  const principalId = optionalString(body, "principal_id", LIMITS.identifier) ?? newId("agent");
 
   const created = await createApiKey(
     {
       orgId: principal.orgId,
-      principalId: optionalString(body, "principal_id", LIMITS.identifier) ?? newId("agent"),
+      principalId,
       principalKind,
       label,
       scopes,
@@ -64,6 +65,7 @@ export async function createKey(ctx: RequestContext): Promise<Result> {
       key_id: created.id,
       // The only time the raw key exists outside the client's hands.
       api_key: created.key,
+      principal_id: principalId,
       label,
       scopes,
       max_trust: maxTrust,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -103,6 +103,25 @@ export interface HandoffOptions {
   message?: string;
 }
 
+export interface CreateKeyOptions {
+  label: string;
+  scopes: string[];
+  max_trust?: "unverified" | "asserted" | "verified" | "policy_approved";
+  principal_id?: string;
+  principal_kind?: "human" | "agent" | "service";
+}
+
+export interface CreatedKey {
+  key_id: string;
+  api_key: string;
+  principal_id: string;
+  principal_kind: "human" | "agent" | "service";
+  label: string;
+  scopes: string[];
+  max_trust: "unverified" | "asserted" | "verified" | "policy_approved";
+  warning: string;
+}
+
 /** Typed convenience methods intentionally kept to the common agent path. */
 export const TITEN_SDK_TYPED_ROUTES = [
   ["health", "GET /healthz"],
@@ -353,8 +372,8 @@ export class TitenClient {
 
   // --- Keys ---
 
-  async createKey(options: { label: string; scopes: string[]; max_trust?: string }) {
-    return this.request("POST", "/v1/keys", { json: options });
+  async createKey(options: CreateKeyOptions): Promise<CreatedKey> {
+    return this.request<CreatedKey>("POST", "/v1/keys", { json: options });
   }
 
   async listKeys() {

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -931,11 +931,13 @@ export const CASES: Case[] = [
           label: "reader",
           scopes: ["context:compile", "evidence:read"],
           max_trust: "asserted",
+          principal_id: "agent_managed_reader",
         },
       });
       expectOk(created, 201);
       const child = created.body.data.api_key as string;
       assert.match(child, /^titen_sk_/);
+      assert.equal(created.body.data.principal_id, "agent_managed_reader");
       assert.match(created.body.data.warning, /cannot show it again/i);
 
       // The child key works for what it was granted and nothing else.
@@ -1475,7 +1477,20 @@ export const CASES: Case[] = [
     name: "handoffs transfer work between principals",
     async run(fx) {
       const sender = await fx.provision({ scopes: ["*"] });
-      const receiver = await fx.provision({ orgId: sender.orgId, scopes: ["*"] });
+      const createdReceiver = await fx.call("POST", "/v1/keys", {
+        key: sender.key,
+        body: {
+          label: "handoff receiver",
+          scopes: ["handoffs:read", "handoffs:write"],
+        },
+      });
+      expectOk(createdReceiver, 201);
+      const receiver = {
+        key: createdReceiver.body.data.api_key as string,
+        principalId: createdReceiver.body.data.principal_id as string,
+      };
+      assert.match(receiver.principalId, /^agent_/);
+      assert.notEqual(receiver.principalId, createdReceiver.body.data.key_id);
 
       const handoff = await fx.call("POST", "/v1/handoffs", {
         key: sender.key,

--- a/tests/sdk/sdk.test.ts
+++ b/tests/sdk/sdk.test.ts
@@ -156,10 +156,14 @@ test("claim lifecycle calls resolve through the client", async () => {
 test("key management round-trips and a scoped key is enforced", async () => {
   const created = await titen.createKey({
     label: "sdk-reader",
-    scopes: ["context:compile"],
+    scopes: ["context:compile", "handoffs:read", "handoffs:write"],
     max_trust: "asserted",
+    principal_id: "agent_sdk_reader",
+    principal_kind: "agent",
   });
   assert.match(created.api_key, /^titen_sk_/);
+  assert.equal(created.principal_id, "agent_sdk_reader");
+  assert.equal(created.principal_kind, "agent");
 
   const reader = new TitenClient({ url: running.url, key: created.api_key });
   const compiled = await reader.compile({
@@ -168,6 +172,16 @@ test("key management round-trips and a scoped key is enforced", async () => {
     max_tokens: 300,
   });
   assert.ok(compiled.context_id);
+
+  const handoff = await titen.createHandoff({
+    to_principal: created.principal_id,
+    subject_id: "user_sdk_handoff",
+    message: "Continue with the returned principal identity.",
+  });
+  const handoffs = await reader.listHandoffs("pending");
+  assert.ok(handoffs.handoffs.some((entry: any) => entry.handoff_id === handoff.handoff_id));
+  const accepted = await reader.resolveHandoff(handoff.handoff_id, "accepted");
+  assert.equal(accepted.status, "accepted");
 
   // The client must surface a refusal as a typed error, not a silent result.
   await assert.rejects(


### PR DESCRIPTION
## Summary

- return the canonical supplied/generated `principal_id` from `POST /v1/keys`
- type the SDK key-creation input/result and prove the returned identity can receive and resolve a handoff
- document temporary writable HOME/XDG setup for pnpm/Wrangler in restricted contributor containers
- extend the active release-hardening spec/plan for the late #71-#73 snapshot

## Workflow

- Spec: `docs/specs/active/2026-07-30-all-open-issues-release-hardening.md`
- Plan: `docs/plans/active/2026-07-30-all-open-issues-release-hardening.md`
- Release impact: patch

## Verification

- `pnpm test:api`: 71 D1 + 90 Bun/vector/SDK passed
- `pnpm test:integration`: 63 passed
- focused SDK handoff test: 11 passed
- restricted temporary HOME/XDG Wrangler dry-build: 221.73 KiB / 48.87 KiB
- dashboard build, route-doc checker, workflow checker, and `git diff --check` passed

## Safety

Additive response field only; no schema, credential, authorization, dependency, runtime, or deployment change. The contributor workaround is opt-in and scoped to a subshell.