### PR TITLE
fix: reject invalid SDK success envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,8 +313,9 @@ titen — self-hosted memory service
 
 ## Releasing
 
-Releases are cut by hand from a maintainer's machine and deliberately have no
-GitHub Action, so an npm token never lives in repository secrets. See
+Releases are cut by hand from a maintainer's machine. GitHub Actions stays
+disabled so the repository has no hosted automation cost; manual publication
+also keeps the npm token out of repository secrets. See
 [`docs/engineering/release.md`](./docs/engineering/release.md).
 
 [Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.3.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-07-31
+
+### Fixed
+
+- Successful SDK responses now reject array, `null`, and primitive JSON
+  envelopes with an `INVALID_RESPONSE` `TitenError` while preserving the HTTP
+  status, request ID, and safe response metadata.
+
 ## [0.3.0] — 2026-07-31
 
 ### Added
@@ -309,7 +317,8 @@ Releases are cut by hand from a maintainer's machine and deliberately have no
 GitHub Action, so an npm token never lives in repository secrets. See
 [`docs/engineering/release.md`](./docs/engineering/release.md).
 
-[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/RamaAditya49/titen/releases/tag/v0.3.1
 [0.3.0]: https://github.com/RamaAditya49/titen/releases/tag/v0.3.0
 [0.2.1]: https://github.com/RamaAditya49/titen/releases/tag/v0.2.1
 [0.2.0]: https://github.com/RamaAditya49/titen/releases/tag/v0.2.0

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -91,8 +91,8 @@ reaches `latest`.
 
 ## What ships
 
-`package.json#files` is an allowlist. The `0.3.0` candidate packs 46 files /
-~106 kB:
+`package.json#files` is an allowlist. The `0.3.1` candidate packs 46 files /
+108,895 bytes:
 
 | Included | Why |
 | --- | --- |

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -13,10 +13,11 @@ That is npm's typosquat filter, not a name collision — `npm view titen` return
 fail at the registry after every local check has passed. The **CLI command is
 still `titen`**, because that comes from `bin`, not from the package name.
 
-Titen publishes to npm **manually, from a maintainer's machine**. There is no
-release GitHub Action and adding one is a decision, not a chore: the npm token
-would then live in repository secrets, and a compromised workflow could publish
-on its own. Publishing by hand keeps the credential on one machine.
+Titen publishes to npm **manually, from a maintainer's machine**. GitHub Actions
+is intentionally disabled so the repository incurs no hosted automation cost.
+Publishing by hand also keeps the npm credential on one machine instead of in a
+repository secret. Adding a release workflow requires a new maintainer decision
+and an explicit cost budget.
 
 ## Versioning and channels
 

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -12,6 +12,10 @@ spec: docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
 ---
 # Plan
 
+The terminal `0.3.0` closure is withdrawn. Keep this pair active until the
+reviewed `0.3.1` artifact has complete registry, tag, release, and issue
+evidence.
+
 - [x] Capture the immutable starting inventory: local WIP/stash, remote heads,
   open issues and pull requests, tags/releases, npm metadata, and Actions state.
 - [ ] Review and integrate or explicitly supersede every remote topic branch;
@@ -20,6 +24,9 @@ spec: docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
   spec first if a verified issue requires scope outside its current boundaries.
 - [x] Land focused fixes from isolated worktrees with the smallest failing tests;
   re-run affected dual-runtime, authorization, migration, and data-loss paths.
+- [x] Reproduce issue #133, trace every typed SDK caller through
+  `requestWithMeta()`, add table-driven envelope-shape regressions, and reject
+  invalid successful JSON at that one shared boundary without retry machinery.
 - [x] Rewrite and human-review README.md, verify `titen.dev`, run `seng-jelas`
   strictly, and prove the packaged README contains only stable external links.
 - [x] Run focused checks after each integration, then the complete local manual
@@ -34,6 +41,9 @@ spec: docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
 - [ ] From a clean detached checkout of the release commit, run the irreversible
   prepublish gate, publish npm manually, push the annotated tag, generate the
   GitHub release from the changelog, and smoke a clean registry install.
+- [x] After the issue #133 fix passes focused and package gates, record it in the
+  changelog, set `package.json` to `0.3.1`, and verify the pnpm lockfile remains
+  valid and unchanged because it does not store the root package version.
 - [ ] Remove only merged temporary branches/worktrees, re-audit GitHub/npm and
   the preserved original checkout, then record the durable non-secret handoff.
 
@@ -62,6 +72,7 @@ to its merged evidence or to the concrete decision recorded here.
 | #117 | Close not planned because manual npm publication and disabled GitHub Actions are an explicit project decision. |
 | #123 | Record and retain the single-process ceiling, then close worker pools/sharding until measured small-team demand breaches it. |
 | #124 | Make FULL durability explicit and retain synchronous context-run evidence; close NORMAL/async persistence as incompatible with acknowledged-write and feedback provenance requirements. |
+| #133 | Reject non-object 2xx JSON envelopes once in `requestWithMeta()`; cover every JSON top-level shape and typed callers, then publish the compatible correction as `0.3.1`. |
 
 ## Acceptance evidence mapping
 
@@ -85,6 +96,12 @@ to its merged evidence or to the concrete decision recorded here.
   MCP negotiation, npm version, and digest evidence.
 - AC-SWP-010: before/after status, branch pointer, diff hashes, untracked hashes,
   and stash object IDs for the original checkout.
+- AC-SWP-011: table-driven SDK tests for array, `null`, string, number, boolean,
+  and valid object responses through both `requestWithMeta()` and a typed
+  convenience method, including `TitenError` status/request-ID/metadata checks.
+- AC-SWP-012: changelog and package version diff, frozen-lockfile verification,
+  focused SDK and package gates, annotated-tag peel, npm/GitHub metadata, and
+  clean `0.3.1` registry smoke against the exact reviewed source.
 
 ## Security, migration, deployment, smoke, and rollback
 

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -69,7 +69,7 @@ to its merged evidence or to the concrete decision recorded here.
 | #96 | Close as duplicate of #80. |
 | #80, #81, #87, #90 | Close not planned: explicit conflict evidence, the current remote MCP boundary, full explainability, and host support remain deliberate until their recorded triggers occur. |
 | #115 | Close the in-core token-bucket proposal not planned; rate limits stay at authenticated ingress where Cloudflare and VPS controls are authoritative. |
-| #117 | Close not planned because manual npm publication and disabled GitHub Actions are an explicit project decision. |
+| #117 | Close not planned because Actions are intentionally disabled to keep the repository free of hosted automation cost; publication remains manual. |
 | #123 | Record and retain the single-process ceiling, then close worker pools/sharding until measured small-team demand breaches it. |
 | #124 | Make FULL durability explicit and retain synchronous context-run evidence; close NORMAL/async persistence as incompatible with acknowledged-write and feedback provenance requirements. |
 | #133 | Reject non-object 2xx JSON envelopes once in `requestWithMeta()`; cover every JSON top-level shape and typed callers, then publish the compatible correction as `0.3.1`. |

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -77,8 +77,9 @@ documentation, and an install smoke against the immutable npm artifact.
   must be packed, installed, and exercised before publication.
 - Parallel agents work in isolated worktrees and commit with the repository's
   required attribution. Integration happens once on the release branch.
-- Titen does not use GitHub Actions; issue #117 cannot override that project
-  decision without a new direct maintainer decision.
+- Titen does not use GitHub Actions so the repository incurs no hosted
+  automation cost; issue #117 cannot override that project decision without a
+  new direct maintainer decision and budget.
 - The dashboard remains synthetic where current docs say it is synthetic. A
   polished website is not runtime evidence for the memory API.
 
@@ -108,7 +109,8 @@ documentation, and an install smoke against the immutable npm artifact.
   package gate.
 - **AC-SWP-006 — Ubiquitous:** Titen shall keep GitHub Actions disabled and
   shall perform verification, integration, publication, and release evidence
-  through the documented manual workflow.
+  through the documented manual workflow so the repository has no hosted
+  automation cost.
 - **AC-SWP-007 — Event-driven:** When the merged batch is ready to release,
   Titen shall choose the smallest SemVer bump allowed by the highest public API
   impact, move the exact `Unreleased` entries under that version, and make

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -19,6 +19,13 @@ package and contains an unreleased agent-distribution batch. The original local
 checkout also contains older dirty work that must not be reset, overwritten, or
 mistaken for current release source.
 
+After `titen-memory@0.3.0` was published, issue #133 demonstrated that a 2xx
+response containing valid JSON with an array or primitive top-level value is
+silently accepted as a successful SDK envelope. The correction requires the
+smallest compatible patch release, `0.3.1`. Any terminal closure drafted for
+the `0.3.0` sweep is withdrawn; this pair remains active until the patch has
+verified publication evidence.
+
 Treating every report as a feature request would add speculative machinery;
 closing every report without checking it would hide real defects. The release
 needs an issue-by-issue resolution, current branch integration, accurate public
@@ -43,6 +50,9 @@ documentation, and an install smoke against the immutable npm artifact.
 - Select the smallest SemVer release justified by the merged batch, publish the
   exact verified candidate to npm, create the matching annotated tag and GitHub
   release, and smoke the registry artifact.
+- Reject non-object successful SDK envelopes at the shared response boundary,
+  preserve diagnostic status, request ID, and safe response metadata in the
+  resulting `TitenError`, and publish the verified correction as `0.3.1`.
 - Preserve the user's dirty original checkout and existing stash byte-for-byte.
 
 ## Out of scope
@@ -115,6 +125,15 @@ documentation, and an install smoke against the immutable npm artifact.
 - **AC-SWP-010 — Ubiquitous:** Titen shall leave the original checkout's tracked
   modifications, untracked files, branch pointer, and stash unchanged throughout
   the sweep.
+- **AC-SWP-011 — Unwanted behavior:** If a 2xx SDK response contains valid JSON
+  whose top-level value is an array, `null`, string, number, or boolean, then
+  `requestWithMeta()` and typed convenience methods shall reject it with a
+  `TitenError` whose code is `INVALID_RESPONSE` and which preserves the HTTP
+  status, request ID, and any safe response metadata available at that boundary.
+- **AC-SWP-012 — Event-driven:** When the issue #133 regression evidence passes,
+  Titen shall publish the same verified source as the backward-compatible
+  `0.3.1` npm patch, annotated tag, and GitHub release; valid object envelopes
+  shall retain their current behavior.
 
 ## Done conditions
 
@@ -124,4 +143,6 @@ remain; all merged temporary branches are removed; the README and release docs
 match the shipped artifact; every mapped gate passes; npm `latest`, the
 annotated tag, the GitHub release, and the release commit agree; a clean install
 smoke passes; the original dirty checkout is unchanged; and this spec and its
-paired plan move to `done` with terminal evidence.
+paired plan move to `done` with terminal evidence. The post-release issue #133
+is resolved by the verified `0.3.1` patch rather than by altering the immutable
+`0.3.0` artifact.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titen-memory",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Collaborative memory fabric for AI agents \u2014 evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -497,9 +497,9 @@ export class TitenClient {
         "Response was not valid JSON.",
         responseRequestId(res),
       );
+    let json: unknown;
     try {
-      const json = JSON.parse(text) as { data?: T; meta?: unknown };
-      return { data: json.data as T, meta: responseMeta(res, json.meta) };
+      json = JSON.parse(text);
     } catch {
       throw new TitenError(
         res.status,
@@ -508,6 +508,15 @@ export class TitenClient {
         responseRequestId(res),
       );
     }
+    if (!isRecord(json))
+      throw new TitenError(
+        res.status,
+        "INVALID_RESPONSE",
+        "Response was not a valid object envelope.",
+        responseRequestId(res),
+        responseMeta(res),
+      );
+    return { data: json.data as T, meta: responseMeta(res, json.meta) };
   }
 
   /** Raw authenticated access for streaming/JSONL responses. */

--- a/tests/sdk/sdk.test.ts
+++ b/tests/sdk/sdk.test.ts
@@ -443,6 +443,68 @@ test("empty and non-JSON responses never leak parser or gateway details", async 
   );
 });
 
