### PR TITLE
chore: mark the 15 unmarked ceilings from the ponytail-debt ledger

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -51,6 +51,10 @@ export async function compileContext(ctx: RequestContext): Promise<Result> {
     optionalString(body, "project_id", LIMITS.identifier),
   );
 
+  // ponytail: compilation is always anchored to now, with no caller-supplied
+  // `at`. The ceiling is that point-in-time recall is impossible even though
+  // `valid_from`/`valid_to` are stored and indexed to support it. Upgrade path:
+  // accept an optional `at` and thread it through the retrieval scope (#118).
   const now = ctx.app.now();
   const at = now.toISOString();
   const scope = { subjectId, projectId, at };

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -37,6 +37,12 @@ export function param(value: string | number | null | undefined): Param {
  * D1 caps bound parameters per statement at 100, so any dynamic `IN (...)` list
  * must be chunked. bun:sqlite is far more permissive, but the shared core keeps
  * the stricter limit so both runtimes execute the same statements.
+ *
+ * ponytail: a single global chunk size rather than one tuned per call site.
+ * The ceiling is that a wide `IN (...)` becomes several round trips, which
+ * multiplies the cost of any statement that is already expensive per
+ * execution. Upgrade path: none needed while the chunked statements are
+ * cheap; revisit if a hot path shows the multiplication in a profile (#121).
  */
 export const MAX_BOUND_PARAMS = 90;
 

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -18,6 +18,11 @@ interface StoredRow {
   expires_at: string;
 }
 
+// ponytail: a fixed 24-hour replay window, which is sized for a retry loop
+// rather than for a re-sync. The ceiling is that any bulk re-ingest run a day
+// later duplicates every record, and there is no content-level dedup behind it
+// to absorb that. Upgrade path: a statement/content hash uniqueness rule so
+// convergence does not depend on the caller replaying inside the window (#101).
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
 export function idempotencyKey(request: Request): string | null {

--- a/src/core/mcp.ts
+++ b/src/core/mcp.ts
@@ -41,6 +41,13 @@ const OUTCOMES = ["used", "useful", "irrelevant", "incorrect", "harmful"];
  * `name:?` a free-form value, and `name=a|b` an enum. One builder expands them
  * into JSON Schema so adding a tool is one line, not a nested literal.
  */
+/**
+ * ponytail: the common agent path only, expressed as data. The ceiling is that
+ * a tool absent here is unreachable over MCP even when its REST route exists —
+ * which today means an MCP client can append evidence but cannot derive a
+ * claim from it, so nothing it writes is retrievable. Upgrade path: add a
+ * combined remember-fact tool plus a plain-text search tool (#88, #89).
+ */
 const TOOL_SPECS: [name: string, description: string, args: string][] = [
   ["titen_remember", "Append an observation to memory.",
     "subject_id! kind! content! source_type! source_ref! trust visibility workspace_id project_id agent_id run_id occurred_at idempotency_key"],

--- a/src/core/migrations.ts
+++ b/src/core/migrations.ts
@@ -6,6 +6,12 @@ import type { Db } from "./db";
  * Rules for new entries: append only, one statement per array item, no PRAGMA
  * (D1 rejects most), parents before children so foreign keys hold, and no
  * destructive statement without its own work item.
+ *
+ * ponytail: forward-only, with no `down` statements. The ceiling is that
+ * recovery from a bad upgrade is restore-from-snapshot, which makes a verified
+ * backup a precondition of every deploy rather than a convenience. Upgrade
+ * path: none planned — instead, document the snapshot runbook and add a
+ * `migrate --dry-run` so the pending statements can be reviewed first (#116).
  */
 export const MIGRATIONS: { version: number; statements: string[] }[] = [
   {
@@ -55,6 +61,11 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
          ingested_at TEXT NOT NULL
        )`,
       `CREATE INDEX observations_scope ON observations (org_id, subject_id, ingested_at)`,
+      // ponytail: an unstemmed tokenizer with no prefix index. The ceiling is
+      // that morphological variants never match — a query for the singular
+      // misses a record holding the plural — which reads as an empty store
+      // rather than as a failed match. Upgrade path: add `porter` to the
+      // tokenizer in a new migration that rebuilds the index (#83).
       `CREATE VIRTUAL TABLE observations_fts USING fts5 (
          content,
          observation_id UNINDEXED,
@@ -79,6 +90,9 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
          created_at TEXT NOT NULL
        )`,
       `CREATE INDEX claims_scope ON claims (org_id, subject_id, status)`,
+      // ponytail: same unstemmed tokenizer as observations_fts, and this is the
+      // index compilation actually reads. The ceiling and upgrade path are the
+      // same; change both together or recall diverges between the two (#83).
       `CREATE VIRTUAL TABLE claims_fts USING fts5 (
          statement,
          claim_id UNINDEXED,
@@ -254,6 +268,12 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
     version: 4,
     statements: [
       // Enterprise governance: policies, channel releases, customer assertions, audit log.
+      // ponytail: `policies` accepts a 'retention' kind that no code reads yet,
+      // so the schema anticipates retention while nothing enforces it. The
+      // ceiling is that every append-only satellite table — events,
+      // record_history, index_outbox, context_runs — grows without bound.
+      // Upgrade path: implement the 'retention' policy kind in
+      // `runMaintenance`, which is where the schema already expects it (#105).
       `CREATE TABLE policies (
          id TEXT PRIMARY KEY,
          org_id TEXT NOT NULL REFERENCES organizations(id),

--- a/src/core/observations.ts
+++ b/src/core/observations.ts
@@ -57,7 +57,16 @@ export function historyStatement(
   };
 }
 
-/** Every canonical write queues its own durable, asynchronously drained work. */
+/**
+ * Every canonical write queues its own durable, asynchronously drained work.
+ *
+ * ponytail: the row is queued unconditionally, without asking whether this
+ * deployment has a vector capability to consume it. The ceiling is that on the
+ * default no-vector deployment the outbox is written on every canonical write
+ * and never drained, so it grows without bound. Upgrade path: skip the enqueue
+ * when no vector capability is configured, and retire stale pending rows in
+ * `runMaintenance` (#105).
+ */
 export function outboxStatement(
   orgId: string,
   recordType: string,

--- a/src/core/portability.ts
+++ b/src/core/portability.ts
@@ -22,6 +22,15 @@ import {
 } from "./validate";
 
 export const EXPORT_FORMAT_VERSION = 1;
+/**
+ * ponytail: the portable format covers the memory surface only, not the whole
+ * deployment. The ceiling is that workspaces, memberships, checkpoints,
+ * feedback and version history do not survive an export/import roundtrip, so
+ * JSONL is an interchange format and `titen backup` is the durability
+ * boundary. Upgrade path: extend these types in dependency order, starting
+ * with workspaces and memberships, which team-scoped records already require
+ * on import (#111).
+ */
 export const EXPORT_TYPES = ["projects", "observations", "claims"] as const;
 export const EXPORT_DEPENDENCY_ORDER = [...EXPORT_TYPES];
 export const EXPORT_DEPENDENCIES: Record<(typeof EXPORT_TYPES)[number], string[]> = {
@@ -29,6 +38,12 @@ export const EXPORT_DEPENDENCIES: Record<(typeof EXPORT_TYPES)[number], string[]
   observations: ["projects"],
   claims: ["projects", "observations"],
 };
+// ponytail: both caps count rows, while the transport cap counts bytes. The
+// ceiling is that the two are not reconciled, so a page this endpoint is
+// willing to emit can exceed what the import endpoint will accept. Upgrade
+// path: cut export pages on accumulated byte length as well as row count and
+// set `next_cursor` accordingly, so any page is importable by construction
+// (#112).
 export const EXPORT_MAX_LIMIT = 2000;
 export const IMPORT_MAX_LINES = 2000;
 

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -12,6 +12,14 @@ export const RANK_WEIGHTS = {
 /** Feedback only moves ranking once enough signals exist (FRD CTX-002). */
 export const UTILITY_MIN_SIGNALS = 3;
 export const RECENCY_HALF_LIFE_DAYS = 90;
+/**
+ * ponytail: a fixed per-kind quota instead of budget-aware diversity. The
+ * ceiling is that a compiled pack can never exceed six kinds times this
+ * number of items however large `max_tokens` is, so a subject whose memory
+ * is concentrated in one kind cannot buy recall with budget. Upgrade path:
+ * derive the quota from the remaining budget, or apply it only below a
+ * relevance floor so a strong match is never displaced (#85).
+ */
 export const MAX_ITEMS_PER_KIND = 3;
 
 export interface RankInput {

--- a/src/core/retrieval.ts
+++ b/src/core/retrieval.ts
@@ -17,6 +17,16 @@ export interface FtsQueryPlan {
   termsDropped: number;
 }
 
+/**
+ * ponytail: term selection by shape (digits, then punctuation, then length)
+ * instead of corpus statistics, and no stopword list. The ceiling is that a
+ * natural-language task is mostly function words, so a single common term can
+ * drive the whole match set, and terms past `LIMITS.queryTerms` are dropped by
+ * character length rather than by how much they discriminate. Upgrade path:
+ * rank terms by inverse document frequency read from `claims_fts`, subtracting
+ * a stopword set, and fall back to the unfiltered list when filtering empties
+ * the query (#84).
+ */
 function termSignal(term: string): number {
   return (/[0-9]/u.test(term) ? 10_000 : 0)
     + (/[_'-]/u.test(term) ? 5_000 : 0)

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -40,6 +40,10 @@ export const LIMITS = {
   label: 120,
   reasonCode: 64,
   maxTokens: 32_000,
+  // ponytail: a fixed candidate ceiling rather than one scaled to the corpus.
+  // The ceiling is that recall past this many lexical matches is unreachable
+  // no matter how the caller ranks or budgets. Upgrade path: make it a
+  // per-request option once retrieval is cheap enough to widen (#121).
   candidates: 200,
   claimsPerConsolidation: 50,
   sourcesPerClaim: 20,

--- a/src/runtime/bun/server.ts
+++ b/src/runtime/bun/server.ts
@@ -84,6 +84,12 @@ export async function serve(options: ServeOptions) {
   });
 
   // @ts-ignore - Bun global is provided by the runtime.
+  // ponytail: one process, one database handle, synchronous bun:sqlite calls on
+  // the main thread. The ceiling is that throughput is set by a single core and
+  // does not improve with client concurrency; the SQLite writer lock is never
+  // the constraint, the event loop is. Upgrade path: move database work to a
+  // worker pool, or serve read-heavy routes from additional processes over
+  // SO_REUSEPORT with one designated writer (#123).
   const server = Bun.serve({
     port: options.port,
     hostname: options.hostname,

--- a/src/runtime/bun/sqlite.ts
+++ b/src/runtime/bun/sqlite.ts
@@ -11,6 +11,12 @@ export function openDatabase(path: string): Database {
   database.run("PRAGMA wal_autocheckpoint = 1000");
   database.run("PRAGMA foreign_keys = ON");
   database.run("PRAGMA busy_timeout = 5000");
+  // ponytail: `synchronous` is left at SQLite's FULL default rather than set
+  // explicitly. The ceiling is an fsync on every commit, which dominates write
+  // latency; NORMAL in WAL mode risks only the last committed transaction on
+  // power loss and never corruption. Upgrade path: set it explicitly with an
+  // env override so the durability trade is a recorded decision rather than an
+  // inherited default (#124).
   return database;
 }
 


### PR DESCRIPTION
Closes the Part 2 half of #125.

Every deliberate simplification in that ledger carried a real ceiling but no trigger, so nothing would ever prompt a revisit. This adds a `ponytail:` marker to each one, in the same style as the six markers already in the tree (`tokens.ts`, `vectors.ts`, `indexing.ts`, `maintenance.ts`, `webhooks.ts`, `runtime/bun/vectors.ts`) — each names **what was simplified**, **the ceiling it imposes**, and **the issue that would retire it**.

The point is narrow: make the next issue sweep self-explanatory from the code, so a deferral cannot quietly become permanent.

## What changed

**Comment-only. 101 added lines, all comments. Zero behaviour change.**

```
 src/core/context.ts       |  4 ++++
 src/core/db.ts            |  6 ++++++
 src/core/idempotency.ts   |  5 +++++
 src/core/mcp.ts           |  7 +++++++
 src/core/migrations.ts    | 20 ++++++++++++++++++++
 src/core/observations.ts  | 11 ++++++++++-
 src/core/portability.ts   | 15 +++++++++++++++
 src/core/rank.ts          |  8 ++++++++
 src/core/retrieval.ts     | 10 ++++++++++
 src/core/validate.ts      |  4 ++++
 src/runtime/bun/server.ts |  6 ++++++
 src/runtime/bun/sqlite.ts |  6 ++++++
 12 files changed, 101 insertions(+), 1 deletion(-)
```

The single deleted line is `observations.ts`'s one-line docblock, converted to a block comment with its original sentence preserved verbatim as the first line.

## Coverage

| marker | ceiling | retires with |
|---|---|---|
| `migrations.ts` observations_fts + claims_fts | unstemmed tokenizer, morphological variants never match | #83 |
| `retrieval.ts` `termSignal` | term selection by shape, no stopword list | #84 |
| `rank.ts` `MAX_ITEMS_PER_KIND` | pack capped at 6 kinds x 3 regardless of budget | #85 |
| `validate.ts` `candidates` | fixed candidate ceiling, not scaled to corpus | #121 |
| `context.ts` `at` | compilation always anchored to now, no point-in-time | #118 |
| `migrations.ts` `policies` retention kind | schema anticipates retention, no handler reads it | #105 |
| `observations.ts` `outboxStatement` | outbox enqueued even with no vector capability to drain it | #105 |
| `idempotency.ts` `IDEMPOTENCY_TTL_MS` | 24h replay window sized for retries, not re-syncs | #101 |
| `runtime/bun/sqlite.ts` | `synchronous` inherited as FULL rather than chosen | #124 |
| `runtime/bun/server.ts` | one process, one core, synchronous DB calls on the loop | #123 |
| `db.ts` `MAX_BOUND_PARAMS` | wide `IN (...)` becomes several round trips | #121 |
| `migrations.ts` header | forward-only, recovery is restore-from-snapshot | #116 |
| `portability.ts` `EXPORT_TYPES` | JSONL is memory-only, not the durability boundary | #111 |
| `portability.ts` row caps | row caps not reconciled with the byte cap | #112 |
| `mcp.ts` `TOOL_SPECS` | a tool absent here is unreachable over MCP | #88, #89 |

**16 markers for 15 ledger entries** — the tokenizer gets one per FTS table so the two cannot drift apart. Total in the tree is now 22.

## Verification

Run against the edited source, not the published tarball:

```
bun build src/core/app.ts        --target=bun          ->  194.10 KB, parsed
bun build src/runtime/bun/cli.ts --target=bun          ->  226.37 KB, parsed
bun build src/sdk.ts             --target=node --esm   ->    8.33 KB, parsed

bun src/runtime/bun/cli.ts bootstrap --db ./verify.db  ->  ok
  migrations applied: 10          integrity_check: ok
  observations_fts -> tokenize = 'unicode61 remove_diacritics 2'   (unchanged)
  claims_fts       -> tokenize = 'unicode61 remove_diacritics 2'   (unchanged)

GET /readyz  ->  ready:true, schema {applied:10, expected:10, verified:true},
                 checks {canonical_sql:ok, migrations:ok, signing_secrets:ok}

observe -> consolidate -> compile
  compile items: 1 | "Production deploys require a verified rollback smoke."
```

The migrations check matters most here: four of the markers are JS comments inserted *between* statement literals in the `MIGRATIONS` array, so the schema was re-derived from scratch to confirm the SQL is byte-identical.

## Deliberately not included

- No behavioural fixes. Every linked issue stays open; this PR only makes the debt legible.
- No `scripts/check-ponytail-debt.mjs`. That was a suggestion in #125, not part of this ask — happy to add it in a follow-up so the ledger stays current alongside `check-route-docs.mjs` and `check-workflow-docs.mjs`.

One note for whoever writes that check: a first scan using `grep -rnE '(#|//) ?ponytail:'` found only **1 of 6** existing markers, because the rest live in block comments. The prefix set needs `\*` — `grep -rnE '(#|//|\*|--) ?ponytail:'`.
