### PR TITLE
fix: validate embedding provider output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+### Fixed
+
+- Bun HTTP and Cloudflare Workers AI embedding responses now require exact
+  output cardinality, ordered provider indices when present, dense configured
+  dimensions, and finite numeric coordinates before vector query or indexing.
+
 ## [0.3.1] — 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,6 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
-### Fixed
-
-- Bun HTTP and Cloudflare Workers AI embedding responses now require exact
-  output cardinality, ordered provider indices when present, dense configured
-  dimensions, and finite numeric coordinates before vector query or indexing.
-
 ## [0.3.1] — 2026-07-31
 
 ### Fixed
@@ -30,6 +24,9 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 - Successful SDK responses now reject array, `null`, and primitive JSON
   envelopes with an `INVALID_RESPONSE` `TitenError` while preserving the HTTP
   status, request ID, and safe response metadata.
+- Bun HTTP and Cloudflare Workers AI embedding responses now require exact
+  output cardinality, ordered provider indices when present, dense configured
+  dimensions, and finite numeric coordinates before vector query or indexing.
 
 ## [0.3.0] — 2026-07-31
 

--- a/docs/FRD.md
+++ b/docs/FRD.md
@@ -394,8 +394,10 @@ Required behavior:
 - repair vector mutations from a durable outbox.
 
 Current implementation note: adapters carry the configured embedding model and
-dimensions, and the Bun HTTP embedder rejects a returned vector with the wrong
-length. Titen does not yet persist or compare a complete index fingerprint.
+dimensions. Bun HTTP and Cloudflare Workers AI share validation for exact output
+cardinality, ordered provider indices when present, dense dimensions, and finite
+numeric coordinates. Titen does not yet persist or compare a complete index
+fingerprint.
 
 Proposed compatibility requirements:
 

--- a/docs/architecture/memory-lifecycle.md
+++ b/docs/architecture/memory-lifecycle.md
@@ -595,11 +595,13 @@ instead of hiding the delay.
 
 ### Proposed embedding fingerprint contract
 
-Current adapters carry a configured model identifier and dimensions. The Bun
-HTTP embedder rejects returned vectors with the wrong length, while current
-readiness reports only the generic embedder/vector capability state. Titen does
-not yet persist or compare a complete index fingerprint, probe the provider at
-startup, or fail readiness on a fingerprint mismatch.
+Current adapters carry a configured model identifier and dimensions. Bun HTTP
+and Cloudflare Workers AI share one validator for exact output cardinality,
+ordered provider indices when present, dense dimensions, and finite numeric
+coordinates. Current readiness still reports only the generic embedder/vector
+capability state. Titen does not yet persist or compare a complete index
+fingerprint, probe the provider at startup, or fail readiness on a fingerprint
+mismatch.
 
 The proposed contract binds every semantic index to a fingerprint containing at
 least:

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -27,6 +27,10 @@ evidence.
 - [x] Reproduce issue #133, trace every typed SDK caller through
   `requestWithMeta()`, add table-driven envelope-shape regressions, and reject
   invalid successful JSON at that one shared boundary without retry machinery.
+- [x] Trace every Bun HTTP and Cloudflare Workers AI embedding caller through a
+  shared output validator; reject malformed shape, cardinality, indices,
+  density, dimensions, and values before vector query/upsert, then prove outbox
+  retryability and FTS degradation behavior in both runtimes.
 - [x] Rewrite and human-review README.md, verify `titen.dev`, run `seng-jelas`
   strictly, and prove the packaged README contains only stable external links.
 - [x] Run focused checks after each integration, then the complete local manual
@@ -73,6 +77,7 @@ to its merged evidence or to the concrete decision recorded here.
 | #123 | Record and retain the single-process ceiling, then close worker pools/sharding until measured small-team demand breaches it. |
 | #124 | Make FULL durability explicit and retain synchronous context-run evidence; close NORMAL/async persistence as incompatible with acknowledged-write and feedback provenance requirements. |
 | #133 | Reject non-object 2xx JSON envelopes once in `requestWithMeta()`; cover every JSON top-level shape and typed callers, then publish the compatible correction as `0.3.1`. |
