### PR TITLE
docs: record public ClawHub skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
   bundle plus native MCP config, a Hermes skill plugin, a Pi skill package, and
   OpenCode/Windsurf/TRAE host kits now package the same seven-tool Titen MCP
   contract without duplicating the server or embedding an endpoint or
-  credential.
+  credential. The standalone Titen Memory skill is public on ClawHub; its
+  bundle-plugin package is staged while an upstream inspector incident blocks
+  live package publication.
 
 ## [0.2.1] — 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ claude plugin marketplace add RamaAditya49/titen
 claude plugin install titen-memory@titen
 ```
 
-OpenClaw installs the skill bundle from ClawHub and uses its native
-Streamable HTTP config for the connection:
+OpenClaw installs the public skill from ClawHub and uses its native Streamable
+HTTP config for the connection:
 
 ```bash
-openclaw plugins install clawhub:@ramaaditya49/titen-memory
+clawhub install titen-memory
 # Merge integrations/openclaw/openclaw.json into the OpenClaw config.
 openclaw mcp doctor titen --probe
 ```
@@ -158,7 +158,8 @@ openclaw mcp doctor titen --probe
 Set the complete MCP endpoint in `TITEN_MCP_URL` and the agent-specific key in
 `TITEN_API_KEY` outside the repository first. No package contains an instance
 URL, credential, automatic transcript capture, lifecycle hook, or second MCP
-server. See the [complete host installation matrix](https://github.com/RamaAditya49/titen/blob/main/docs/agent-plugins.md)
+server. See the [public ClawHub skill](https://clawhub.ai/ramaaditya49/skills/titen-memory),
+[complete host installation matrix](https://github.com/RamaAditya49/titen/blob/main/docs/agent-plugins.md),
 and [seven-tool security boundary](https://github.com/RamaAditya49/titen/blob/main/docs/agent-guide.md#mcp-integration).
 
 ### Agent SDK (any runtime)

--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -21,7 +21,7 @@ agent its own narrow, revocable key. Never paste a key into a repository file.
 | Codex | Native repo-marketplace plugin | `.agents/plugins/marketplace.json` |
 | Claude Code | Native marketplace plugin | `.claude-plugin/marketplace.json` |
 | ZCode | Claude-compatible marketplace plugin | import `RamaAditya49/titen` |
-| OpenClaw | ClawHub skill bundle + native MCP config | ClawHub + `integrations/openclaw` |
+| OpenClaw | Public ClawHub skill, staged bundle plugin, and native MCP config | ClawHub + `integrations/openclaw` |
 | Cursor | Native marketplace plugin | `.cursor-plugin/marketplace.json` |
 | Hermes | Native Python skill plugin | `plugins/hermes/titen-memory` |
 | Pi | Native Pi skill package | `plugins/pi/titen-memory` |
@@ -75,11 +75,12 @@ so the key stays in the environment. See [ZCode plugins](https://zcode.z.ai/en/d
 
 ## OpenClaw and ClawHub
 
-After publication, install the OpenClaw-safe skill bundle from ClawHub:
+Install the verified public [Titen Memory skill](https://clawhub.ai/ramaaditya49/skills/titen-memory)
+from ClawHub:
 
 ```bash
-openclaw plugins install clawhub:@ramaaditya49/titen-memory
-openclaw plugins inspect titen-memory
+clawhub install titen-memory
+clawhub skill verify titen-memory
 ```
 
 Merge only the `mcp.servers.titen` entry from
@@ -97,6 +98,15 @@ therefore omits that Claude-only file and uses OpenClaw's native
 plugin code is loaded. Its exposed tool names use
 `titen__<canonical-name>`. See [OpenClaw bundles](https://docs.openclaw.ai/plugins/bundles)
 and [native MCP configuration](https://docs.openclaw.ai/cli/mcp).
+
+The repository also contains the validated bundle-plugin package intended for
+`openclaw plugins install clawhub:@ramaaditya49/titen-memory`. Its live package
+publication remains blocked by the ClawHub inspector sandbox incident
+[openclaw/clawhub#3327](https://github.com/openclaw/clawhub/issues/3327), even
+though local validation and the exact merged-source dry-run pass with no
+warnings. Until that incident is resolved, use the public skill plus the native
+config above. ClawHub publishes standalone skills under its platform-wide
+MIT-0 terms; the source repository and bundle package remain Apache-2.0.
 
 ## Cursor
 

--- a/docs/plans/active/2026-07-31-cross-host-agent-distribution.md
+++ b/docs/plans/active/2026-07-31-cross-host-agent-distribution.md
@@ -60,3 +60,16 @@ rollback is branch deletion. After merge, host artifacts can be removed in a
 normal revert; after ClawHub publication, an immutable version cannot be erased
 as a rollback mechanism, so a corrected superseding version or registry yank is
 required. The existing MCP and npm service remain independently usable.
+
+## Current external publication evidence
+
+- PRs #127 and #128 are merged; the package source is commit
+  `1cc8823282c8b660126c17a38a26a8c5452571b6`.
+- The standalone `titen-memory@0.1.0` ClawHub skill is public, installs with a
+  byte-identical `SKILL.md`, and passes `clawhub skill verify` with clean static,
+  SkillSpector, and VirusTotal results.
+- The bundle plugin passes local Plugin Inspector with zero breakages and zero
+  warnings; its exact merged-source dry-run contains five files and 5,074 bytes.
+- Live bundle publication is still blocked by the upstream ClawHub inspector
+  sandbox incident `openclaw/clawhub#3327`. Keep the publication and terminal
+  evidence items unchecked until the package itself is public and inspected.


### PR DESCRIPTION
## Summary

- document the public, verified `titen-memory@0.1.0` ClawHub skill as the current OpenClaw install path
- replace the not-yet-public bundle-plugin command in README with the install command that passed a real smoke
- record clean scanner/SkillSpector/VirusTotal evidence and the upstream package-inspector incident
- keep the paired spec/plan active until the exact merged bundle package is public

## Verification

- public page returns HTTP 200
- `clawhub install titen-memory` installs a byte-identical `SKILL.md`
- `clawhub skill verify titen-memory` passes
- focused plugin tests, workflow-doc checks, and diff checks pass

ClawHub applies MIT-0 to standalone skills by platform policy; Titen source and the staged bundle remain Apache-2.0.

Co-Authored-By: CADIS <agent@cadis.digital>