### PR TITLE
fix: complete ClawHub package metadata

### DIFF
--- a/plugins/claude/titen-memory/package.json
+++ b/plugins/claude/titen-memory/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ramaaditya49/titen-memory",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Titen memory skill bundle for Claude-compatible and OpenClaw hosts.",
+  "license": "Apache-2.0"
+}

--- a/tests/integration/agent-plugin.test.ts
+++ b/tests/integration/agent-plugin.test.ts
@@ -122,6 +122,12 @@ test("native marketplaces and host kits use the correct secret interpolation", (
   });
   for (const executable of ["extensions", "providers", "hooks"])
     assert.equal(executable in openClawManifest, false, `${executable} must stay absent`);
+  const packageManifest = json(join(claudeRoot, "package.json"));
+  assert.equal(packageManifest.name, "@ramaaditya49/titen-memory");
+  assert.equal(packageManifest.version, openClawManifest.version);
+  assert.equal(packageManifest.private, true);
+  for (const executable of ["scripts", "dependencies", "devDependencies"])
+    assert.equal(executable in packageManifest, false, `${executable} must stay absent`);
   assertRemoteConfig(
     json(join(claudeRoot, ".mcp.json")),
     "${TITEN_MCP_URL}",


### PR DESCRIPTION
## Summary

- add the minimal package metadata expected by ClawHub Plugin Inspector
- keep the bundle private, dependency-free, script-free, and instruction-only
- assert package/manifest version parity and the absence of executable package surfaces

## Verification

- `bun test tests/integration/agent-plugin.test.ts` — 5 passed
- `clawhub package validate plugins/claude/titen-memory` — 0 breakages, 0 warnings
- ClawHub package dry-run — 5 files from the intended bundle
- `claude plugin validate plugins/claude/titen-memory --strict` — passed
- workflow docs and diff checks passed

The live ClawHub publish is still waiting on the upstream sandbox incident openclaw/clawhub#3327; this change removes the only package-local warning before retry.

Co-Authored-By: CADIS <agent@cadis.digital>