+| #137 | Validate all untrusted embedding output once in shared code; require exact cardinality, ordered unique contiguous provider indices when present, dense configured dimensions, and finite numeric coordinates before either runtime can query or mutate a vector index. |
 
 ## Acceptance evidence mapping
 
@@ -102,6 +107,10 @@ to its merged evidence or to the concrete decision recorded here.
 - AC-SWP-012: changelog and package version diff, frozen-lockfile verification,
   focused SDK and package gates, annotated-tag peel, npm/GitHub metadata, and
   clean `0.3.1` registry smoke against the exact reviewed source.
+- AC-SWP-013: table-driven shared-validator cases plus Bun HTTP and Cloudflare
+  Workers AI contract regressions for missing/extra/index/sparse/type/finite/
+  dimension failures, no vector writes, unchanged pending outbox rows,
+  sanitized `503` metadata, and successful authorized FTS-only compile.
 
 ## Security, migration, deployment, smoke, and rollback
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -283,6 +283,12 @@ store. If embedding or vector-store upsert is unavailable, the response is
 by the bounded request. No selected outbox row advances on either dependency
 failure, so the same batch can be retried after recovery.
 
+Both built-in embedding adapters require exactly one dense, configured-length
+vector per input and reject non-numeric or non-finite coordinates. Provider
+indices, when present, must be the ordered contiguous range starting at zero.
+Malformed successful provider output follows the same safe retryable embedder
+failure path before any vector upsert; canonical SQL and FTS remain available.
+
 ### `GET /v1/claims/:id/evidence`
 
 Return an authorized claim and its supporting, contradicting, and qualifying

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -26,6 +26,13 @@ smallest compatible patch release, `0.3.1`. Any terminal closure drafted for
 the `0.3.0` sweep is withdrawn; this pair remains active until the patch has
 verified publication evidence.
 
+Issue #137 subsequently demonstrated that both embedding adapters trust
+successful provider payloads too far: missing or extra outputs, invalid
+provider indices, and sparse or non-finite vectors can reach the rebuildable
+semantic-index path. The same patch candidate must reject malformed embedding
+output at one shared boundary while retaining canonical SQL, FTS, and retryable
+index work.
+
 Treating every report as a feature request would add speculative machinery;
 closing every report without checking it would hide real defects. The release
 needs an issue-by-issue resolution, current branch integration, accurate public
@@ -53,6 +60,8 @@ documentation, and an install smoke against the immutable npm artifact.
 - Reject non-object successful SDK envelopes at the shared response boundary,
   preserve diagnostic status, request ID, and safe response metadata in the
   resulting `TitenError`, and publish the verified correction as `0.3.1`.
+- Validate Bun HTTP and Cloudflare Workers AI embedding output through one
+  shared boundary before any vector query or mutation can consume it.
 - Preserve the user's dirty original checkout and existing stash byte-for-byte.
 
 ## Out of scope
@@ -136,6 +145,13 @@ documentation, and an install smoke against the immutable npm artifact.
   Titen shall publish the same verified source as the backward-compatible
   `0.3.1` npm patch, annotated tag, and GitHub release; valid object envelopes
   shall retain their current behavior.
+- **AC-SWP-013 — Unwanted behavior:** If an embedding provider returns anything
+  other than exactly one dense configured-dimension vector per input containing
+  only finite JavaScript numbers, or supplies indices that are not unique,
+  contiguous, and in input order, then the shared Bun/Cloudflare validator shall
+  reject the output as a sanitized retryable embedder dependency failure, write
+  no vector, leave selected index work pending, and keep authorized FTS recall
+  available.
 
 ## Done conditions
 
@@ -147,4 +163,5 @@ annotated tag, the GitHub release, and the release commit agree; a clean install
 smoke passes; the original dirty checkout is unchanged; and this spec and its
 paired plan move to `done` with terminal evidence. The post-release issue #133
 is resolved by the verified `0.3.1` patch rather than by altering the immutable
