### PR TITLE
docs: record v0.2.1 terminal evidence

### DIFF
--- a/docs/plans/done/2026-07-30-all-open-issues-release-hardening.md
+++ b/docs/plans/done/2026-07-30-all-open-issues-release-hardening.md
@@ -144,7 +144,8 @@ spec: docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
 - Reconciliation: every original and late issue, including #71-#73, #75, and
   #77, was closed only after an individual explanatory comment. #75 required no
   fix; #77 was closed as not planned with its delivered, future, and trigger-based
-  debt scopes separated. The terminal snapshot has zero open issues and PRs.
+  debt scopes separated. Before terminal-documentation PR #78 opened, the final
+  release snapshot had zero open issues and PRs; #78 was its sole temporary PR.
 - Publication: tag `v0.2.0` resolves to `023fdd0`, and its public npm/GitHub
   artifacts remain available. Annotated tag `v0.2.1` peels to the exact release
   commit `a6c9edf`; npm `latest` resolves to `0.2.1` with SHA-1
@@ -154,8 +155,10 @@ spec: docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
 - Project policy remained intact: GitHub Actions is disabled, current `main` has
   no workflow, and no workflow was used as a release gate. GitHub retains one
   failed historical run from the deleted `ci/issue-8-guardrail` branch.
-- Remote branch cleanup left only `main`. Enumerated temporary topic branches
-  were removed without modifying the user's original dirty checkout.
+- Before opening PR #78, remote branch cleanup left only `main`; its
+  `docs/complete-v0.2.1-release` head was the sole temporary branch exception.
+  Earlier enumerated topic branches were removed without modifying the user's
+  original dirty checkout.
 - Late focused gates: the key response and handoff path passed 71 D1, 90
   Bun/vector/SDK, and 63 integration tests. A clean temporary HOME/XDG setup
   reached Wrangler's 221.73 KiB / 48.87 KiB dry-build successfully; workflow,

--- a/docs/plans/done/2026-07-30-all-open-issues-release-hardening.md
+++ b/docs/plans/done/2026-07-30-all-open-issues-release-hardening.md
@@ -1,14 +1,13 @@
 ---
 work_id: all-open-issues-release-hardening
-status: active
-stage: implement
-outcome: pending
+status: done
+stage: done
+outcome: completed
 complexity: complex
 created: 2026-07-30
 updated: 2026-07-31
-review_after: 2026-08-14
 owner: CADIS
-spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
+spec: docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
 ---
 # Plan
 
@@ -55,10 +54,10 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
   normal/custom-prefix pack verification, and installed-tarball CLI/SDK smoke.
 - [x] Request and execute the explicit operator window for the `rama-tuf` reboot;
   capture boot, service, health, data-preservation, journal, and full live evidence.
-- [ ] Commit the corrective diff with the required CADIS trailer, open, review,
+- [x] Commit the corrective diff with the required CADIS trailer, open, review,
   and merge the PR; enumerate exact branch/worktree cleanup targets and remove
   only merged or superseded ones.
-- [ ] Post a specific root-cause/fix/evidence comment to every cutoff issue before
+- [x] Post a specific root-cause/fix/evidence comment to every cutoff issue before
   closing it; leave no issue silently closed and re-snapshot for late arrivals.
 - [x] Prepare version `0.2.0` and changelog, verify the exact main commit, publish
   npm through the maintainer approval URL, create the matching GitHub release, and
@@ -67,9 +66,9 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
 - [x] Reconcile #71 against the current lease contract, return `principal_id`
   from key creation with dual-runtime coverage for #72, and add the smallest
   sandbox HOME/XDG contributor guidance for #73.
-- [ ] Run focused and full regression gates, publish the exact verified `0.2.1`
+- [x] Run focused and full regression gates, publish the exact verified `0.2.1`
   patch to npm and GitHub, and smoke the public SDK/CLI artifact.
