### PR TITLE
docs: record npm 0.3.0 release evidence

### DIFF
--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -13,10 +13,11 @@ That is npm's typosquat filter, not a name collision — `npm view titen` return
 fail at the registry after every local check has passed. The **CLI command is
 still `titen`**, because that comes from `bin`, not from the package name.
 
-Titen publishes to npm **manually, from a maintainer's machine**. There is no
-release GitHub Action and adding one is a decision, not a chore: the npm token
-would then live in repository secrets, and a compromised workflow could publish
-on its own. Publishing by hand keeps the credential on one machine.
+Titen publishes to npm **manually, from a maintainer's machine**. GitHub Actions
+is intentionally disabled so the repository incurs no hosted automation cost.
+Publishing by hand also keeps the npm credential on one machine instead of in a
+repository secret. Adding a release workflow requires a new maintainer decision
+and an explicit cost budget.
 
 ## Versioning and channels
 

--- a/docs/plans/done/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/done/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -1,20 +1,19 @@
 ---
 work_id: open-issue-sweep-and-npm-release
-status: active
-stage: implement
-outcome: pending
+status: done
+stage: done
+outcome: completed
 complexity: complex
 created: 2026-07-31
 updated: 2026-07-31
-review_after: 2026-08-14
 owner: CADIS
-spec: docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+spec: docs/specs/done/2026-07-31-open-issue-sweep-and-npm-release.md
 ---
 # Plan
 
 - [x] Capture the immutable starting inventory: local WIP/stash, remote heads,
   open issues and pull requests, tags/releases, npm metadata, and Actions state.
-- [ ] Review and integrate or explicitly supersede every remote topic branch;
+- [x] Review and integrate or explicitly supersede every remote topic branch;
   validate its completed workflow artifacts and remove only a merged branch.
 - [x] Build an issue resolution matrix, group shared root causes, and update this
   spec first if a verified issue requires scope outside its current boundaries.
@@ -25,16 +24,16 @@ spec: docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
 - [x] Run focused checks after each integration, then the complete local manual
   gate: route/workflow checks, API/integration/browser tests, package smoke,
   production dependency audit, secret scan, and `git diff --check`.
-- [ ] Resolve every starting GitHub issue with its merged evidence, exact
+- [x] Resolve every starting GitHub issue with its merged evidence, exact
   duplicate, or concrete Ponytail not-planned reason; verify zero accidental
   closures and no open pull request.
-- [ ] Finalize the changelog and smallest valid SemVer version, close this
+- [x] Finalize the changelog and smallest valid SemVer version, close this
   spec/plan pair with exact evidence, merge the reviewed release pull request,
   and verify the exact merge source before publication.
-- [ ] From a clean detached checkout of the release commit, run the irreversible
+- [x] From a clean detached checkout of the release commit, run the irreversible
   prepublish gate, publish npm manually, push the annotated tag, generate the
   GitHub release from the changelog, and smoke a clean registry install.
-- [ ] Remove only merged temporary branches/worktrees, re-audit GitHub/npm and
+- [x] Remove only merged temporary branches/worktrees, re-audit GitHub/npm and
   the preserved original checkout, then record the durable non-secret handoff.
 
 ## Issue disposition
@@ -59,7 +58,7 @@ to its merged evidence or to the concrete decision recorded here.
 | #96 | Close as duplicate of #80. |
 | #80, #81, #87, #90 | Close not planned: explicit conflict evidence, the current remote MCP boundary, full explainability, and host support remain deliberate until their recorded triggers occur. |
 | #115 | Close the in-core token-bucket proposal not planned; rate limits stay at authenticated ingress where Cloudflare and VPS controls are authoritative. |
-| #117 | Close not planned because manual npm publication and disabled GitHub Actions are an explicit project decision. |
+| #117 | Close not planned because Actions are intentionally disabled to keep the repository free of hosted automation cost; publication remains manual. |
 | #123 | Record and retain the single-process ceiling, then close worker pools/sharding until measured small-team demand breaches it. |
 | #124 | Make FULL durability explicit and retain synchronous context-run evidence; close NORMAL/async persistence as incompatible with acknowledged-write and feedback provenance requirements. |
 