-`0.3.0` artifact.
+`0.3.0` artifact. Issue #137 is resolved only after malformed-output regressions
+pass against the shared validator and both runtime paths.

--- a/src/core/vectors.ts
+++ b/src/core/vectors.ts
@@ -42,6 +42,63 @@ export interface EmbeddingProvider {
   model: string;
 }
 
+function invalidEmbeddingResponse(): never {
+  throw new Error("Invalid embedding response.");
+}
+
+/** Validate untrusted provider output before it can reach a vector backend. */
+export function validateEmbeddingResponse(
+  response: unknown,
+  expectedCount: number,
+  dimensions: number,
+): Float32Array[] {
+  if (!response || typeof response !== "object" || Array.isArray(response))
+    invalidEmbeddingResponse();
+  const data = (response as { data?: unknown }).data;
+  if (!Array.isArray(data) || data.length !== expectedCount)
+    invalidEmbeddingResponse();
+
+  const indexed = data.some(
+    (entry) =>
+      entry !== null &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      Object.hasOwn(entry, "index"),
+  );
+  const vectors: Float32Array[] = [];
+  for (let position = 0; position < data.length; position += 1) {
+    if (!Object.hasOwn(data, position)) invalidEmbeddingResponse();
+    const entry = data[position];
+    let values: unknown;
+    if (Array.isArray(entry)) {
+      if (indexed) invalidEmbeddingResponse();
+      values = entry;
+    } else if (entry !== null && typeof entry === "object") {
+      if (
+        indexed &&
+        (!Object.hasOwn(entry, "index") ||
+          (entry as { index?: unknown }).index !== position)
+      )
+        invalidEmbeddingResponse();
+      values = (entry as { embedding?: unknown }).embedding;
+    } else invalidEmbeddingResponse();
+
+    if (!Array.isArray(values) || values.length !== dimensions)
+      invalidEmbeddingResponse();
+    const vector = new Float32Array(dimensions);
+    for (let coordinate = 0; coordinate < dimensions; coordinate += 1) {
+      if (!Object.hasOwn(values, coordinate)) invalidEmbeddingResponse();
+      const value = values[coordinate];
+      if (typeof value !== "number" || !Number.isFinite(value))
+        invalidEmbeddingResponse();
+      vector[coordinate] = value;
+      if (!Number.isFinite(vector[coordinate])) invalidEmbeddingResponse();
+    }
+    vectors.push(vector);
+  }
+  return vectors;
+}
+
 /**
  * The vector capability aggregates a store and an embedding provider. When
  * absent from AppContext, retrieval uses FTS5 only.

--- a/src/runtime/bun/vectors.ts
+++ b/src/runtime/bun/vectors.ts
@@ -5,6 +5,7 @@ import type {
   VectorCapability,
   VectorStore,
 } from "../../core/vectors";
+import { validateEmbeddingResponse } from "../../core/vectors";
 
 /**
  * A sqlite-vec backed vector store.
@@ -145,15 +146,11 @@ export function createHttpEmbedder(config: {
         body: JSON.stringify({ model: config.model, input: texts }),
       });
       if (!res.ok) throw new Error(`embedding request failed: ${res.status}`);
-      const json = (await res.json()) as { data: { embedding: number[] }[] };
-      const vectors = json.data.map((entry) => new Float32Array(entry.embedding));
-      // A dimension mismatch silently ruins retrieval quality, so fail loudly.
-      for (const vector of vectors)
-        if (vector.length !== config.dimensions)
-          throw new Error(
-            `embedding dimension mismatch: expected ${config.dimensions}, got ${vector.length}`,
-          );
-      return vectors;
+      return validateEmbeddingResponse(
+        await res.json(),
+        texts.length,
+        config.dimensions,
+      );
     },
   };
 }

--- a/src/runtime/cloudflare/vectors.ts
+++ b/src/runtime/cloudflare/vectors.ts
@@ -1,3 +1,4 @@
+import { validateEmbeddingResponse } from "../../core/vectors";
 import type { VectorStore, VectorMatch, EmbeddingProvider, VectorCapability } from "../../core/vectors";
 
 /** Minimal Vectorize binding interface (no @cloudflare/workers-types needed). */