-- [ ] Record exact evidence, mark every item complete, and move this pair to
+- [x] Record exact evidence, mark every item complete, and move this pair to
   `docs/specs/done/` and `docs/plans/done/` in the terminal evidence commit.
 
 ## Acceptance evidence mapping
@@ -130,8 +129,10 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
 
 ## Verification
 
-- Merged implementation/release commits: `3971e3a`, `2bcfdab`, and exact
-  release candidate `023fdd0fe2f78d9e67eb15ba66d35a4142e88b7a`.
+- Merged implementation/release commits: `3971e3a`, `2bcfdab`, exact `0.2.0`
+  release candidate `023fdd0fe2f78d9e67eb15ba66d35a4142e88b7a`, corrective
+  PR #74 commit `426d48c7`, and exact `0.2.1` release commit
+  `a6c9edf4801d43f0f897af06d1bba7b8e3665b6a` from PR #76.
 - Local gates: 71 D1, 90 Bun/vector/SDK, 63 integration, 10 browser, workflow
   checker/self-test, route docs, dashboard adapter, Worker dry-build, and the
   six-stage real-tarball verifier all passed.
@@ -140,21 +141,31 @@ spec: docs/specs/active/2026-07-30-all-open-issues-release-hardening.md
   with `NRestarts=0`, preserved 34 observations, 34 claims, 125 events and the
   recorded event ID, produced no warning-or-higher boot journal entry, and
   passed `scripts/verify-live.ts` with real `embeddinggemma` vectors.
-- Reconciliation progress: all original 34 cutoff issues were closed only after
-  individual explanatory comments. The late snapshot exposed #71-#73, which
-  remain subject to the corrective tasks above.
-  Remote branches contain only `main`; enumerated temporary worktrees and local
-  branches were removed without modifying the user's original dirty checkout.
-- Publication: tag `v0.2.0` resolves to `023fdd0`; npm `latest` resolves to
-  `0.2.0` with SHA-1 `fe6826cbdb3f0210fe3b4cf53ef51ec44ee04c55` and passed
-  clean registry SDK/CLI/README smokes; GitHub release
-  `https://github.com/RamaAditya49/titen/releases/tag/v0.2.0` is public.
-- Project policy remained intact: GitHub Actions stayed disabled and no
-  workflow was added as a release gate.
+- Reconciliation: every original and late issue, including #71-#73, #75, and
+  #77, was closed only after an individual explanatory comment. #75 required no
+  fix; #77 was closed as not planned with its delivered, future, and trigger-based
+  debt scopes separated. The terminal snapshot has zero open issues and PRs.
+- Publication: tag `v0.2.0` resolves to `023fdd0`, and its public npm/GitHub
+  artifacts remain available. Annotated tag `v0.2.1` peels to the exact release
+  commit `a6c9edf`; npm `latest` resolves to `0.2.1` with SHA-1
+  `7b1fd4f9893a94153b303e191d4f7281e122524f`; the registry SDK/CLI smoke passed;
+  and `https://github.com/RamaAditya49/titen/releases/tag/v0.2.1` is public,
+  non-draft, and not a prerelease.
+- Project policy remained intact: GitHub Actions is disabled, current `main` has
+  no workflow, and no workflow was used as a release gate. GitHub retains one
+  failed historical run from the deleted `ci/issue-8-guardrail` branch.
+- Remote branch cleanup left only `main`. Enumerated temporary topic branches
+  were removed without modifying the user's original dirty checkout.
 - Late focused gates: the key response and handoff path passed 71 D1, 90
   Bun/vector/SDK, and 63 integration tests. A clean temporary HOME/XDG setup
   reached Wrangler's 221.73 KiB / 48.87 KiB dry-build successfully; workflow,
   route-documentation, build, and diff checks passed.
+- Live corrective gate: image
+  `61b70145edbce715b5878d7279c9f6aa3ff83671a85a2418309a598e40d8b603`
+  (digest `sha256:4e0fd3ce9064cce2432a451cba93dcfdef7060f2105f201629c51d20b713ebc4`)
+  served revision `a6c9edf` healthy with schema 10 and `NRestarts=0`; generated
+  principal handoff, pre-existing event persistence, and the full real-model
+  verifier passed.
 
 ## Security, migration, deployment, and rollback
 