@@ -98,3 +97,54 @@ rollback is a reviewed revert. After npm publish, a bad immutable artifact must
 be deprecated and replaced by a corrected patch; unpublish is not the rollback
 plan. The user's original dirty checkout is never a release source or rollback
 mechanism.
+
+## Verification evidence
+
+- Integration: PR
+  [#131](https://github.com/RamaAditya49/titen/pull/131) merged the issue
+  sweep; PR [#132](https://github.com/RamaAditya49/titen/pull/132) restored the
+  requested C.A.D.I.S credit. Their merge commits carry the required CADIS
+  trailer.
+- GitHub disposition: all 44 starting issues were closed with a merged fix,
+  duplicate/meta closure, or explicit not-planned reason. Final queries returned
+  zero open issues and zero open pull requests. The two merged remote topic
+  branches were deleted and the release audit found only `refs/heads/main`.
+- Release identity: npm `titen-memory@0.3.0`, annotated tag `v0.3.0`, and
+  [GitHub Release v0.3.0](https://github.com/RamaAditya49/titen/releases/tag/v0.3.0)
+  all identify release commit
+  `9f10bfd625ba947897056f1dbc0ab7bfc4ce6304`. Tag object
+  `7ff8b3d5a802d68e4af8403d27174824712c3f11` peels to that commit.
+- Registry identity: npm `latest` is `0.3.0`; SHA-1 is
+  `568d56175257f515ee3c79c7672d62bc39c07dda`; integrity is
+  `sha512-R49HwOllKtfn3psuNz4WBW0vVrqJteuGwjatH25djqh4RA5hqbyM5hbd+nlNFtkvlkhuAMmiXrARFodp/wTR/w==`.
+  The registry tarball contains 46 files.
+- Registry smoke: a fresh `npm install titen-memory@0.3.0` installed no runtime
+  dependency, imported `TitenClient` and `TitenError` from the root and SDK
+  subpath, explained the missing-Bun path, bootstrapped and served a schema-12
+  database, negotiated MCP revision `2025-11-25`, listed all nine tools, and
+  ran from a custom global prefix.
+- Final manual gate: D1 contract 91 passed; Bun/vector/SDK 112 passed;
+  integration 82 passed; browser 10 passed; the live dashboard adapter,
+  workflow checker/self-test (44 artifacts), 56-route checker, package smoke,
+  production audit, secret scan, and diff check passed. The first loaded-host
+  run exposed one Miniflare shim flake; isolated targeted D1 ran 30/30, a full
+  API run passed 203/203, and the final clean `pnpm test:all` passed without
+  weakening the concurrency contract or adding a retry.
+- Documentation: `https://titen.dev` and `https://cadis.digital/` returned
+  HTTP 200. The published README prominently links Titen's website, retains
+  `Built with C.A.D.I.S Agent`, and reports zero strict `seng-jelas`
+  findings.
+- Cost policy: repository Actions permission is `enabled: false` and there is
+  no workflow. Manual local gates are deliberate because the maintainer wants
+  the repository to incur no hosted automation cost.
+- Preservation: the original checkout stayed on
+  `b19bd917e6dec493261109ad1693097fbb47d7dc`; its tracked diff SHA-256 remained
+  `9a3fdfe6f36938bfed608fb30c93b37109bc13ada8f860c9c30612ab44347c88`.
+  Stash objects remained `d99c8e3a957f9e4b5d2629ad63f481f377e71421`,
+  `fd9181b0fc62221849300c85e071fe8fd7b7c547`,
+  `104a17d4e7a0d496b091c746eea7f222d77f516a`, and
+  `9f2a2fc918f5af4ba4093ba8752d8832539616be`; all five named untracked-file
+  hashes also matched the starting inventory.
+- Durable handoff: the verified release outcome and the maintainer's zero-cost
+  Actions rationale were stored in repository-scoped `mem0-coding`. No
+  credential, prompt, memory content, or raw command transcript was stored.

--- a/docs/specs/done/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/done/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -1,12 +1,11 @@
 ---
 work_id: open-issue-sweep-and-npm-release
-status: active
-stage: implement
-outcome: pending
+status: done
+stage: done
+outcome: completed
 complexity: complex
 created: 2026-07-31
 updated: 2026-07-31
-review_after: 2026-08-14
 owner: CADIS
 ---
 # Open issue sweep and npm release
@@ -38,8 +37,9 @@ documentation, and an install smoke against the immutable npm artifact.
   through a reviewed pull request or document why it is superseded before
   removing the remote branch.
 - Rewrite the public README for an international open-source audience, link
-  `https://titen.dev` prominently, preserve shipped-package link constraints,
-  and run the `seng-jelas` prose checker.
+  `https://titen.dev` prominently, retain the `Built with C.A.D.I.S Agent`
+  credit, preserve shipped-package link constraints, and run the `seng-jelas`
+  prose checker.
 - Select the smallest SemVer release justified by the merged batch, publish the
   exact verified candidate to npm, create the matching annotated tag and GitHub
   release, and smoke the registry artifact.
@@ -67,8 +67,9 @@ documentation, and an install smoke against the immutable npm artifact.
   must be packed, installed, and exercised before publication.
 - Parallel agents work in isolated worktrees and commit with the repository's
   required attribution. Integration happens once on the release branch.
-- Titen does not use GitHub Actions; issue #117 cannot override that project
-  decision without a new direct maintainer decision.
+- Titen does not use GitHub Actions so the repository incurs no hosted
+  automation cost; issue #117 cannot override that project decision without a
+  new direct maintainer decision and budget.
 - The dashboard remains synthetic where current docs say it is synthetic. A
   polished website is not runtime evidence for the memory API.
 
@@ -90,15 +91,16 @@ documentation, and an install smoke against the immutable npm artifact.
 - **AC-SWP-004 — Event-driven:** When a reader opens the repository or the npm
   package README, Titen shall present a concise English open-source entrypoint,
   a working `https://titen.dev` link, runnable installation and first-use steps,
-  truthful runtime and maturity boundaries, and absolute links for files omitted
-  from the npm tarball.
+  truthful runtime and maturity boundaries, the `Built with C.A.D.I.S Agent`
+  credit, and absolute links for files omitted from the npm tarball.
 - **AC-SWP-005 — Unwanted behavior:** If the README contains a `seng-jelas`
   strict finding, a repository-relative packaged link, or an unsupported live
   capability claim, then the release candidate shall fail its documentation or
   package gate.
 - **AC-SWP-006 — Ubiquitous:** Titen shall keep GitHub Actions disabled and
   shall perform verification, integration, publication, and release evidence
-  through the documented manual workflow.
+  through the documented manual workflow so the repository has no hosted
+  automation cost.
 - **AC-SWP-007 — Event-driven:** When the merged batch is ready to release,
   Titen shall choose the smallest SemVer bump allowed by the highest public API
   impact, move the exact `Unreleased` entries under that version, and make
@@ -125,3 +127,19 @@ match the shipped artifact; every mapped gate passes; npm `latest`, the
 annotated tag, the GitHub release, and the release commit agree; a clean install
 smoke passes; the original dirty checkout is unchanged; and this spec and its
 paired plan move to `done` with terminal evidence.
+
+## Closure evidence
+
+All 44 issues that were open at sweep start received a public resolution.
+Reviewed pull requests #131 and #132 merged the implementation and restored the
+C.A.D.I.S credit; the two merged remote topic branches were then removed. The
+release commit `9f10bfd625ba947897056f1dbc0ab7bfc4ce6304` passed the complete
+manual gate and was published as npm `titen-memory@0.3.0`, annotated tag
+`v0.3.0`, and the public GitHub release. A clean registry install exercised
+both SDK exports, the installed CLI, schema 12, all nine MCP tools, and a custom
+global npm prefix.
+
+The final GitHub audit found zero open issues, zero open pull requests, Actions
+disabled, and only `main` as a persistent remote head. The original checkout,
+tracked diff, stash objects, and five named untracked files retained their
+starting hashes.


### PR DESCRIPTION
## Summary

- move the open-issue sweep spec and plan from active to done with terminal release evidence
- record the verified npm, tag, GitHub Release, registry smoke, issue/branch, and original-checkout preservation results
- document that GitHub Actions stays disabled to keep hosted automation cost at zero

## Verification

- `pnpm check:workflow`
- `git diff --cached --check`
- npm `titen-memory@0.3.0`, tag `v0.3.0`, and GitHub Release verified live
- final issue, pull request, branch, Actions-permission, and original-checkout audits verified live