@@ -9,7 +10,7 @@ export interface VectorizeIndex {
 
 /** Minimal Workers AI binding interface. */
 export interface AiBinding {
-  run(model: string, input: { text: string[] }): Promise<{ data: number[][] }>;
+  run(model: string, input: { text: string[] }): Promise<unknown>;
 }
 
 export function createVectorizeStore(index: VectorizeIndex): VectorStore {
@@ -40,7 +41,7 @@ export function createWorkersAiEmbedder(ai: AiBinding, model: string, dimensions
     model,
     async embed(texts) {
       const result = await ai.run(model, { text: texts });
-      return result.data.map(d => new Float32Array(d));
+      return validateEmbeddingResponse(result, texts.length, dimensions);
     },
   };
 }

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -1,0 +1,247 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../../src/core/app";
+import { migrate } from "../../src/core/migrations";
+import {
+  validateEmbeddingResponse,
+  type EmbeddingProvider,
+  type VectorStore,
+} from "../../src/core/vectors";
+import { createHttpEmbedder } from "../../src/runtime/bun/vectors";
+import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
+import { createWorkersAiEmbedder } from "../../src/runtime/cloudflare/vectors";
+import { clientVia, provisionWith } from "../contract/harness";
+
+const dimensions = 4;
+const dense = () => [1, 0, 0, 0];
+const sparse = () => {
+  const values = dense();
+  delete values[1];
+  return values;
+};
+
+const invalid = [
+  ["null response", () => null, 1],
+  ["missing data", () => ({}), 1],
+  ["missing output", () => ({ data: [] }), 1],
+  ["extra output", () => ({ data: [dense(), dense()] }), 1],
+  ["sparse output list", () => ({ data: Array(1) }), 1],
+  ["sparse vector", () => ({ data: [sparse()] }), 1],
+  ["null coordinate", () => ({ data: [[1, null, 0, 0]] }), 1],
+  ["string coordinate", () => ({ data: [[1, "0", 0, 0]] }), 1],
+  ["NaN coordinate", () => ({ data: [[1, Number.NaN, 0, 0]] }), 1],
+  ["infinite coordinate", () => ({ data: [[1, Number.POSITIVE_INFINITY, 0, 0]] }), 1],
+  ["float32 overflow", () => ({ data: [[1, Number.MAX_VALUE, 0, 0]] }), 1],
+  ["wrong dimensions", () => ({ data: [[1, 0]] }), 1],
+  [
+    "missing provider index",
+    () => ({
+      data: [
+        { index: 0, embedding: dense() },
+        { embedding: dense() },
+      ],
+    }),
+    2,
+  ],
+  [
+    "duplicate provider index",
+    () => ({
+      data: [
+        { index: 0, embedding: dense() },
+        { index: 0, embedding: dense() },
+      ],
+    }),
+    2,
+  ],
+  [
+    "non-contiguous provider index",
+    () => ({
+      data: [
+        { index: 0, embedding: dense() },
+        { index: 2, embedding: dense() },
+      ],
+    }),
+    2,
+  ],
+  [
+    "out-of-order provider indices",
+    () => ({
+      data: [
+        { index: 1, embedding: dense() },
+        { index: 0, embedding: dense() },
+      ],
+    }),
+    2,
+  ],
+] as const;
+
+for (const [name, response, expectedCount] of invalid)
+  test(`shared embedding validator rejects ${name}`, () => {
+    assert.throws(
+      () => validateEmbeddingResponse(response(), expectedCount, dimensions),
+      /^Error: Invalid embedding response\.$/,
+    );
+  });
+
+test("shared embedding validator accepts both provider shapes in input order", () => {
+  assert.deepEqual(
+    validateEmbeddingResponse({ data: [dense(), dense()] }, 2, dimensions),
+    [new Float32Array(dense()), new Float32Array(dense())],
+  );
+  assert.deepEqual(
+    validateEmbeddingResponse(
+      {
+        data: [
+          { index: 0, embedding: dense() },
+          { index: 1, embedding: dense() },
+        ],
+      },
+      2,
+      dimensions,
+    ),
+    [new Float32Array(dense()), new Float32Array(dense())],
+  );
+});
+
+const adapters: {
+  name: string;
+  create: () => { embedder: EmbeddingProvider; close: () => void | Promise<void> };
+}[] = [
+  {
+    name: "Bun HTTP",
+    create() {
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: () => Response.json({ data: [] }),
+      });
+      return {
+        embedder: createHttpEmbedder({
+          baseUrl: `http://127.0.0.1:${server.port}/v1`,
+          model: "malformed",
+          dimensions,
+        }),
+        close: () => server.stop(true),
+      };
+    },
+  },
+  {
+    name: "Cloudflare Workers AI",
+    create: () => ({
+      embedder: createWorkersAiEmbedder(
+        { run: async () => ({ data: [] }) },
+        "malformed",
+        dimensions,
+      ),
+      close: () => {},
+    }),
+  },
+];
+
+for (const adapter of adapters)
+  test(`${adapter.name} malformed output stays retryable and degrades to FTS`, async () => {
+    const directory = mkdtempSync(join(tmpdir(), "titen-embed-validation-"));
+    const handle = openDatabase(join(directory, "titen.db"));
+    const db = createSqliteDb(handle);
+    const { embedder, close } = adapter.create();
+    let vectorWrites = 0;
+    let vectorQueries = 0;
+    const store: VectorStore = {
+      async upsert() {
+        vectorWrites += 1;
+      },
+      async query() {
+        vectorQueries += 1;
+        return [];
+      },
+      async remove() {},
+    };
+
+    try {
+      await migrate(db);
+      const provisioned = await provisionWith(db, { scopes: ["*"] });
+      const client = clientVia(
+        createApp({
+          db,
+          revision: "embedding-validation",
+          runtime: adapter.name,
+          vectors: { store, embedder },
+        }),
+        "http://titen.test",
+      );
+      const subjectId = `subject_${adapter.name.replaceAll(" ", "_").toLowerCase()}`;
+      const statement = "Malformed embedding output must preserve lexical recall.";
+      const observation = await client.call("POST", "/v1/observations", {
+        key: provisioned.key,
+        body: {
+          subject_id: subjectId,
+          kind: "tool_result",
+          content: statement,
+          source: { type: "tool", ref: "embedding-validation" },
+          trust: "verified",
+        },
+      });
+      assert.equal(observation.status, 201);
+      const consolidation = await client.call("POST", "/v1/consolidations", {
+        key: provisioned.key,
+        body: {
+          subject_id: subjectId,
+          claims: [
+            {
+              kind: "procedural",
+              statement,
+              sources: [
+                {
+                  observation_id: observation.body.data.observation_id,
+                  relation: "supports",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      assert.equal(consolidation.status, 201);
+      const claimId = consolidation.body.data.claims[0].claim_id as string;
+      const pending = async () =>
+        Number(
+          (
+            await db.all<{ count: number }>(
+              `SELECT COUNT(*) AS count FROM index_outbox WHERE state = 'pending'`,
+            )
+          )[0]!.count,
+        );
+      const before = await pending();
+
+      const failed = await client.call("POST", "/v1/index/drain", {
+        key: provisioned.key,
+      });
+      assert.equal(failed.status, 503);
+      assert.equal(failed.body.error.code, "UNAVAILABLE");
+      assert.equal(failed.body.error.message, "Indexing dependency is unavailable.");
+      assert.equal(failed.body.meta.dependency, "embedder");
+      assert.equal(failed.body.meta.retryable, true);
+      assert.equal(failed.body.meta.pending, before);
+      assert.doesNotMatch(JSON.stringify(failed.body), /Invalid embedding response/);
+      assert.equal(await pending(), before);
+      assert.equal(vectorWrites, 0);
+
+      const compiled = await client.call("POST", "/v1/context/compile", {
+        key: provisioned.key,
+        body: { subject_id: subjectId, task: statement, max_tokens: 900 },
+      });
+      assert.equal(compiled.status, 200);
+      assert.equal(compiled.body.meta.degraded.vector, "error");
+      assert.ok(
+        compiled.body.data.items.some((item: { claim_id: string }) => item.claim_id === claimId),
+      );
+      assert.equal(vectorQueries, 0);
+      assert.equal(vectorWrites, 0);
+    } finally {
+      await close();
+      handle.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -108,15 +108,18 @@ test("shared embedding validator accepts both provider shapes in input order", (
 
 const adapters: {
   name: string;
-  create: () => { embedder: EmbeddingProvider; close: () => void | Promise<void> };
+  create: (response: unknown) => {
+    embedder: EmbeddingProvider;
+    close: () => void | Promise<void>;
+  };
 }[] = [
   {
     name: "Bun HTTP",
-    create() {
+    create(response) {
       const server = Bun.serve({
         port: 0,
         hostname: "127.0.0.1",
-        fetch: () => Response.json({ data: [] }),
+        fetch: () => Response.json(response),
       });
       return {
         embedder: createHttpEmbedder({
@@ -130,9 +133,9 @@ const adapters: {
   },
   {
     name: "Cloudflare Workers AI",
-    create: () => ({
+    create: (response) => ({
       embedder: createWorkersAiEmbedder(
-        { run: async () => ({ data: [] }) },
+        { run: async () => response },
         "malformed",
         dimensions,
       ),
@@ -142,11 +145,28 @@ const adapters: {
 ];
 
 for (const adapter of adapters)
+  for (const [name, response, expectedCount] of invalid)
+    test(`${adapter.name} rejects ${name}`, async () => {
+      const { embedder, close } = adapter.create(response());
+      try {
+        await assert.rejects(
+          () =>
+            embedder.embed(
+              Array.from({ length: expectedCount }, () => "input"),
+            ),
+          /^Error: Invalid embedding response\.$/,
+        );
+      } finally {
+        await close();
+      }
+    });
+
+for (const adapter of adapters)
   test(`${adapter.name} malformed output stays retryable and degrades to FTS`, async () => {
     const directory = mkdtempSync(join(tmpdir(), "titen-embed-validation-"));
     const handle = openDatabase(join(directory, "titen.db"));
     const db = createSqliteDb(handle);
-    const { embedder, close } = adapter.create();
+    const { embedder, close } = adapter.create({ data: [] });
     let vectorWrites = 0;
     let vectorQueries = 0;
     const store: VectorStore = {

--- a/tests/integration/sqlite-vec.test.ts
+++ b/tests/integration/sqlite-vec.test.ts
@@ -149,7 +149,7 @@ test("an embedder whose dimensions disagree fails loudly", async () => {
   });
   await assert.rejects(
     () => embedder.embed(["anything"]),
-    /dimension mismatch: expected 4, got 2/,
+    /Invalid embedding response/,
   );
   server.stop(true);
 });


### PR DESCRIPTION
## Summary

- validate untrusted embedding output once before either runtime can query or mutate a vector backend
- require exact cardinality, dense configured dimensions, finite f32 coordinates, and ordered contiguous provider indices when present
- keep failed indexing pending with a sanitized retryable error while authorized FTS recall remains usable
- cover the full malformed matrix through both Bun HTTP and Cloudflare Workers AI adapters

Fixes #137

## Verification

- full malformed adapter matrix: 51 passed
- D1 contract: 91 passed
- Bun/core/SDK: 113 passed
- integration: 101 passed
- workflow checker/self-test: 46 artifacts
- route docs: 56 routes
- no dependency, provider factory, retry wrapper, or runtime-specific semantic rule added

GitHub Actions remains disabled; all gates are manual to keep hosted automation cost at zero.