--- a/docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
+++ b/docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
@@ -262,7 +262,9 @@ unchecked work.
   `7b1fd4f9893a94153b303e191d4f7281e122524f`; clean registry SDK/CLI smokes
   passed. The public, non-draft GitHub release is
   `https://github.com/RamaAditya49/titen/releases/tag/v0.2.1`.
-- The final snapshot has zero open issues, zero open pull requests, and only the
-  remote `main` branch. GitHub Actions is disabled and current `main` contains no
-  workflow; one failed run from the deleted historical `ci/issue-8-guardrail`
-  branch remains GitHub metadata and is not release evidence.
+- Before opening terminal-documentation PR #78, the final release snapshot had
+  zero open issues, zero open pull requests, and only remote `main`; #78 and its
+  `docs/complete-v0.2.1-release` head were the sole temporary finalization
+  exception. GitHub Actions is disabled and current `main` contains no workflow;
+  one failed run from the deleted historical `ci/issue-8-guardrail` branch
+  remains GitHub metadata and is not release evidence.

--- a/docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
+++ b/docs/specs/done/2026-07-30-all-open-issues-release-hardening.md
@@ -1,31 +1,30 @@
 ---
 work_id: all-open-issues-release-hardening
-status: active
-stage: implement
-outcome: pending
+status: done
+stage: done
+outcome: completed
 complexity: complex
 created: 2026-07-30
 updated: 2026-07-31
-review_after: 2026-08-14
 owner: CADIS
 ---
 # All-open-issues release hardening
 
 ## Problem
 
-The public `0.1.2` surface and the terminal `0.2.0` snapshot exposed 37 issues
-covering authorization, data integrity, runtime recovery, adapters, operator
-workflow, client safety, packaging, and deployment truth. Several features are
-advertised beyond their verified security boundary. The next release must
-resolve the open set from one fixed cutoff without hiding incomplete work behind
-issue closure.
+The release-hardening window across the public `0.1.2` surface and terminal
+`0.2.0` snapshot eventually exposed 39 issues covering authorization, data
+integrity, runtime recovery, adapters, operator workflow, client safety,
+packaging, and deployment truth. Several features were advertised beyond their
+verified security boundary. The release must resolve the full observed set
+without hiding incomplete work behind issue closure.
 
 ## Issue cutoff and classification
 
-The release cutoff is every issue open immediately before the release tag,
-starting with #9, #11, #13, #15-#18, #20-#24, #31-#41, #48, #54-#56,
-#59-#60, #63-#67, and the late terminal snapshot #71-#73. New issues opened
-before tagging enter this spec through an updated issue matrix and acceptance
+The work scope is every issue in the original pre-release cutoff—#9, #11, #13,
+#15-#18, #20-#24, #31-#41, #48, #54-#56, #59-#60, and #63-#67—plus the late
+terminal arrivals #71-#73, #75, and #77. New issues opened before terminal
+completion enter this spec through an updated issue matrix and acceptance
 mapping.
 
 The current batch groups the root causes as follows:
@@ -37,6 +36,7 @@ The current batch groups the root causes as follows:
 - CLI, SDK, package, and contributor safety: #54-#56, #59-#60, #63-#64,
   #67, #72-#73;
 - deployment evidence and test reliability: #13, #15-#18.
+- validation and roadmap dispositions requiring no code: #75, #77.
 
 ## Scope
 
@@ -189,10 +189,10 @@ The current batch groups the root causes as follows:
   command whose clean checkout completes every Bun and workerd contract without
   a disposed Miniflare cascade.
 - **AC-RH-025 — Event-driven:** When implementation and all required evidence are
