### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-07-31
+
 ### Fixed
 
 - Key creation now returns the canonical `principal_id`, so SDK callers can use

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titen-memory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Collaborative memory fabric for AI agents \u2014 evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Publish the minimal corrective `0.2.1` patch after PR #74:

- return canonical `principal_id` from key creation and type it in the SDK
- document the restricted-home contributor setup
- no schema, dependency, authorization, or deployment change

## Verification

Exact `0.2.1` candidate passed:

- 71 Cloudflare D1 tests
- 90 Bun/vector/SDK tests
- 63 integration tests
- real dashboard adapter E2E
- 10 browser tests
- workflow checker and self-test
- Worker dry-build: 221.73 KiB / 48.87 KiB
- six-stage `titen-memory-0.2.1.tgz` install/SDK/CLI/custom-prefix verifier

## Release impact

Patch. npm and GitHub publication remain manual after merge; GitHub Actions stay disabled.