+test("successful JSON responses require an object envelope", async () => {
+  const invalid: Array<[string, unknown]> = [
+    ["array", []],
+    ["null", null],
+    ["string", "ok"],
+    ["number", 1],
+    ["boolean", true],
+  ];
+  const calls: Array<[
+    string,
+    (client: TitenClient) => Promise<unknown>,
+  ]> = [
+    ["requestWithMeta", (client) => client.requestWithMeta("GET", "/healthz")],
+    ["health", (client) => client.health()],
+  ];
+
+  for (const [shape, value] of invalid) {
+    for (const [method, call] of calls) {
+      const requestId = `req-${shape}-${method}`;
+      const client = new TitenClient({
+        url: "http://example.test",
+        key: "test",
+        fetch: async () =>
+          Response.json(value, { headers: { "x-request-id": requestId } }),
+      });
+      await assert.rejects(
+        () => call(client),
+        (error: unknown) => {
+          assert.ok(error instanceof TitenError, `${method} accepted ${shape}`);
+          assert.equal(error.code, "INVALID_RESPONSE");
+          assert.equal(error.status, 200);
+          assert.equal(error.requestId, requestId);
+          assert.deepEqual(error.meta, { request_id: requestId });
+          return true;
+        },
+      );
+    }
+  }
+
+  const client = new TitenClient({
+    url: "http://example.test",
+    key: "test",
+    fetch: async () =>
+      Response.json(
+        {
+          data: { status: "ok", runtime: "test", revision: "valid" },
+          meta: { replayed: true },
+        },
+        { headers: { "x-request-id": "req-valid" } },
+      ),
+  });
+  assert.deepEqual(await client.requestWithMeta("GET", "/healthz"), {
+    data: { status: "ok", runtime: "test", revision: "valid" },
+    meta: { replayed: true, request_id: "req-valid" },
+  });
+  assert.deepEqual(await client.health(), {
+    status: "ok",
+    runtime: "test",
+    revision: "valid",
+  });
+});
+
 test("mutation idempotency reaches the server and preserves replay semantics", async () => {
   const idempotencyKey = `sdk-retry-${crypto.randomUUID()}`;
   const observation = {


### PR DESCRIPTION
## Summary

- reject arrays, null, and primitive JSON success bodies at the shared SDK response boundary
- preserve HTTP status, request ID, and safe response metadata in INVALID_RESPONSE errors
- cover generic and typed SDK callers across every top-level JSON shape
- prepare the compatible 0.3.1 patch and record the manual zero-cost release policy

Fixes #133

## Verification

- focused regression: red on 0.3.0, green on this branch
- SDK: 15 passed
- D1 contract: 91 passed in an independent clean worktree without retry
- Bun/vector/SDK: 113 passed
- integration: 82 passed
- browser: 10 passed
- package clean-install smoke for titen-memory@0.3.1 (46 files, 108,895 bytes)
- workflow checker/self-test, 56-route check, production audit, Seng Jelas, and diff check
- src/core and src/runtime trees are identical to the 0.3.0 release; no product test was weakened and no retry was added

## Release impact

Patch: 0.3.1. Publication remains manual; GitHub Actions stays disabled to keep hosted automation cost at zero.