-  complete, maintainers shall merge the reviewed change, comment on and close
-  every cutoff issue with its specific reason and evidence, remove only
-  enumerated merged/obsolete branches, and publish the exact verified `0.2.0`
-  commit to npm and a matching GitHub release while Actions remains disabled.
+  complete, maintainers shall merge the reviewed changes, comment on and close
+  every issue with its specific reason and evidence, remove only enumerated
+  merged/obsolete branches, and publish the exact verified `0.2.0` and `0.2.1`
+  artifacts to npm and matching GitHub releases while Actions remains disabled.
 - **AC-RH-026 — Unwanted behavior:** If an MCP HTTP request carries an invalid
   cross-origin source or unsupported protocol revision, then Titen shall reject
   it before tool execution; otherwise its stateless endpoint shall expose the
@@ -216,7 +216,7 @@ open; branch cleanup preserves unique work; the final version/tag/GitHub/npm
 artifacts identify one commit; and this spec/plan pair moves to `done` with no
 unchecked work.
 
-## Progress evidence
+## Completion evidence
 
 - PR #68 merged the issue hardening as `3971e3a`; PR #69 prepared version
   `0.2.0` as `2bcfdab`; PR #70 corrected the live lifecycle verifier, leaving
@@ -242,7 +242,27 @@ unchecked work.
 - The official-source host integration matrix is documented in
   `docs/architecture/agent-integration.md`; speculative native adapters remain
   explicit, trigger-based entries in `PONYTAIL-DEBT.md`.
-- The terminal snapshot then exposed #71-#73. Issue #71 is already fixed in
-  `0.2.0`; #72 is a valid response-contract omission and #73 is a valid
-  contributor-documentation gap. They remain active until individually
-  reconciled and the necessary `0.2.1` artifact is public.
+- PR #74 merged the #72 response-contract and #73 contributor-documentation
+  correction as `426d48c7`; PR #76 merged the exact `0.2.1` release commit as
+  `a6c9edf4801d43f0f897af06d1bba7b8e3665b6a`. Independent focused and release
+  reviews reported no findings.
+- The corrective tree passed 71 Cloudflare D1, 90 Bun/vector/SDK, 63 integration,
+  dashboard-adapter, 10 browser, workflow, Worker dry-build, restricted HOME/XDG,
+  and six-stage packed-tarball gates. The deployed `rama-tuf` image
+  `61b70145edbce715b5878d7279c9f6aa3ff83671a85a2418309a598e40d8b603`
+  (`sha256:4e0fd3ce9064cce2432a451cba93dcfdef7060f2105f201629c51d20b713ebc4`)
+  served revision `a6c9edf` healthy with `NRestarts=0`; generated-principal SDK
+  handoff, persistence, and the full real-model live verifier passed.
+- Issues #71-#73 were individually reconciled; #75 was a successful verification
+  report with no remaining defect, and #77 was closed as not planned because it
+  combined already-delivered behavior, future product decisions, and explicitly
+  trigger-based Ponytail debt. Every closure has a specific explanatory comment.
+- Annotated tag `v0.2.1` peels to the exact release commit `a6c9edf`. npm
+  `latest` is `titen-memory@0.2.1` with SHA-1
+  `7b1fd4f9893a94153b303e191d4f7281e122524f`; clean registry SDK/CLI smokes
+  passed. The public, non-draft GitHub release is
+  `https://github.com/RamaAditya49/titen/releases/tag/v0.2.1`.
+- The final snapshot has zero open issues, zero open pull requests, and only the
+  remote `main` branch. GitHub Actions is disabled and current `main` contains no
+  workflow; one failed run from the deleted historical `ci/issue-8-guardrail`
+  branch remains GitHub metadata and is not release evidence.


### PR DESCRIPTION
## Summary

- move the release-hardening spec and plan from active to done
- record npm, GitHub Release, live runtime, issue, PR, and branch evidence
- preserve the distinction between disabled Actions and one historical failed run

## Verification

- `node scripts/check-workflow-docs.mjs`
- `node scripts/check-workflow-docs.mjs --self-test`
- `git diff --check`