### PR TITLE
fix: fail semantic readiness closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 - Bun HTTP and Cloudflare Workers AI embedding responses now require exact
   output cardinality, ordered provider indices when present, dense configured
   dimensions, and finite numeric coordinates before vector query or indexing.
+- Semantic readiness now distinguishes intentional FTS-only operation from
+  partial configuration, unavailable vector initialization, legacy untracked
+  vectors, missing requeue work, unsafe storage aliasing, empty restored
+  projections, and incompatible fingerprints; configured failures return a
+  fixed local diagnostic without probing providers.
+
+### Changed
+
+- Capability contract version 1 reports embedding, extraction, and background
+  enrichment separately while retaining `model` as a deprecated `0.3.x`
+  embedding alias. Migration 13 persists the claim-index provider, model,
+  revision, dimensions, metric, preprocessing, and schema fingerprint and
+  requires an explicit reindex after incompatibility.
+- `sqlite-vec@0.1.9` is a pinned optional peer: default installs remain
+  dependency-light while the documented vector install is machine-verifiable.
 
 ## [0.3.0] — 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ The default listener is `http://127.0.0.1:8787`. Check it from another shell:
 curl http://127.0.0.1:8787/readyz
 ```
 
+The default install is FTS-only. A Bun vector deployment must explicitly add
+`sqlite-vec@0.1.9`; configured semantic retrieval fails readiness if the native
+extension or stored index fingerprint is incompatible.
+
+```bash
+bun add titen-memory sqlite-vec@0.1.9
+
+TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1 \
+TITEN_EMBED_MODEL=embeddinggemma \
+TITEN_EMBED_DIMS=768 \
+TITEN_EMBED_REVISION=local-pinned \
+bunx titen-memory serve
+```
+
+The packaged vector path is verified on glibc Linux x64 with Bun 1.3.13.
+Other `sqlite-vec` prebuilt platforms need the same local ready/drain/query
+smoke before production use.
+
 For a durable host setup, backups, key rotation, and optional vector retrieval,
 use the [Bun/VPS deployment guide](https://github.com/RamaAditya49/titen/blob/main/docs/deployment/vps.md).
 

--- a/docs/FRD.md
+++ b/docs/FRD.md
@@ -162,20 +162,19 @@ Implemented P0 behavior:
 - `GET /healthz` reports process liveness without sensitive details;
 - `GET /readyz` checks migrations, canonical SQL, and signing-secret
   decryptability;
-- readiness reports FTS, vector, the embedder under the legacy `model` name,
-  background-repair freshness, and export/import capability;
-- readiness performs no provider or vector-index network probe and does not
-  persist or compare a full embedding fingerprint;
+- readiness capability contract version 1 reports FTS, vector, embedding,
+  extraction, background enrichment, background-repair freshness, and
+  export/import state; the legacy `model` field aliases embedding for `0.3.x`;
+- readiness performs no provider or vector-index network probe, persists the
+  configured semantic fingerprint locally, and fails semantic readiness on
+  invalid configuration, vector initialization failure, missing legacy
+  fingerprint evidence, or fingerprint mismatch;
 - responses include a non-secret request ID and deployed revision/build value.
 
-Proposed readiness extensions (unimplemented):
+Remaining proposed readiness extensions:
 
-- replace the ambiguous `model` field with separate embedding, extraction, and
-  background-enrichment capability/degradation states;
 - when channel serving is enabled, readiness also checks release FTS schema and
   configured customer-assertion issuer/key references without exposing them;
-- persist an embedding/index compatibility fingerprint and fail semantic
-  readiness when it mismatches the configured index;
 - a transient optional embedding/vector/extraction outage is visible under its
   own capability while canonical FTS-only operation remains available.
 
@@ -184,8 +183,8 @@ Acceptance:
 - a missing canonical database or pending incompatible migration fails ready;
 - a disabled vector capability does not prevent observation and FTS context;
 - health output contains no key, content, prompt, embedding, or private ID;
-- the proposed fingerprint gate needs dual-runtime contract evidence before it
-  may be described as implemented.
+- a configured semantic mismatch returns `configured_error` with a fixed local
+  diagnostic and no provider call on both runtime adapters.
 
 ### FND-003 — Scoped credential verification
 
@@ -396,10 +395,10 @@ Required behavior:
 Current implementation note: adapters carry the configured embedding model and
 dimensions. Bun HTTP and Cloudflare Workers AI share validation for exact output
 cardinality, ordered provider indices when present, dense dimensions, and finite
-numeric coordinates. Titen does not yet persist or compare a complete index
-fingerprint.
+numeric coordinates. Titen persists and compares the configured semantic index
+fingerprint before exposing vector retrieval.
 
-Proposed compatibility requirements:
+Implemented compatibility requirements:
 
 - persist provider/model, dimensions, distance metric, normalization,
   preprocessing/template, and semantic-unit schema as a versioned fingerprint;
@@ -411,8 +410,7 @@ Acceptance:
 - FTS-only mode returns relevant results without a model/vector service;
 - vector outage cannot lose writes or bypass authorization;
 - stale vector records never return canonical content;
-- the proposed fingerprint mismatch gate passes on both runtime adapters before
-  it is reported as shipped.
+- the fingerprint mismatch gate passes on both runtime adapters.
 
 ### CTX-001 — Compile a bounded context pack
 
@@ -538,7 +536,7 @@ Required behavior:
 - make import idempotent and reject unknown incompatible versions;
 - require explicit authorized destination scope mapping;
 - rebuild FTS and enqueue optional vector re-indexing using the destination's
-  configured embedder; the complete destination fingerprint gate is proposed;
+  configured embedder and verified destination fingerprint;
 - preserve conflicts and history rather than last-write-wins replacement;
 - when v0.3 channel schemas are enabled, export channel/release snapshots and
   lifecycle history but no gateway credential or assertion-verification secret;

--- a/docs/architecture/memory-lifecycle.md
+++ b/docs/architecture/memory-lifecycle.md
@@ -531,8 +531,9 @@ Vectorize insert and upsert visibility is asynchronous. Titen therefore treats
 mutation acceptance as pending index work, uses an outbox and bounded repair,
 and never makes Vectorize the canonical record.
 
-The current adapter does not persist a complete embedding fingerprint or
-compare one during readiness; that remains the proposed contract below.
+The adapter persists and compares the configured embedding/index fingerprint in
+D1 before exposing Vectorize. Readiness inspects only local binding shape and D1
+metadata; it does not call Workers AI or Vectorize.
 
 ### Lightweight VPS path
 
@@ -593,42 +594,39 @@ that an observation is not context-eligible until a direct or derived claim
 exists. The proposed enrichment API must expose that pending state honestly
 instead of hiding the delay.
 
-### Proposed embedding fingerprint contract
+### Embedding fingerprint contract
 
 Current adapters carry a configured model identifier and dimensions. Bun HTTP
 and Cloudflare Workers AI share one validator for exact output cardinality,
 ordered provider indices when present, dense dimensions, and finite numeric
-coordinates. Current readiness still reports only the generic embedder/vector
-capability state. Titen does not yet persist or compare a complete index
-fingerprint, probe the provider at startup, or fail readiness on a fingerprint
-mismatch.
+coordinates. Capability contract version 1 reports embedding separately from
+planned extraction/background enrichment, and the deprecated `model` field
+mirrors embedding for `0.3.x` compatibility.
 
-The proposed contract binds every semantic index to a fingerprint containing at
-least:
+Every semantic index is bound to a fingerprint containing:
 
 - provider and model identifier;
 - immutable revision when available;
 - output dimensions;
 - distance metric;
-- normalization and preprocessing version;
-- text-format/template version;
+- preprocessing version, including normalization and text formatting;
 - Titen semantic-unit schema version.
 
-Once implemented, startup and provisioning probe the configured model output
-and compare the persisted contract with the index. Titen will not pad or
-truncate mismatched vectors. Changing the fingerprint will require an explicit
-re-index and will fail semantic readiness until compatibility is restored.
+Startup compares the locally configured contract with migration-13 metadata
+without a provider request. Titen does not pad or truncate mismatched vectors.
+Changing the fingerprint requires an explicit re-index and fails semantic
+readiness until the vector backend is rebuilt, metadata is reset, and claim
+index work is requeued.
 
-Canonical export excludes embeddings by default. A destination currently
-rebuilds its semantic projection with its configured embedder; under the
-proposed contract it also declares and verifies the complete fingerprint.
-Changing providers can change retrieval scores without changing evidence,
-claims, or record IDs.
+Canonical export excludes embeddings by default. A destination rebuilds its
+semantic projection only with a declared, verified fingerprint. Changing
+providers can change retrieval scores without changing evidence, claims, or
+record IDs.
 
 The dated pilot found that `embeddinggemma` retrieved all 24 small multilingual
 gold targets within top five, but that synthetic result is not a permanent
-default, production threshold, or implementation evidence for the fingerprint
-gate. A production evaluation must record the available provider/model revision,
+default, production threshold, or provider-reachability evidence. A production
+evaluation must record the available provider/model revision,
 dimensions, preprocessing contract, and index configuration.
 
 ### Hybrid retrieval
@@ -722,9 +720,9 @@ or returns worse useful context is a failed benchmark.
 
 - “Works without embeddings” means canonical writes, FTS recall, context
   compilation, feedback, and collaboration primitives remain functional.
-- “Semantic retrieval enabled” currently names the configured model,
-  dimensions, and vector backend; after the proposed fingerprint gate ships, it
-  names the complete verified fingerprint.
+- “Semantic retrieval enabled” names a locally initialized vector backend whose
+  complete configured fingerprint matches migration-13 metadata; it does not
+  prove provider reachability until real indexing/query evidence exists.
 - “Faster” names the workload, comparison lane, dataset, p95/p99, quality floor,
   and raw results.
 - “More effective” requires downstream task or useful-context evidence.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -110,8 +110,9 @@ planned.
 
 Automatic model-assisted derivation/reflection is also planned. Current
 maintenance drains claim indexing and delivery work only; it does not classify
-observations. `capabilities.model` in the current implementation describes the
-embedder and must not be read as extraction readiness.
+observations. Capability contract version 1 reports `embedding`, `extraction`,
+and `background_enrichment` separately. Deprecated `capabilities.model` mirrors
+embedding for `0.3.x` compatibility and must not be read as extraction readiness.
 
 ## Write path
 

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -107,7 +107,32 @@ Cron binding, so those capabilities are not active by default or live-verified.
 - **Channel serving** — CRM/chatbot gateway via scoped service credential.
 - **Memory Atlas** — read-only browser client against authenticated REST.
 
-Readiness and `/healthz` will report when optional capabilities are unavailable.
+With no AI/Vectorize binding or embedding variables, the Worker remains ready
+in intentional FTS-only mode. Semantic opt-in requires both native bindings and
+a valid local contract. Configure `TITEN_EMBED_MODEL`, `TITEN_EMBED_DIMS`, and,
+when the provider exposes one, `TITEN_EMBED_REVISION`; the bound Vectorize index
+must use the same dimensions and cosine metric. A partial binding/variable set,
+invalid dimension, or binding object without the required methods returns
+`configured_error` and fails `/readyz`.
+
+Migration 13 persists provider `workers-ai`, model, revision, dimensions,
+cosine metric, preprocessing `text-v1`, and index schema `claims-scope-v1` in
+D1. Readiness compares those local facts without calling Workers AI or
+Vectorize. `enabled` is therefore not provider-reachability evidence; a real
+index drain/query smoke supplies that evidence.
+
+Changing any fingerprint field requires an explicit reindex. Provision a fresh
+compatible Vectorize index (or clear the rebuildable old projection), stop
+index maintenance, then reset only the D1 projection metadata/work:
+
+```bash
+wrangler d1 execute titen --remote --command \
+  "DELETE FROM semantic_index_metadata WHERE id = 'claims'; UPDATE index_outbox SET state = 'pending', attempts = 0 WHERE record_type = 'claim'; INSERT INTO index_outbox (id, org_id, record_type, record_id, operation, state, attempts, created_at) SELECT 'obx_' || lower(hex(randomblob(16))), c.org_id, 'claim', c.id, 'upsert', 'pending', 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now') FROM claims c WHERE c.status IN ('active', 'disputed') AND NOT EXISTS (SELECT 1 FROM index_outbox o WHERE o.record_type = 'claim' AND o.record_id = c.id AND o.operation = 'upsert');"
+```
+
+Bind the intended index, deploy, require `/readyz`, and drain the pending claim
+work before declaring semantic retrieval operational. Never reset canonical
+claims or observations for a reindex.
 
 ADR-0004's model-assisted target adds a separate leased D1 enrichment job. A
 Cron Trigger drains it in bounded passes and is the durability guarantee.

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -116,6 +116,7 @@ TITEN_VEC_DB_PATH=/var/lib/titen/titen.db.vec
 TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1
 TITEN_EMBED_MODEL=bge-m3
 TITEN_EMBED_DIMS=1024
+TITEN_EMBED_REVISION=<immutable-provider-revision>
 TITEN_MAINTENANCE_INTERVAL_MS=15000
 TITEN_SECRET_KEYS={"active":"v1","keys":{"v1":"<32-byte-base64url-key>"}}
 TITEN_WEBHOOK_ALLOWED_HOSTNAMES=hooks.example.com
@@ -124,6 +125,11 @@ TITEN_WEBHOOK_ALLOWED_HOSTNAMES=hooks.example.com
 Embedding variables are optional. Observations and lexical context work without
 them. Put `TITEN_EMBED_API_KEY` only in the mode-`0600` service environment; it
 is required only when the configured embedder requires bearer authentication.
+Base URL, model, and dimensions form one opt-in tuple. Supplying only part of
+that tuple, or supplying API-key/revision settings without it, returns
+`configured_error` and makes `/readyz` fail. If no immutable revision is
+available, omit `TITEN_EMBED_REVISION`; Titen records `unspecified`, and adding a
+revision later intentionally requires a reindex.
 
 The ADR-0004 implementation will add a separate opt-in tuple such as
 `TITEN_EXTRACT_BASE_URL`, `TITEN_EXTRACT_MODEL`, and
@@ -164,6 +170,48 @@ VPS:
 bun add titen-memory sqlite-vec@0.1.9
 ```
 
+With no embedding tuple and no `sqlite-vec`, an SDK/default install remains a
+ready FTS-only deployment. Once the tuple is present, `sqlite-vec@0.1.9`, a
+writable vector database, and the expected `vec_claims` schema are required;
+failure is `503 NOT_READY`, never a silent fallback.
+
+### Explicit semantic reindex
+
+Migration 13 binds the claim-vector projection to provider, model, revision,
+dimensions, L2 metric, preprocessing `text-v1`, and index schema
+`claims-scope-v1`. A missing legacy fingerprint or any change fails readiness.
+Titen never rewrites this metadata or deletes vectors automatically.
+
+To adopt a new fingerprint, stop Titen, take a verified canonical backup, then
+reset only the rebuildable projection and requeue claim index work:
+
+```bash
+rm /var/lib/titen/titen.db.vec
+sqlite3 /var/lib/titen/titen.db <<'SQL'
+BEGIN IMMEDIATE;
+DELETE FROM semantic_index_metadata WHERE id = 'claims';
+UPDATE index_outbox SET state = 'pending', attempts = 0
+ WHERE record_type = 'claim';
+INSERT INTO index_outbox
+  (id, org_id, record_type, record_id, operation, state, attempts, created_at)
+SELECT 'obx_' || lower(hex(randomblob(16))), c.org_id, 'claim', c.id,
+       'upsert', 'pending', 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  FROM claims c
+ WHERE c.status IN ('active', 'disputed')
+   AND NOT EXISTS (
+     SELECT 1 FROM index_outbox o
+      WHERE o.record_type = 'claim' AND o.record_id = c.id
+        AND o.operation = 'upsert'
+   );
+COMMIT;
+SQL
+```
+
+Replace the vector path with the exact configured `TITEN_VEC_DB_PATH`; never
+remove the canonical database. Start Titen with the intended tuple, require
+`/readyz`, then let maintenance drain or call `POST /v1/index/drain`. Provider
+reachability is proved by that real drain/query evidence, not by readiness.
+
 ## Container install (verified)
 
 Optional. The service runs fine directly under Bun; this exists so a deployment
@@ -194,9 +242,10 @@ Two things that will bite otherwise:
 
 - **The base image must use glibc.** `sqlite-vec` ships a glibc-linked prebuilt
   binary; on Alpine it fails to load with `__memcpy_chk: symbol not found`. An
-  Alpine image still starts and serves, it just loses vector retrieval silently.
-  The current audited Debian image is about 239 MB. Treat this as measured
-  evidence, not a fixed resource limit.
+  Alpine image may still answer `/healthz`, but a configured semantic deployment
+  now fails `/readyz` with `vector_initialization_failed`. The current audited
+  Debian image is about 239 MB. Treat this as measured evidence, not a fixed
+  resource limit.
 - **Podman builds OCI images, which ignore `HEALTHCHECK`.** Use
   `podman build --format docker` if you want it honoured, or rely on an external
   probe against `/healthz`.
@@ -342,7 +391,11 @@ code.
   failure leaves an existing output untouched and prints no internal stack.
 - Do not copy a live WAL database file. Keep timestamped snapshots and an
   independently verified checksum outside the service state directory.
-- Vector indexes are rebuildable and do not block canonical restore.
+- Vector indexes are rebuildable and do not block canonical restore. The
+  canonical snapshot does not contain `TITEN_VEC_DB_PATH`; after restoring it
+  without the matching vector file, run the explicit semantic reindex above
+  before returning semantic traffic. Readiness rejects a newly created empty
+  projection paired with restored fingerprint metadata.
 - Before an upgrade, run
   `bunx titen-memory migrate --db /var/lib/titen/titen.db --dry-run`; it prints
   pending forward-only SQL without creating or changing the database. Take the

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -105,11 +105,12 @@ reaches `latest`.
 Not shipped: the Astro dashboard (`src/pages`, `src/styles`), the Cloudflare
 adapter (deploy that from a clone with `wrangler`), tests, and docs.
 
-SDK and lexical-only server consumers install only `titen-memory`. A
-vector-enabled VPS explicitly installs `sqlite-vec`, which brings its platform
-binary. The repository retains `sqlite-vec` as a devDependency for integration
-tests. `astro`, `wrangler`, `playwright`, and `miniflare` remain development-only;
-none belongs on a consumer's disk.
+SDK and lexical-only server consumers install only `titen-memory`. The manifest
+declares pinned `sqlite-vec@0.1.9` as an optional peer; a vector-enabled VPS
+installs it explicitly, which brings its platform binary. The repository also
+retains it as a devDependency for integration tests. `astro`, `wrangler`,
+`playwright`, and `miniflare` remain development-only; none belongs on a
+consumer's disk.
 
 ## Publishing
 

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -31,6 +31,31 @@ evidence.
   shared output validator; reject malformed shape, cardinality, indices,
   density, dimensions, and values before vector query/upsert, then prove outbox
   retryability and FTS degradation behavior in both runtimes.
+- [x] Trace semantic configuration, vector initialization, index metadata,
+  readiness, and maintenance through both runtime adapters; add migration 13
+  for the minimal index fingerprint and fail configured semantic startup closed
+  without adding provider probes or abstractions.
+- [x] Bind Bun fingerprints to the normalized endpoint without storing topology,
+  reject canonical/vector path aliasing before extension mutation, and fail
+  readiness closed when historical indexable claims lack requeue work.
+- [x] Require the existing `vec_claims` object to be a `vec0` virtual table with
+  the configured dimensions and scope columns; reject plain or wrong-module
+  lookalikes before reporting vector readiness.
+- [x] Validate a supplied capability's fingerprint model/dimensions against its
+  attached embedder before persisting metadata or reporting readiness.
+- [x] Extend the explicit reindex commands to insert missing active/disputed
+  claim work, then prove the guard and recovery through both runtime contracts.
+- [x] Fail local readiness when restored canonical fingerprint metadata meets a
+  newly created empty Bun vector projection; document and test the required
+  projection reset/requeue after canonical-only restore.
+- [x] Add focused FTS-only, clean-install, configured-error, healthy semantic,
+  and fingerprint-mismatch regressions; document `sqlite-vec@0.1.9` and the
+  versioned capability/readiness contract.
+- [x] From the clean packed consumer used by the release verifier, install the
+  exact documented `sqlite-vec@0.1.9` extra and prove `/readyz` changes from the
+  missing-dependency failure to healthy vector/embedding capability state.
+- [x] Declare `sqlite-vec@0.1.9` as an optional peer, then prove package-manager
+  metadata does not pull it into the default production install.
 - [x] Rewrite and human-review README.md, verify `titen.dev`, run `seng-jelas`
   strictly, and prove the packaged README contains only stable external links.
 - [x] Run focused checks after each integration, then the complete local manual
@@ -78,6 +103,8 @@ to its merged evidence or to the concrete decision recorded here.
 | #124 | Make FULL durability explicit and retain synchronous context-run evidence; close NORMAL/async persistence as incompatible with acknowledged-write and feedback provenance requirements. |
 | #133 | Reject non-object 2xx JSON envelopes once in `requestWithMeta()`; cover every JSON top-level shape and typed callers, then publish the compatible correction as `0.3.1`. |
 | #137 | Validate all untrusted embedding output once in shared code; require exact cardinality, ordered unique contiguous provider indices when present, dense configured dimensions, and finite numeric coordinates before either runtime can query or mutate a vector index. |
+| #138 | Distinguish intentional FTS-only operation from configured semantic failure; persist/compare the migration-13 index fingerprint, fail local readiness closed on incompatible or unavailable vector state, and expose separate embedding/extraction/background capability fields without implementing planned enrichment. |
+| #140 | Keep the default package dependency-free, publish one explicit `sqlite-vec@0.1.9` install command, and exercise both missing-dependency failure and vector-ready success from the clean packed consumer. |
 
 ## Acceptance evidence mapping
 
@@ -111,6 +138,23 @@ to its merged evidence or to the concrete decision recorded here.
   Workers AI contract regressions for missing/extra/index/sparse/type/finite/
   dimension failures, no vector writes, unchanged pending outbox rows,
   sanitized `503` metadata, and successful authorized FTS-only compile.
+- AC-SWP-014: dual-runtime FTS-only readiness tests plus a clean production
+  install without `sqlite-vec` or semantic configuration.
+- AC-SWP-015: table-driven partial/invalid configuration, missing
+  extension/backend/schema, and fingerprint-mismatch readiness tests with
+  sanitized diagnostics.
+- AC-SWP-016: migration-13 schema inspection, first-initialization persistence,
+  exact fingerprint comparison, mismatch recovery only after an explicit
+  reindex, and dual-runtime contract evidence.
+- AC-SWP-017: API/reference schema assertions for independently versioned
+  embedding, extraction, and background-enrichment fields plus the deprecated
+  `model` compatibility alias.
+- AC-SWP-018: readiness-path inspection and tests proving no embedder/provider
+  call occurs while local configuration, migration, vector, and fingerprint
+  state are checked.
+- AC-SWP-019: README/VPS instructions naming `sqlite-vec@0.1.9`, clean packed
+  consumer smokes before and after installing it, and the focused semantic
+  readiness matrix.
 
 ## Security, migration, deployment, smoke, and rollback
 
@@ -118,6 +162,11 @@ Issue fixes may cross authentication, migrations, Cloudflare D1, Bun/SQLite,
 and canonical export/import boundaries. Each such fix must fail closed and run
 the same shared contract where applicable. No production service deploy is part
 of this release; npm and GitHub are the publication surfaces.
+
+Migration 13 adds only semantic index metadata; SQL remains canonical and
+vectors remain rebuildable. A semantic fingerprint mismatch is not repaired
+implicitly: rollback is disabling semantic configuration for explicit FTS-only
+operation or running the documented reindex path with the intended fingerprint.
 
 Before merge, rollback is branch deletion. After merge and before npm publish,
 rollback is a reviewed revert. After npm publish, a bad immutable artifact must

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -582,22 +582,31 @@ derived cache/vector or release-status maintenance job is stale.
 
 - `GET /healthz`: process liveness without sensitive details.
 - `GET /readyz`: canonical SQL, migration integrity, signing-secret
-  decryptability, and the current FTS, vector, legacy `model`,
-  `background_repair`, and export/import capability states. It makes no
-  embedding-provider or vector-index network call and does not compare a
-  persisted embedding fingerprint.
+  decryptability, and capability-contract version 1. Capability states include
+  FTS, vector, embedding, extraction, background enrichment,
+  `background_repair`, and export/import. `disabled`, `enabled`, and
+  `configured_error` distinguish intentional omission from broken opt-in
+  configuration.
 
-In the current readiness and context responses, `capabilities.model` and
-`meta.degraded.model` respectively refer to the configured embedder. They do not
-prove an extraction model exists. A future enrichment implementation must
-introduce explicit `embedding`, `extraction`, and `background_enrichment`
-capability/degradation fields with a versioned API change; clients must not
-infer them today.
+`capabilities.model` and `meta.degraded.model` are deprecated `0.3.x` aliases
+for embedding. `embedding`, `extraction`, and `background_enrichment` are
+separate fields; planned extraction/enrichment remain `disabled` until their
+own implementation and evidence ship.
 
-A persisted embedding/index fingerprint and mismatch readiness gate are also
-proposed. The current index-drain response reports only the configured model and
-dimensions; clients must not treat those two fields as a verified full
-fingerprint.
+When semantic retrieval is configured, readiness compares credential-free
+provider identity, model, revision, dimensions, metric, preprocessing version,
+and index-schema version with migration-13 metadata. Partial/invalid
+configuration, unavailable or aliased local vector storage, an untracked legacy
+index, missing historical requeue work, an empty projection after canonical-only
+restore, or fingerprint mismatch returns `503 NOT_READY`, marks the affected
+capability `configured_error`, and supplies one fixed
+`checks.semantic_index` diagnostic. The response does not expose the
+fingerprint, endpoint, database path, or provider error.
+
+Readiness performs bounded local configuration/path/schema/metadata checks only. It
+makes no embedding-provider or vector-index network call. `enabled` therefore
+means locally initialized and fingerprint-compatible, not that a remote provider
+was reachable; indexing and context degradation report runtime provider failure.
 
 `capabilities.background_repair` is canonical scheduler evidence. `enabled`
 means a configured scheduler recorded a successful pass within its bounded

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -3,7 +3,8 @@
 Status: logical target schema. Current migrations implement the canonical
 kernel, `index_outbox`, and delivery state; model-assisted `enrichment_jobs`,
 their worker lease/fingerprint semantics, and vector `submitted/ready` states
-remain proposed. Collaboration leases described below are implemented.
+remain proposed. Migration 13 implements the singleton semantic-index
+fingerprint; collaboration leases described below are implemented.
 
 ## Authority and precedence
 
@@ -372,8 +373,8 @@ not source claim IDs that a gateway could hydrate directly. Customer-private
 memory is never copied into the release vector corpus.
 
 Embedding provider, model, immutable revision when available, dimensions,
-metric, and normalization form a fingerprint. Padding or truncating a mismatched
-vector is prohibited.
+metric, preprocessing version, and index-schema version form a fingerprint.
+Padding or truncating a mismatched vector is prohibited.
 
 ### Memory Atlas projections
 
@@ -430,8 +431,8 @@ An outbox row is complete only when the derived index matches the target
 canonical version or the deletion is confirmed.
 
 The current physical `index_outbox` has a smaller `pending/done/failed` shape
-and marks an accepted upsert complete. It must not be presented as the target
-leased/fingerprinted readiness contract until a migration and parity tests ship.
+and marks an accepted upsert complete. Migration 13 fingerprints the index as a
+whole; per-row leased/fingerprinted outbox state remains proposed.
 
 ### `event_outbox`
 
@@ -477,13 +478,17 @@ paging. Pre-migration equal-timestamp events are backfilled deterministically by
 timestamp and ID; every event committed after migration follows database write
 order even when timestamps are identical.
 
-### `schema_meta`
+### `semantic_index_metadata`
 
-Stores migration/export versions and, when implemented, separate embedding and
-extraction pipeline fingerprints. Current `/readyz` fails on an incompatible
-migration. The proposed extension also fails semantic readiness on an enabled
-vector fingerprint mismatch and reports extraction degradation independently
-from semantic retrieval.
+Migration 13 stores one immutable `claims` row containing credential-free
+provider identity, model, revision, dimensions, metric, preprocessing, index
+schema, and creation time. `/readyz` fails semantic readiness when configured
+values differ, when indexable claims lack durable work, when legacy completed
+index work has no fingerprint, when a restored projection is empty, or when
+local vector initialization cannot satisfy the contract. Recovery is an
+explicit vector rebuild plus metadata reset and complete claim-work requeue;
+startup never rewrites a mismatch.
+Extraction pipeline metadata remains separate and proposed.
 
 ### `audit_events`
 

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -33,6 +33,16 @@ semantic-index path. The same patch candidate must reject malformed embedding
 output at one shared boundary while retaining canonical SQL, FTS, and retryable
 index work.
 
+Issue #138 then demonstrated that a configured semantic deployment can report
+ready while silently falling back to FTS because invalid embedding settings,
+an unavailable vector backend, and an incompatible vector fingerprint are not
+distinguished from an intentionally unconfigured FTS-only deployment.
+
+Issue #140 requires the public npm path to prove both sides of that contract:
+the default tarball must stay dependency-light, while following the documented
+explicit `sqlite-vec@0.1.9` install must make the same packed artifact report a
+healthy local vector capability.
+
 Treating every report as a feature request would add speculative machinery;
 closing every report without checking it would hide real defects. The release
 needs an issue-by-issue resolution, current branch integration, accurate public
@@ -62,6 +72,20 @@ documentation, and an install smoke against the immutable npm artifact.
   resulting `TitenError`, and publish the verified correction as `0.3.1`.
 - Validate Bun HTTP and Cloudflare Workers AI embedding output through one
   shared boundary before any vector query or mutation can consume it.
+- Make semantic readiness fail closed when embedding or vector operation is
+  requested but cannot be initialized safely; persist and compare the minimum
+  compatible index fingerprint while preserving intentional FTS-only startup.
+- Bind the Bun fingerprint to a credential-free digest of the normalized
+  embedding endpoint, refuse a vector file that aliases the canonical database,
+  and require explicit requeue before historical FTS-only claims can be called
+  semantically ready.
+- Expose separate versioned `embedding`, `extraction`, and
+  `background_enrichment` readiness fields, retain the ambiguous `model` field
+  only as a deprecated compatibility alias, and document the explicit Bun
+  vector dependency.
+- Exercise the packed npm artifact first without and then with the documented
+  vector dependency so the public quick start proves fail-closed and healthy
+  semantic initialization from a clean consumer tree.
 - Preserve the user's dirty original checkout and existing stash byte-for-byte.
 
 ## Out of scope
@@ -72,6 +96,8 @@ documentation, and an install smoke against the immutable npm artifact.
 - Multi-process SQLite, native host memory providers, automatic model-driven
   contradiction inference, or other architecture whose issue provides no
   accepted throughput, adopter, quality, or lifecycle requirement.
+- Network provider probes on `/readyz`, automatic reindex after an embedding
+  fingerprint change, or implementation of planned extraction/enrichment.
 - Publishing the externally blocked ClawHub bundle unless the upstream
   inspector accepts the already validated package during this work.
 - Changing or cleaning the original dirty checkout.
@@ -91,6 +117,8 @@ documentation, and an install smoke against the immutable npm artifact.
   new direct maintainer decision and budget.
 - The dashboard remains synthetic where current docs say it is synthetic. A
   polished website is not runtime evidence for the memory API.
+- Readiness must remain a bounded local check. Configuration and stored index
+  metadata may be inspected, but `/readyz` must not call a model provider.
 
 ## Acceptance criteria
 
@@ -152,6 +180,37 @@ documentation, and an install smoke against the immutable npm artifact.
   reject the output as a sanitized retryable embedder dependency failure, write
   no vector, leave selected index work pending, and keep authorized FTS recall
   available.
+- **AC-SWP-014 — Optional feature:** Where no embedding or vector capability is
+  configured, Titen shall keep `/readyz` ready with FTS `enabled` and semantic
+  capabilities explicitly `disabled`.
+- **AC-SWP-015 — Unwanted behavior:** If embedding configuration is partial or
+  invalid, a configured vector backend cannot initialize its extension,
+  database, or schema, the vector path aliases canonical SQL, historical active
+  claims lack reindex work, restored canonical metadata points at a newly
+  created empty vector projection, or the active index fingerprint is
+  incompatible with stored metadata, then Titen shall return `ready: false`,
+  mark the affected semantic capability `configured_error`, and expose only a
+  sanitized local diagnostic.
+- **AC-SWP-016 — Event-driven:** When a semantic index is first initialized,
+  Titen shall persist a fingerprint containing credential-free provider
+  endpoint identity, model, revision, dimensions, metric, preprocessing
+  version, and index-schema version; when a later configuration differs, Titen
+  shall require an explicit reindex before semantic readiness can recover.
+- **AC-SWP-017 — Ubiquitous:** Titen shall expose independently versioned
+  `embedding`, `extraction`, and `background_enrichment` capability fields,
+  shall retain `model` as a deprecated embedding compatibility alias for the
+  `0.3.x` contract, and shall not present planned extraction or enrichment as
+  enabled.
+- **AC-SWP-018 — Ubiquitous:** Titen shall determine `/readyz` from bounded
+  local configuration, path, schema, extension, fingerprint, and missing-work
+  existence checks without a provider network request or unbounded backfill.
+- **AC-SWP-019 — Event-driven:** When an operator configures Bun vector
+  retrieval for `0.3.x`, the deployment documentation shall require an
+  explicit optional peer `sqlite-vec@0.1.9` install and the packed-artifact
+  regression shall cover a clean FTS-only install, the configured
+  missing-dependency error, and healthy semantic initialization after following
+  that exact install command; focused tests shall also cover fingerprint
+  mismatch.
 
 ## Done conditions
 
@@ -164,4 +223,6 @@ smoke passes; the original dirty checkout is unchanged; and this spec and its
 paired plan move to `done` with terminal evidence. The post-release issue #133
 is resolved by the verified `0.3.1` patch rather than by altering the immutable
 `0.3.0` artifact. Issue #137 is resolved only after malformed-output regressions
-pass against the shared validator and both runtime paths.
+pass against the shared validator and both runtime paths. Issue #138 is resolved
+only after configured semantic failures and fingerprint mismatches fail local
+readiness closed while intentional FTS-only operation remains ready.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,14 @@
     "node": ">=22",
     "bun": ">=1.2"
   },
+  "peerDependencies": {
+    "sqlite-vec": "0.1.9"
+  },
+  "peerDependenciesMeta": {
+    "sqlite-vec": {
+      "optional": true
+    }
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build && node scripts/check-dashboard-bundle.mjs",

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -36,6 +36,12 @@ if [ -d node_modules/sqlite-vec ]; then
   echo "FAIL: SDK/default installs must not pull the optional vector extension" >&2
   exit 1
 fi
+node -e '
+  const manifest = require("./node_modules/titen-memory/package.json");
+  if (manifest.peerDependencies?.["sqlite-vec"] !== "0.1.9" ||
+      manifest.peerDependenciesMeta?.["sqlite-vec"]?.optional !== true)
+    throw new Error("sqlite-vec optional peer metadata is missing or unpinned");
+'
 for toolchain in astro wrangler playwright miniflare vite esbuild; do
   if [ -d "node_modules/$toolchain" ]; then
     echo "FAIL: $toolchain reached consumers; it belongs in devDependencies" >&2
@@ -81,7 +87,7 @@ for _ in $(seq 1 60); do
 done
 ready="$(curl --max-time 5 -sf "http://127.0.0.1:$port/readyz" || true)"
 case "$ready" in
-  *'"ready":true'*) : ;;
+  *'"ready":true'*'"version":1'*'"vector":"disabled"'*'"embedding":"disabled"'*) : ;;
   *) echo "FAIL: /readyz not ready: ${ready:-<no response>}" >&2; cat "$work/serve.log" >&2; exit 1 ;;
 esac
 initialize="$(curl --max-time 5 -sf "http://127.0.0.1:$port/mcp" \
@@ -126,6 +132,68 @@ titen_project_resolve
 titen_remember'
 [ "$tool_names" = "$expected_tools" ] \
   || { echo "FAIL: installed MCP tool list differs" >&2; exit 1; }
+kill "$server" 2>/dev/null || true
+
+# A production install intentionally omits sqlite-vec. Once semantic retrieval
+# is requested, that absence must fail readiness instead of masquerading as FTS.
+semantic_port="$(node --input-type=module -e '
+  import { createServer } from "node:net";
+  const server = createServer();
+  server.listen(0, "127.0.0.1", () => {
+    console.log(server.address().port);
+    server.close();
+  });
+')"
+TITEN_EMBED_BASE_URL=http://127.0.0.1:9/v1 \
+TITEN_EMBED_MODEL=pack-verify \
+TITEN_EMBED_DIMS=4 \
+./node_modules/.bin/titen serve --db "$work/t.db" --port "$semantic_port" \
+  >"$work/semantic-serve.log" 2>&1 &
+server=$!
+for _ in $(seq 1 60); do
+  curl --max-time 2 -sf "http://127.0.0.1:$semantic_port/healthz" >/dev/null 2>&1 && break
+  kill -0 "$server" 2>/dev/null \
+    || { echo "FAIL: configured installed server exited" >&2; cat "$work/semantic-serve.log" >&2; exit 1; }
+  sleep 0.25
+done
+semantic_ready="$(curl --max-time 5 -sS "http://127.0.0.1:$semantic_port/readyz")"
+case "$semantic_ready" in
+  *'"code":"NOT_READY"'*'"semantic_index":"vector_initialization_failed"'*'"vector":"configured_error"'*) : ;;
+  *) echo "FAIL: missing sqlite-vec did not fail semantic readiness: $semantic_ready" >&2; exit 1 ;;
+esac
+kill "$server" 2>/dev/null || true
+trap 'rm -rf "$work"' EXIT
+
+# Follow the public vector install command in this same clean consumer tree.
+# Readiness is local and must not contact the deliberately unreachable embedder.
+npm install sqlite-vec@0.1.9 >/dev/null
+vector_port="$(node --input-type=module -e '
+  import { createServer } from "node:net";
+  const server = createServer();
+  server.listen(0, "127.0.0.1", () => {
+    console.log(server.address().port);
+    server.close();
+  });
+')"
+TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1 \
+TITEN_EMBED_MODEL=embeddinggemma \
+TITEN_EMBED_DIMS=768 \
+TITEN_EMBED_REVISION=local-pinned \
+./node_modules/.bin/titen serve --db "$work/vector-ready.db" --port "$vector_port" \
+  >"$work/vector-ready.log" 2>&1 &
+server=$!
+trap 'kill "$server" 2>/dev/null || true; rm -rf "$work"' EXIT
+for _ in $(seq 1 60); do
+  curl --max-time 2 -sf "http://127.0.0.1:$vector_port/healthz" >/dev/null 2>&1 && break
+  kill -0 "$server" 2>/dev/null \
+    || { echo "FAIL: vector-enabled installed server exited" >&2; cat "$work/vector-ready.log" >&2; exit 1; }
+  sleep 0.25
+done
+vector_ready="$(curl --max-time 5 -sf "http://127.0.0.1:$vector_port/readyz" || true)"
+case "$vector_ready" in
+  *'"ready":true'*'"vector":"enabled"'*'"embedding":"enabled"'*) : ;;
+  *) echo "FAIL: explicit sqlite-vec install was not vector-ready: ${vector_ready:-<no response>}" >&2; cat "$work/vector-ready.log" >&2; exit 1 ;;
+esac
 kill "$server" 2>/dev/null || true
 trap 'rm -rf "$work"' EXIT
 

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -31,7 +31,14 @@ import {
   type RouteDef,
 } from "./http";
 import type { Db } from "./db";
-import type { VectorCapability } from "./vectors";
+import {
+  CAPABILITY_VERSION,
+  SEMANTIC_DISABLED,
+  prepareSemanticReadiness,
+  type CapabilityState,
+  type SemanticReadiness,
+  type VectorCapability,
+} from "./vectors";
 import { backgroundRepairState } from "./maintenance";
 import type { WebhookSecurity } from "./webhook-security";
 import type { SecretCipher } from "./secrets";
@@ -45,6 +52,11 @@ export interface AppContext {
   runtime: string;
   /** Optional vector capability. Absent means FTS-only retrieval. */
   vectors?: VectorCapability;
+  semanticReadiness: SemanticReadiness;
+  modelCapabilities: {
+    extraction: CapabilityState;
+    backgroundEnrichment: CapabilityState;
+  };
   /** Scheduler intent; readiness still derives state from canonical evidence. */
   backgroundRepair: { configured: boolean; staleAfterMs: number };
   /** False only after a required startup migration failed. */
@@ -58,9 +70,14 @@ export interface AppContext {
 /** Capabilities are reported honestly based on what's configured. */
 export async function capabilities(app: AppContext) {
   return {
+    version: CAPABILITY_VERSION,
     fts: "enabled",
-    vector: app.vectors ? "enabled" : "disabled",
-    model: app.vectors?.embedder ? "enabled" : "disabled",
+    vector: app.semanticReadiness.vector,
+    embedding: app.semanticReadiness.embedding,
+    extraction: app.modelCapabilities.extraction,
+    background_enrichment: app.modelCapabilities.backgroundEnrichment,
+    /** @deprecated Use `embedding`; this alias remains for the 0.3.x API. */
+    model: app.semanticReadiness.embedding,
     background_repair: await backgroundRepairState({
       db: app.db,
       configured: app.backgroundRepair.configured,
@@ -239,6 +256,21 @@ async function readiness(ctx: RequestContext): Promise<Result> {
   if (!ctx.app.secretStorageReady) ready = false;
 
   const caps = await capabilities(ctx.app);
+  checks.semantic_index = ctx.app.semanticReadiness.diagnostic ??
+    (ctx.app.semanticReadiness.vector === "enabled" ? "ok" : "disabled");
+  if (
+    ctx.app.semanticReadiness.diagnostic ||
+    ctx.app.semanticReadiness.embedding === "configured_error" ||
+    ctx.app.semanticReadiness.vector === "configured_error"
+  )
+    ready = false;
+  checks.extraction = ctx.app.modelCapabilities.extraction;
+  checks.background_enrichment = ctx.app.modelCapabilities.backgroundEnrichment;
+  if (
+    ctx.app.modelCapabilities.extraction === "configured_error" ||
+    ctx.app.modelCapabilities.backgroundEnrichment === "configured_error"
+  )
+    ready = false;
   const body = {
     ready,
     runtime: ctx.app.runtime,
@@ -274,6 +306,13 @@ export function createApp(context: {
   revision?: string;
   runtime: string;
   vectors?: VectorCapability;
+  semanticReadiness?: SemanticReadiness;
+  /** Runtime adapter already completed the local semantic readiness check. */
+  semanticPrepared?: boolean;
+  modelCapabilities?: {
+    extraction?: CapabilityState;
+    backgroundEnrichment?: CapabilityState;
+  };
   backgroundRepair?: { configured: boolean; staleAfterMs: number };
   migrationsReady?: boolean;
   secretStorageReady?: boolean;
@@ -282,17 +321,50 @@ export function createApp(context: {
   mcpOrigin?: string;
 }): (request: Request) => Promise<Response> {
   const mcpOrigin = parseMcpOrigin(context.mcpOrigin);
+  const configuredVectors = context.vectors;
+  const initialSemanticReadiness = context.semanticReadiness ??
+    (configuredVectors
+      ? { embedding: "enabled", vector: "enabled" }
+      : SEMANTIC_DISABLED);
+  const semanticPrepared = context.semanticPrepared === true;
   const app: AppContext = {
     db: context.db,
     now: context.now ?? (() => new Date()),
     revision: context.revision ?? "dev",
     runtime: context.runtime,
-    vectors: context.vectors,
+    vectors:
+      semanticPrepared && initialSemanticReadiness.vector === "enabled"
+        ? configuredVectors
+        : undefined,
+    semanticReadiness: initialSemanticReadiness,
+    modelCapabilities: {
+      extraction: context.modelCapabilities?.extraction ?? "disabled",
+      backgroundEnrichment:
+        context.modelCapabilities?.backgroundEnrichment ?? "disabled",
+    },
     backgroundRepair: context.backgroundRepair ?? { configured: false, staleAfterMs: 60_000 },
     migrationsReady: context.migrationsReady ?? true,
     secretStorageReady: context.secretStorageReady ?? true,
     webhookSecurity: context.webhookSecurity,
     secretCipher: context.secretCipher,
+  };
+  let semanticPreparation: Promise<SemanticReadiness> | undefined;
+
+  const prepareSemantic = async () => {
+    if (semanticPrepared) return;
+    if (!app.migrationsReady) {
+      app.vectors = undefined;
+      return;
+    }
+    semanticPreparation ??= prepareSemanticReadiness(
+      app.db,
+      { vectors: configuredVectors, readiness: initialSemanticReadiness },
+      app.now().toISOString(),
+    );
+    app.semanticReadiness = await semanticPreparation;
+    app.vectors = app.semanticReadiness.vector === "enabled"
+      ? configuredVectors
+      : undefined;
   };
 
   return async function handle(request: Request): Promise<Response> {
@@ -322,6 +394,7 @@ export function createApp(context: {
         matched.route.path !== "/readyz"
       )
         throw unavailable("Required database migration has not completed.");
+      if (matched.route.path !== "/healthz") await prepareSemantic();
 
       let cachedBody: string | undefined;
       const rawBody = async () => {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -152,10 +152,17 @@ export async function compileContext(ctx: RequestContext): Promise<Result> {
     }));
 
   const degraded = {
+    version: 1,
     lexical: lexical.match ? "used" : "no_terms",
     semantic: false,
-    vector: ctx.app.vectors ? (vectorUsed ? "used" : "error") : "disabled",
-    model: ctx.app.vectors ? "enabled" : "disabled",
+    vector: ctx.app.vectors
+      ? (vectorUsed ? "used" : "error")
+      : ctx.app.semanticReadiness.vector,
+    embedding: ctx.app.semanticReadiness.embedding,
+    extraction: ctx.app.modelCapabilities.extraction,
+    background_enrichment: ctx.app.modelCapabilities.backgroundEnrichment,
+    /** @deprecated Use `embedding`; retained for the 0.3.x response contract. */
+    model: ctx.app.semanticReadiness.embedding,
     ...(includeCheckpoints ? { checkpoints: "unavailable" } : {}),
   };
 

--- a/src/core/migrations.ts
+++ b/src/core/migrations.ts
@@ -735,6 +735,25 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
          END`,
     ],
   },
+  {
+    version: 13,
+    statements: [
+      // One immutable contract binds the rebuildable claim-vector projection.
+      // Changing it requires an explicit reindex rather than silently mixing
+      // vectors produced by incompatible models or schemas.
+      `CREATE TABLE semantic_index_metadata (
+         id TEXT PRIMARY KEY CHECK (id = 'claims'),
+         provider TEXT NOT NULL,
+         model TEXT NOT NULL,
+         revision TEXT NOT NULL,
+         dimensions INTEGER NOT NULL CHECK (dimensions > 0),
+         metric TEXT NOT NULL,
+         preprocessing TEXT NOT NULL,
+         index_schema TEXT NOT NULL,
+         created_at TEXT NOT NULL
+       )`,
+    ],
+  },
 ];
 
 export const SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]!.version;

--- a/src/core/vectors.ts
+++ b/src/core/vectors.ts
@@ -5,11 +5,11 @@
  * implementation: sqlite-vec for Bun, Vectorize for Cloudflare. When no vector
  * provider is configured, the system falls back to FTS5 alone.
  *
- * ponytail: abstraction boundary only, no runtime code here. The ceiling is
- * that both implementations must produce compatible f32 vectors of the same
- * dimension from the same embedding provider. Upgrade path: add a dimension
- * mismatch readiness check.
+ * ponytail: one shared boundary and one persisted fingerprint, without a
+ * provider factory or network probe in readiness.
  */
+
+import type { Db } from "./db";
 
 export interface VectorMatch {
   id: string;
@@ -106,4 +106,201 @@ export function validateEmbeddingResponse(
 export interface VectorCapability {
   store: VectorStore;
   embedder: EmbeddingProvider;
+  fingerprint: EmbeddingFingerprint;
+  /** Local Bun projection was empty when the capability initialized. */
+  indexEmpty?: boolean;
+}
+
+export const CAPABILITY_VERSION = 1;
+
+export type CapabilityState = "disabled" | "enabled" | "configured_error";
+
+export type SemanticDiagnostic =
+  | "embedding_configuration_invalid"
+  | "vector_initialization_failed"
+  | "vector_storage_conflict"
+  | "index_backfill_required"
+  | "index_fingerprint_missing"
+  | "index_fingerprint_mismatch"
+  | "index_metadata_unavailable";
+
+/** Immutable compatibility contract for one rebuildable semantic index. */
+export interface EmbeddingFingerprint {
+  provider: string;
+  model: string;
+  revision: string;
+  dimensions: number;
+  metric: string;
+  preprocessing: string;
+  index_schema: string;
+}
+
+export interface SemanticReadiness {
+  embedding: CapabilityState;
+  vector: CapabilityState;
+  diagnostic?: SemanticDiagnostic;
+}
+
+export interface VectorInitialization {
+  vectors?: VectorCapability;
+  readiness: SemanticReadiness;
+}
+
+export const SEMANTIC_DISABLED: SemanticReadiness = {
+  embedding: "disabled",
+  vector: "disabled",
+};
+
+function sameFingerprint(
+  stored: EmbeddingFingerprint,
+  configured: EmbeddingFingerprint,
+): boolean {
+  return (
+    stored.provider === configured.provider &&
+    stored.model === configured.model &&
+    stored.revision === configured.revision &&
+    Number(stored.dimensions) === configured.dimensions &&
+    stored.metric === configured.metric &&
+    stored.preprocessing === configured.preprocessing &&
+    stored.index_schema === configured.index_schema
+  );
+}
+
+function validFingerprint(value: EmbeddingFingerprint): boolean {
+  return (
+    [
+      value.provider,
+      value.model,
+      value.revision,
+      value.metric,
+      value.preprocessing,
+      value.index_schema,
+    ].every(
+      (part) => typeof part === "string" && part.length > 0 && part.length <= 200,
+    ) &&
+    Number.isInteger(value.dimensions) &&
+    value.dimensions > 0 &&
+    value.dimensions <= 65_536
+  );
+}
+
+/**
+ * Persist or compare the local semantic contract before exposing vectors.
+ * This performs bounded SQL only; provider and vector-index calls never belong
+ * in readiness.
+ */
+export async function prepareSemanticReadiness(
+  db: Db,
+  initialization: VectorInitialization,
+  at: string,
+): Promise<SemanticReadiness> {
+  if (initialization.readiness.vector !== "enabled")
+    return initialization.readiness;
+  const fingerprint = initialization.vectors?.fingerprint;
+  if (
+    !fingerprint ||
+    !validFingerprint(fingerprint) ||
+    fingerprint.model !== initialization.vectors?.embedder.model ||
+    fingerprint.dimensions !== initialization.vectors.embedder.dimensions
+  )
+    return {
+      embedding: "configured_error",
+      vector: "configured_error",
+      diagnostic: "embedding_configuration_invalid",
+    };
+
+  try {
+    let stored = (
+      await db.all<EmbeddingFingerprint>(
+        `SELECT provider, model, revision, dimensions, metric, preprocessing, index_schema
+           FROM semantic_index_metadata WHERE id = 'claims'`,
+      )
+    )[0];
+    const missingWork = await db.all<{ present: number }>(
+      `SELECT 1 AS present FROM claims c
+        WHERE c.status IN ('active', 'disputed')
+          AND NOT EXISTS (
+            SELECT 1 FROM index_outbox o
+             WHERE o.record_type = 'claim' AND o.record_id = c.id
+               AND o.operation = 'upsert' AND o.state IN ('pending', 'done')
+          )
+        LIMIT 1`,
+    );
+    if (missingWork.length)
+      return {
+        embedding: "enabled",
+        vector: "configured_error",
+        diagnostic: "index_backfill_required",
+      };
+    if (stored && initialization.vectors?.indexEmpty) {
+      // ponytail: this catches the canonical-only restore case without a second
+      // index metadata protocol. Partial external index loss still requires the
+      // documented drain/query smoke to detect.
+      const missingPending = await db.all<{ present: number }>(
+        `SELECT 1 AS present FROM claims c
+          WHERE c.status IN ('active', 'disputed')
+            AND NOT EXISTS (
+              SELECT 1 FROM index_outbox o
+               WHERE o.record_type = 'claim' AND o.record_id = c.id
+                 AND o.operation = 'upsert' AND o.state = 'pending'
+            )
+          LIMIT 1`,
+      );
+      if (missingPending.length)
+        return {
+          embedding: "enabled",
+          vector: "configured_error",
+          diagnostic: "index_backfill_required",
+        };
+    }
+    if (!stored) {
+      const indexed = await db.all<{ present: number }>(
+        `SELECT 1 AS present FROM index_outbox
+          WHERE record_type = 'claim' AND state = 'done' LIMIT 1`,
+      );
+      if (indexed.length)
+        return {
+          embedding: "enabled",
+          vector: "configured_error",
+          diagnostic: "index_fingerprint_missing",
+        };
+      await db.batch([
+        {
+          sql: `INSERT OR IGNORE INTO semantic_index_metadata
+                  (id, provider, model, revision, dimensions, metric,
+                   preprocessing, index_schema, created_at)
+                VALUES ('claims', ?, ?, ?, ?, ?, ?, ?, ?)`,
+          params: [
+            fingerprint.provider,
+            fingerprint.model,
+            fingerprint.revision,
+            fingerprint.dimensions,
+            fingerprint.metric,
+            fingerprint.preprocessing,
+            fingerprint.index_schema,
+            at,
+          ],
+        },
+      ]);
+      stored = (
+        await db.all<EmbeddingFingerprint>(
+          `SELECT provider, model, revision, dimensions, metric, preprocessing, index_schema
+             FROM semantic_index_metadata WHERE id = 'claims'`,
+        )
+      )[0];
+    }
+    if (!stored || !sameFingerprint(stored, fingerprint))
+      return {
+        embedding: "enabled",
+        vector: "configured_error",
+        diagnostic: "index_fingerprint_mismatch",
+      };
+    return { embedding: "enabled", vector: "enabled" };
+  } catch {
+    return {
+      embedding: "enabled",
+      vector: "configured_error",
+      diagnostic: "index_metadata_unavailable",
+    };
+  }
 }

--- a/src/runtime/bun/cli.ts
+++ b/src/runtime/bun/cli.ts
@@ -136,7 +136,6 @@ switch (command) {
     // are deployment facts (and one is a credential), so they belong in the unit
     // file or the container environment rather than a shell history. Absent any
     // of them the service serves lexical retrieval and says so in readiness.
-    const embedDims = Number(process.env.TITEN_EMBED_DIMS ?? "0");
     const servePort = port(flags.port);
     const quiet = flags.quiet === true;
     let started: Awaited<ReturnType<typeof serve>>;
@@ -150,7 +149,8 @@ switch (command) {
         vecDbPath: process.env.TITEN_VEC_DB_PATH ?? `${dbPath}.vec`,
         embedBaseUrl: process.env.TITEN_EMBED_BASE_URL,
         embedModel: process.env.TITEN_EMBED_MODEL,
-        embedDims: Number.isInteger(embedDims) && embedDims > 0 ? embedDims : undefined,
+        embedDims: process.env.TITEN_EMBED_DIMS,
+        embedRevision: process.env.TITEN_EMBED_REVISION,
         embedApiKey: process.env.TITEN_EMBED_API_KEY,
         maintenanceIntervalMs:
           process.env.TITEN_MAINTENANCE_INTERVAL_MS === undefined

--- a/src/runtime/bun/server.ts
+++ b/src/runtime/bun/server.ts
@@ -1,7 +1,10 @@
 import { createApp, parseMcpOrigin } from "../../core/app";
 import { migrate, schemaState } from "../../core/migrations";
 import { runMaintenance } from "../../core/maintenance";
-import type { VectorCapability } from "../../core/vectors";
+import {
+  prepareSemanticReadiness,
+  type VectorCapability,
+} from "../../core/vectors";
 import { createSqliteDb, openDatabase } from "./sqlite";
 import { tryCreateVectors } from "./vectors";
 import type { WebhookSecurity } from "../../core/webhook-security";
@@ -24,7 +27,8 @@ export interface ServeOptions {
   vecDbPath?: string;
   embedBaseUrl?: string;
   embedModel?: string;
-  embedDims?: number;
+  embedDims?: number | string;
+  embedRevision?: string;
   embedApiKey?: string;
   webhookSecurity?: WebhookSecurity;
   secretCipher?: SecretCipher;
@@ -56,15 +60,26 @@ export async function serve(options: ServeOptions) {
       secretStorageReady = false;
     }
   }
-  const vectors =
-    options.vectors ??
-    tryCreateVectors({
-    vecDbPath: options.vecDbPath,
-    embedBaseUrl: options.embedBaseUrl,
-    embedModel: options.embedModel,
-    embedDims: options.embedDims,
-    embedApiKey: options.embedApiKey,
-  });
+  const vectorInitialization = options.vectors
+    ? {
+        vectors: options.vectors,
+        readiness: { embedding: "enabled", vector: "enabled" } as const,
+      }
+    : tryCreateVectors({
+        canonicalDbPath: options.dbPath,
+        vecDbPath: options.vecDbPath,
+        embedBaseUrl: options.embedBaseUrl,
+        embedModel: options.embedModel,
+        embedDims: options.embedDims,
+        embedRevision: options.embedRevision,
+        embedApiKey: options.embedApiKey,
+      });
+  const semanticReadiness = migrationsReady
+    ? await prepareSemanticReadiness(db, vectorInitialization, new Date().toISOString())
+    : vectorInitialization.readiness;
+  const vectors = semanticReadiness.vector === "enabled"
+    ? vectorInitialization.vectors
+    : undefined;
   const intervalMs = options.maintenanceIntervalMs ?? 15_000;
   const backgroundRepair = intervalMs > 0 && migrationsReady && secretStorageReady;
   const app = createApp({
@@ -72,6 +87,8 @@ export async function serve(options: ServeOptions) {
     revision: options.revision ?? "dev",
     runtime: "bun-sqlite",
     vectors,
+    semanticReadiness,
+    semanticPrepared: true,
     backgroundRepair: {
       configured: backgroundRepair,
       staleAfterMs: Math.max(1_000, intervalMs * 3),

--- a/src/runtime/bun/vectors.ts
+++ b/src/runtime/bun/vectors.ts
@@ -1,19 +1,47 @@
 // @ts-ignore - bun:sqlite types ship with the Bun runtime, not with this package.
 import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import type {
   EmbeddingProvider,
-  VectorCapability,
+  EmbeddingFingerprint,
+  VectorInitialization,
   VectorStore,
 } from "../../core/vectors";
 import { validateEmbeddingResponse } from "../../core/vectors";
+
+function normalizedFilePath(path: string): string {
+  const absolute = resolve(path);
+  try {
+    return realpathSync(absolute);
+  } catch {
+    try {
+      return join(realpathSync(dirname(absolute)), basename(absolute));
+    } catch {
+      return absolute;
+    }
+  }
+}
+
+function aliasesFile(first: string, second: string): boolean {
+  if (normalizedFilePath(first) === normalizedFilePath(second)) return true;
+  try {
+    const left = statSync(first);
+    const right = statSync(second);
+    return left.dev === right.dev && left.ino === right.ino;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * A sqlite-vec backed vector store.
  *
  * Vectors live in their own database file, never in the canonical one: an index
  * is rebuildable and must never be able to corrupt evidence. Returns null when
- * the extension is unavailable so the service degrades to FTS instead of
- * refusing to start.
+ * the extension, database, or expected schema is unavailable; configured
+ * semantic readiness then fails closed while canonical SQL remains intact.
  *
  * ponytail: cosine-style scoring derived from L2 distance as 1/(1+d). The
  * ceiling is that the score is monotonic but not a calibrated similarity, which
@@ -23,7 +51,9 @@ import { validateEmbeddingResponse } from "../../core/vectors";
 export function createSqliteVecStore(
   dbPath: string,
   dimensions: number,
-): VectorStore | null {
+): (VectorStore & { empty: boolean }) | null {
+  if (!Number.isInteger(dimensions) || dimensions < 1 || dimensions > 65_536)
+    return null;
   let db: Database;
   try {
     db = new Database(dbPath, { create: true });
@@ -31,6 +61,7 @@ export function createSqliteVecStore(
     return null;
   }
 
+  let empty = true;
   try {
     // The prebuilt extension ships per-platform; absence is expected, not fatal.
     //
@@ -54,8 +85,13 @@ export function createSqliteVecStore(
     const columns = db
       .query(`PRAGMA table_info(vec_claims)`)
       .all() as { name: string }[];
-    if (columns.length > 0 && !columns.some((column) => column.name === "subject_id"))
-      db.run(`DROP TABLE vec_claims`);
+    if (
+      columns.length > 0 &&
+      !["id", "embedding", "org_id", "subject_id", "project_id"].every((name) =>
+        columns.some((column) => column.name === name)
+      )
+    )
+      throw new Error("incompatible vector schema");
     db.run(
       `CREATE VIRTUAL TABLE IF NOT EXISTS vec_claims USING vec0(
          id TEXT PRIMARY KEY,
@@ -65,6 +101,17 @@ export function createSqliteVecStore(
          project_id TEXT
        )`,
     );
+    const table = db
+      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vec_claims'`)
+      .get() as { sql: string } | null;
+    if (
+      !table ||
+      !/^CREATE VIRTUAL TABLE\s+[`"']?vec_claims[`"']?\s+USING\s+vec0\s*\(/i.test(table.sql) ||
+      !new RegExp(`embedding\\s+float\\[${dimensions}\\]`, "i").test(table.sql) ||
+      !/org_id\s+TEXT\s+partition\s+key/i.test(table.sql)
+    )
+      throw new Error("incompatible vector schema");
+    empty = !db.query(`SELECT 1 FROM vec_claims LIMIT 1`).get();
   } catch {
     db.close();
     return null;
@@ -74,6 +121,7 @@ export function createSqliteVecStore(
     Buffer.from(vector.buffer, vector.byteOffset, vector.byteLength);
 
   return {
+    empty,
     async upsert(records) {
       if (records.length === 0) return;
       // vec0 does not honour INSERT OR REPLACE: it raises a uniqueness error
@@ -156,30 +204,109 @@ export function createHttpEmbedder(config: {
 }
 
 /**
- * Builds the capability only when both halves are present. Vector retrieval
- * needs a store and a model; either one missing means FTS-only, reported
- * honestly by readiness.
+ * Builds the capability only when both halves are valid. A completely absent
+ * tuple is FTS-only; partial or broken opt-in is a configured readiness error.
  */
 export function tryCreateVectors(config: {
+  canonicalDbPath?: string;
   vecDbPath?: string;
   embedBaseUrl?: string;
   embedModel?: string;
-  embedDims?: number;
+  embedDims?: number | string;
+  embedRevision?: string;
   embedApiKey?: string;
-}): VectorCapability | undefined {
-  if (!config.embedBaseUrl || !config.embedModel || !config.embedDims) return undefined;
-  const store = createSqliteVecStore(
-    config.vecDbPath ?? "titen-vec.db",
+}): VectorInitialization {
+  const requested = [
+    config.embedBaseUrl,
+    config.embedModel,
     config.embedDims,
+    config.embedRevision,
+    config.embedApiKey,
+  ].some((value) => value !== undefined);
+  if (!requested)
+    return { readiness: { embedding: "disabled", vector: "disabled" } };
+
+  const dimensions = Number(config.embedDims);
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(config.embedBaseUrl ?? "");
+  } catch {
+    return {
+      readiness: {
+        embedding: "configured_error",
+        vector: "configured_error",
+        diagnostic: "embedding_configuration_invalid",
+      },
+    };
+  }
+  if (
+    !config.embedModel?.trim() ||
+    config.embedModel.trim().length > 200 ||
+    !Number.isInteger(dimensions) ||
+    dimensions < 1 ||
+    dimensions > 65_536 ||
+    !["http:", "https:"].includes(baseUrl.protocol) ||
+    baseUrl.username ||
+    baseUrl.password ||
+    baseUrl.search ||
+    baseUrl.hash ||
+    baseUrl.href.length > 2_048 ||
+    (config.embedRevision !== undefined &&
+      (!config.embedRevision.trim() || config.embedRevision.trim().length > 200)) ||
+    (config.vecDbPath !== undefined && !config.vecDbPath.trim())
+  )
+    return {
+      readiness: {
+        embedding: "configured_error",
+        vector: "configured_error",
+        diagnostic: "embedding_configuration_invalid",
+      },
+    };
+
+  const vecDbPath = config.vecDbPath ?? "titen-vec.db";
+  if (config.canonicalDbPath && aliasesFile(config.canonicalDbPath, vecDbPath))
+    return {
+      readiness: {
+        embedding: "enabled",
+        vector: "configured_error",
+        diagnostic: "vector_storage_conflict",
+      },
+    };
+
+  const store = createSqliteVecStore(
+    vecDbPath,
+    dimensions,
   );
-  if (!store) return undefined;
+  if (!store)
+    return {
+      readiness: {
+        embedding: "enabled",
+        vector: "configured_error",
+        diagnostic: "vector_initialization_failed",
+      },
+    };
+  const endpoint = baseUrl.href.replace(/\/$/, "");
+  const fingerprint: EmbeddingFingerprint = {
+    provider: `openai-compatible:${createHash("sha256").update(endpoint).digest("hex")}`,
+    model: config.embedModel.trim(),
+    revision: config.embedRevision?.trim() ?? "unspecified",
+    dimensions,
+    metric: "l2",
+    preprocessing: "text-v1",
+    index_schema: "claims-scope-v1",
+  };
   return {
-    store,
-    embedder: createHttpEmbedder({
-      baseUrl: config.embedBaseUrl,
-      model: config.embedModel,
-      dimensions: config.embedDims,
-      apiKey: config.embedApiKey,
-    }),
+    readiness: { embedding: "enabled", vector: "enabled" },
+    vectors: {
+      store,
+      indexEmpty: store.empty,
+      fingerprint,
+      embedder: createHttpEmbedder({
+        baseUrl: endpoint,
+        model: config.embedModel.trim(),
+        dimensions,
+        apiKey: config.embedApiKey,
+      }),
+    },
   };
 }

--- a/src/runtime/cloudflare/vectors.ts
+++ b/src/runtime/cloudflare/vectors.ts
@@ -1,5 +1,9 @@
 import { validateEmbeddingResponse } from "../../core/vectors";
-import type { VectorStore, VectorMatch, EmbeddingProvider, VectorCapability } from "../../core/vectors";
+import type {
+  EmbeddingProvider,
+  VectorInitialization,
+  VectorStore,
+} from "../../core/vectors";
 
 /** Minimal Vectorize binding interface (no @cloudflare/workers-types needed). */
 export interface VectorizeIndex {
@@ -46,18 +50,71 @@ export function createWorkersAiEmbedder(ai: AiBinding, model: string, dimensions
   };
 }
 
-/** Builds VectorCapability from Worker env bindings. Returns undefined if bindings absent. */
+/** Builds a locally validated capability from native Worker bindings. */
 export function tryCreateVectorize(env: {
   VECTORIZE?: VectorizeIndex;
   AI?: AiBinding;
   TITEN_EMBED_MODEL?: string;
   TITEN_EMBED_DIMS?: string;
-}): VectorCapability | undefined {
-  if (!env.VECTORIZE || !env.AI) return undefined;
+  TITEN_EMBED_REVISION?: string;
+}): VectorInitialization {
+  const requested = [
+    env.VECTORIZE,
+    env.AI,
+    env.TITEN_EMBED_MODEL,
+    env.TITEN_EMBED_DIMS,
+    env.TITEN_EMBED_REVISION,
+  ].some((value) => value !== undefined);
+  if (!requested)
+    return { readiness: { embedding: "disabled", vector: "disabled" } };
+
   const model = env.TITEN_EMBED_MODEL ?? "@cf/baai/bge-base-en-v1.5";
-  const dims = Number(env.TITEN_EMBED_DIMS ?? "768");
+  const dimensions = Number(env.TITEN_EMBED_DIMS ?? "768");
+  const aiReady = Boolean(env.AI && typeof env.AI.run === "function");
+  const vectorReady = Boolean(
+    env.VECTORIZE &&
+    typeof env.VECTORIZE.upsert === "function" &&
+    typeof env.VECTORIZE.query === "function" &&
+    typeof env.VECTORIZE.deleteByIds === "function"
+  );
+  if (
+    !model.trim() ||
+    model.trim().length > 200 ||
+    !Number.isInteger(dimensions) ||
+    dimensions < 1 ||
+    dimensions > 65_536 ||
+    (env.TITEN_EMBED_REVISION !== undefined &&
+      (!env.TITEN_EMBED_REVISION.trim() || env.TITEN_EMBED_REVISION.trim().length > 200))
+  )
+    return {
+      readiness: {
+        embedding: "configured_error",
+        vector: "configured_error",
+        diagnostic: "embedding_configuration_invalid",
+      },
+    };
+  if (!aiReady || !vectorReady)
+    return {
+      readiness: {
+        embedding: aiReady ? "enabled" : "configured_error",
+        vector: "configured_error",
+        diagnostic: "vector_initialization_failed",
+      },
+    };
   return {
-    store: createVectorizeStore(env.VECTORIZE),
-    embedder: createWorkersAiEmbedder(env.AI, model, dims),
+    readiness: { embedding: "enabled", vector: "enabled" },
+    vectors: {
+      store: createVectorizeStore(env.VECTORIZE!),
+      embedder: createWorkersAiEmbedder(env.AI!, model.trim(), dimensions),
+      fingerprint: {
+        provider: "workers-ai",
+        model: model.trim(),
+        revision: env.TITEN_EMBED_REVISION?.trim() ?? "unspecified",
+        dimensions,
+        metric: "cosine",
+        preprocessing: "text-v1",
+        index_schema: "claims-scope-v1",
+      },
+    },
   };
 }

--- a/src/runtime/cloudflare/worker.ts
+++ b/src/runtime/cloudflare/worker.ts
@@ -2,6 +2,7 @@ import { createApp } from "../../core/app";
 import { migrate, schemaState } from "../../core/migrations";
 import { createD1Db, type D1Database } from "./d1";
 import { runMaintenance } from "../../core/maintenance";
+import { prepareSemanticReadiness } from "../../core/vectors";
 import { tryCreateVectorize } from "./vectors";
 import { parseSecretCipher, prepareSigningSecrets } from "../../core/secrets";
 import type { WebhookSecurity } from "../../core/webhook-security";
@@ -16,6 +17,7 @@ export interface Env {
   AI?: unknown;
   TITEN_EMBED_MODEL?: string;
   TITEN_EMBED_DIMS?: string;
+  TITEN_EMBED_REVISION?: string;
   /** Secret JSON keyring; keep in a Worker secret, never vars or D1. */
   TITEN_SECRET_KEYS?: string;
   /** Test-only fixed resolution; production has no generic address-pinned fetch. */
@@ -73,7 +75,7 @@ export default {
       schemaVerification = undefined;
       migrationsReady = false;
     }
-    const vectors = tryCreateVectorize(env as any);
+    const vectorInitialization = tryCreateVectorize(env as any);
     let secretCipher;
     let secretStorageReady = false;
     try {
@@ -91,7 +93,8 @@ export default {
       db,
       revision: env.TITEN_REVISION ?? "dev",
       runtime: "cloudflare-d1",
-      vectors,
+      vectors: vectorInitialization.vectors,
+      semanticReadiness: vectorInitialization.readiness,
       backgroundRepair: { configured: true, staleAfterMs: 180_000 },
       migrationsReady,
       secretStorageReady,
@@ -109,7 +112,15 @@ export default {
    */
   async scheduled(_event: unknown, env: Env, context: { waitUntil(p: Promise<unknown>): void }) {
     const db = createD1Db(env.DB);
-    const vectors = tryCreateVectorize(env as never);
+    const vectorInitialization = tryCreateVectorize(env as never);
+    const semanticReadiness = await prepareSemanticReadiness(
+      db,
+      vectorInitialization,
+      new Date().toISOString(),
+    );
+    const vectors = semanticReadiness.vector === "enabled"
+      ? vectorInitialization.vectors
+      : undefined;
     const secretCipher = parseSecretCipher(env.TITEN_SECRET_KEYS);
     if (!(await prepareSigningSecrets(db, secretCipher)))
       throw new Error("Signing-secret storage is not ready.");

--- a/tests/contract/bun-sqlite.test.ts
+++ b/tests/contract/bun-sqlite.test.ts
@@ -6,6 +6,7 @@ import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
 import { serve } from "../../src/runtime/bun/server";
 import { CASES, assertBatchAtomicity } from "./cases";
 import { clientVia, provisionWith, revokeWith, TEST_SECRET_CIPHER, TEST_WEBHOOK_SECURITY, type Fixture } from "./harness";
+import { assertSemanticReadiness } from "./semantic-readiness";
 
 const directory = mkdtempSync(join(tmpdir(), "titen-bun-"));
 const dbPath = join(directory, "titen.db");
@@ -57,6 +58,10 @@ afterAll(async () => {
 
 test("batch writes are atomic on bun:sqlite", async () => {
   await assertBatchAtomicity(db);
+});
+
+test("bun:sqlite semantic readiness persists and compares its fingerprint locally", async () => {
+  await assertSemanticReadiness(db, "bun-sqlite");
 });
 
 for (const contractCase of CASES)

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -88,8 +88,12 @@ export const CASES: Case[] = [
       assert.equal(res.body.data.ready, true);
       assert.equal(res.body.data.schema.applied, res.body.data.schema.expected);
       assert.equal(res.body.data.checks.canonical_sql, "ok");
+      assert.equal(res.body.data.capabilities.version, 1);
       assert.equal(res.body.data.capabilities.fts, "enabled");
       assert.equal(res.body.data.capabilities.vector, "disabled");
+      assert.equal(res.body.data.capabilities.embedding, "disabled");
+      assert.equal(res.body.data.capabilities.extraction, "disabled");
+      assert.equal(res.body.data.capabilities.background_enrichment, "disabled");
       assert.equal(res.body.data.capabilities.model, "disabled");
       assert.equal(
         res.body.data.capabilities.background_repair,

--- a/tests/contract/cloudflare-d1.test.ts
+++ b/tests/contract/cloudflare-d1.test.ts
@@ -12,6 +12,7 @@ import { CASES, assertBatchAtomicity } from "./cases";
 import { clientVia, provisionWith, revokeWith, TEST_SECRET_KEY, type Fixture } from "./harness";
 import { assertPopulatedV10RetrievalMigration } from "./retrieval-migration";
 import { assertPopulatedV11IntegrityMigration } from "./integrity-migration";
+import { assertSemanticReadiness } from "./semantic-readiness";
 
 const scriptPath = join(process.cwd(), "dist/worker/worker.js");
 if (!existsSync(scriptPath))
@@ -111,6 +112,10 @@ test("batch writes are atomic on D1", async () => {
   await assertBatchAtomicity(db);
 });
 
+test("D1 semantic readiness persists and compares its fingerprint locally", async () => {
+  await assertSemanticReadiness(db, "cloudflare-d1");
+});
+
 test("auto-migrate off blocks API traffic on a stale D1 schema", async () => {
   const stalePersist = mkdtempSync(join(tmpdir(), "titen-d1-stale-"));
   const stale = new Miniflare({
@@ -132,6 +137,36 @@ test("auto-migrate off blocks API traffic on a stale D1 schema", async () => {
   } finally {
     await stale.dispose();
     rmSync(stalePersist, { recursive: true, force: true });
+  }
+});
+
+test("partial Worker semantic configuration fails readiness without leaking it", async () => {
+  const partialPersist = mkdtempSync(join(tmpdir(), "titen-d1-partial-semantic-"));
+  const partial = new Miniflare({
+    modules: true,
+    scriptPath,
+    compatibilityDate: "2026-07-01",
+    d1Databases: { DB: "titen-partial-semantic" },
+    d1Persist: partialPersist,
+    bindings: {
+      TITEN_AUTO_MIGRATE: "1",
+      TITEN_EMBED_MODEL: "must-not-leak",
+      TITEN_SECRET_KEYS: JSON.stringify({ active: "test-v1", keys: { "test-v1": TEST_SECRET_KEY } }),
+    },
+  });
+  try {
+    await partial.ready;
+    assert.equal((await partial.dispatchFetch(`${origin}/healthz`)).status, 200);
+    const response = await partial.dispatchFetch(`${origin}/readyz`);
+    assert.equal(response.status, 503);
+    const body = await response.json() as any;
+    assert.equal(body.meta.capabilities.embedding, "configured_error");
+    assert.equal(body.meta.capabilities.vector, "configured_error");
+    assert.equal(body.meta.checks.semantic_index, "vector_initialization_failed");
+    assert.doesNotMatch(JSON.stringify(body), /must-not-leak/);
+  } finally {
+    await partial.dispose();
+    rmSync(partialPersist, { recursive: true, force: true });
   }
 });
 
@@ -166,10 +201,11 @@ test("a D1 migration batch rolls back on fault and concurrent retries converge",
     assert.equal(Number((await real.all<{ version: number }>("SELECT MAX(version) AS version FROM titen_migrations"))[0]!.version), SCHEMA_VERSION - 1);
     const integrity = await real.all<{ name: string; sql: string }>(
       `SELECT name, sql FROM sqlite_master
-        WHERE name IN ('checkpoints_scope', 'event_order') ORDER BY name`,
+        WHERE name IN ('checkpoints_scope', 'event_order', 'semantic_index_metadata')
+        ORDER BY name`,
     );
-    assert.deepEqual(integrity.map(({ name }) => name), ["checkpoints_scope"]);
-    assert.doesNotMatch(integrity[0]!.sql, /UNIQUE/);
+    assert.deepEqual(integrity.map(({ name }) => name), ["checkpoints_scope", "event_order"]);
+    assert.match(integrity.find(({ name }) => name === "checkpoints_scope")!.sql, /UNIQUE/);
     assert.deepEqual(await Promise.all([migrate(real), migrate(real)]), [SCHEMA_VERSION, SCHEMA_VERSION]);
   } finally {
     await fault.dispose();

--- a/tests/contract/harness.ts
+++ b/tests/contract/harness.ts
@@ -200,6 +200,15 @@ export function fakeVectors(): VectorCapability & {
     embedCalls: () => calls,
     metadataFor: (id) => metadata.get(id),
     lastFilter: () => filter,
+    fingerprint: {
+      provider: "contract",
+      model: "contract-stub",
+      revision: "v1",
+      dimensions: 4,
+      metric: "cosine",
+      preprocessing: "text-v1",
+      index_schema: "claims-scope-v1",
+    },
     embedder: {
       dimensions: 4,
       model: "contract-stub",

--- a/tests/contract/integrity-migration.ts
+++ b/tests/contract/integrity-migration.ts
@@ -172,7 +172,11 @@ export async function assertPopulatedV11IntegrityMigration(db: Db): Promise<void
   }
 
   assert.equal(await migrate(db), SCHEMA_VERSION);
-  assert.equal(SCHEMA_VERSION, 12);
+  assert.equal(SCHEMA_VERSION, 13);
+  assert.deepEqual(
+    await db.all(`SELECT name FROM sqlite_master WHERE name = 'semantic_index_metadata'`),
+    [{ name: "semantic_index_metadata" }],
+  );
   assert.deepEqual(await db.all(
     `SELECT id, state FROM checkpoints
       WHERE org_id = 'org_integrity_a' AND subject_id = 'subject_integrity'`,

--- a/tests/contract/semantic-readiness.ts
+++ b/tests/contract/semantic-readiness.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { createApp } from "../../src/core/app";
+import type { Db } from "../../src/core/db";
+import { clientVia, fakeVectors } from "./harness";
+
+const readyWith = (db: Db, runtime: string, vectors?: ReturnType<typeof fakeVectors>) =>
+  clientVia(
+    createApp({ db, runtime, revision: "semantic-readiness", vectors }),
+    "http://titen.test",
+  ).call("GET", "/readyz");
+
+/** Same persisted fingerprint/readiness contract against D1 and bun:sqlite. */
+export async function assertSemanticReadiness(db: Db, runtime: string) {
+  const diagnosticFree = await clientVia(
+    createApp({
+      db,
+      runtime,
+      semanticReadiness: {
+        embedding: "configured_error",
+        vector: "configured_error",
+      },
+    }),
+    "http://titen.test",
+  ).call("GET", "/readyz");
+  assert.equal(diagnosticFree.status, 503);
+
+  await db.batch([
+    { sql: `DELETE FROM semantic_index_metadata` },
+    { sql: `DELETE FROM index_outbox WHERE id = 'idx_semantic_legacy'` },
+    {
+      sql: `INSERT INTO index_outbox
+              (id, org_id, record_type, record_id, operation, state, attempts, created_at)
+            VALUES ('idx_semantic_legacy', 'org_test', 'claim', 'clm_test',
+                    'upsert', 'done', 1, '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+
+  const legacyVectors = fakeVectors();
+  const missing = await readyWith(db, runtime, legacyVectors);
+  assert.equal(missing.status, 503);
+  assert.equal(missing.body.meta.ready, false);
+  assert.equal(missing.body.meta.capabilities.embedding, "enabled");
+  assert.equal(missing.body.meta.capabilities.vector, "configured_error");
+  assert.equal(missing.body.meta.checks.semantic_index, "index_fingerprint_missing");
+  assert.equal(legacyVectors.embedCalls(), 0, "readiness must not call the provider");
+
+  const dishonest = fakeVectors();
+  dishonest.embedder.model = "different-runtime-model";
+  dishonest.embedder.dimensions = 8;
+  const invalid = await readyWith(db, runtime, dishonest);
+  assert.equal(invalid.status, 503);
+  assert.equal(invalid.body.meta.checks.semantic_index, "embedding_configuration_invalid");
+  assert.equal(dishonest.embedCalls(), 0);
+
+  await db.batch([
+    { sql: `DELETE FROM index_outbox WHERE id = 'idx_semantic_legacy'` },
+    {
+      sql: `INSERT OR IGNORE INTO organizations (id, name, created_at)
+            VALUES ('org_semantic_backfill', 'Semantic Backfill', '2026-07-31T00:00:00.000Z')`,
+    },
+    {
+      sql: `INSERT INTO claims
+              (id, org_id, subject_id, project_id, workspace_id, observer_id,
+               actor_id, kind, statement, confidence, trust, visibility, status,
+               version, valid_from, valid_to, created_at)
+            VALUES ('clm_semantic_backfill', 'org_semantic_backfill', 'subject',
+                    NULL, NULL, NULL, 'agent', 'semantic_fact', 'Backfill me',
+                    1, 'asserted', 'private', 'active', 1,
+                    '2026-07-31T00:00:00.000Z', NULL, '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+  const vectors = fakeVectors();
+  const backfillRequired = await readyWith(db, runtime, vectors);
+  assert.equal(backfillRequired.status, 503);
+  assert.equal(
+    backfillRequired.body.meta.checks.semantic_index,
+    "index_backfill_required",
+  );
+  assert.equal(vectors.embedCalls(), 0);
+  await db.batch([
+    {
+      sql: `INSERT INTO index_outbox
+              (id, org_id, record_type, record_id, operation, state, attempts, created_at)
+            VALUES ('idx_semantic_backfill', 'org_semantic_backfill', 'claim',
+                    'clm_semantic_backfill', 'upsert', 'pending', 0,
+                    '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+  const healthy = await readyWith(db, runtime, vectors);
+  assert.equal(healthy.status, 200);
+  assert.equal(healthy.body.data.capabilities.version, 1);
+  assert.equal(healthy.body.data.capabilities.embedding, "enabled");
+  assert.equal(healthy.body.data.capabilities.vector, "enabled");
+  assert.equal(healthy.body.data.capabilities.extraction, "disabled");
+  assert.equal(healthy.body.data.capabilities.background_enrichment, "disabled");
+  assert.equal(healthy.body.data.capabilities.model, "enabled");
+  assert.equal(vectors.embedCalls(), 0, "readiness must remain local");
+  const persisted = await db.all<Record<string, unknown>>(
+    `SELECT provider, model, revision, dimensions, metric, preprocessing, index_schema
+       FROM semantic_index_metadata WHERE id = 'claims'`,
+  );
+  assert.deepEqual(persisted, [{ ...vectors.fingerprint }]);
+
+  await db.batch([
+    {
+      sql: `INSERT INTO claims
+              (id, org_id, subject_id, project_id, workspace_id, observer_id,
+               actor_id, kind, statement, confidence, trust, visibility, status,
+               version, valid_from, valid_to, created_at)
+            VALUES ('clm_semantic_interim', 'org_semantic_backfill', 'subject',
+                    NULL, NULL, NULL, 'agent', 'semantic_fact', 'Interim FTS claim',
+                    1, 'asserted', 'private', 'active', 1,
+                    '2026-07-31T00:00:00.000Z', NULL, '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+  const interimGuard = await readyWith(db, runtime, vectors);
+  assert.equal(interimGuard.status, 503);
+  assert.equal(interimGuard.body.meta.checks.semantic_index, "index_backfill_required");
+  await db.batch([
+    {
+      sql: `INSERT INTO index_outbox
+              (id, org_id, record_type, record_id, operation, state, attempts, created_at)
+            VALUES ('idx_semantic_interim', 'org_semantic_backfill', 'claim',
+                    'clm_semantic_interim', 'upsert', 'pending', 0,
+                    '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+  assert.equal((await readyWith(db, runtime, vectors)).status, 200);
+
+  await db.batch([
+    {
+      sql: `UPDATE index_outbox SET state = 'done'
+             WHERE id IN ('idx_semantic_backfill', 'idx_semantic_interim')`,
+    },
+  ]);
+  const restoredWithoutProjection = fakeVectors();
+  restoredWithoutProjection.indexEmpty = true;
+  for (let restart = 0; restart < 2; restart += 1) {
+    const restoreGuard = await readyWith(db, runtime, restoredWithoutProjection);
+    assert.equal(restoreGuard.status, 503);
+    assert.equal(restoreGuard.body.meta.checks.semantic_index, "index_backfill_required");
+  }
+  assert.equal(restoredWithoutProjection.embedCalls(), 0);
+
+  const changed = fakeVectors();
+  changed.fingerprint = { ...changed.fingerprint, model: "contract-stub-v2" };
+  changed.embedder.model = "contract-stub-v2";
+  const mismatch = await readyWith(db, runtime, changed);
+  assert.equal(mismatch.status, 503);
+  assert.equal(mismatch.body.meta.capabilities.embedding, "enabled");
+  assert.equal(mismatch.body.meta.capabilities.vector, "configured_error");
+  assert.equal(mismatch.body.meta.checks.semantic_index, "index_fingerprint_mismatch");
+  assert.doesNotMatch(JSON.stringify(mismatch.body), /contract-stub-v2/);
+  assert.equal(changed.embedCalls(), 0);
+
+  const lexicalOnly = await readyWith(db, runtime);
+  assert.equal(lexicalOnly.status, 200);
+  assert.equal(lexicalOnly.body.data.capabilities.embedding, "disabled");
+  assert.equal(lexicalOnly.body.data.capabilities.vector, "disabled");
+
+  // Explicit reindex resets metadata and requeues derived work before the new
+  // fingerprint can become ready. The vector backend reset is runtime-specific.
+  await db.batch([
+    { sql: `DELETE FROM semantic_index_metadata WHERE id = 'claims'` },
+    {
+      sql: `UPDATE index_outbox SET state = 'pending', attempts = 0
+             WHERE record_type = 'claim'`,
+    },
+  ]);
+  const recovered = await readyWith(db, runtime, changed);
+  assert.equal(recovered.status, 200);
+  assert.equal(recovered.body.data.capabilities.vector, "enabled");
+  assert.equal(changed.embedCalls(), 0);
+
+  await db.batch([
+    { sql: `DELETE FROM semantic_index_metadata` },
+    {
+      sql: `DELETE FROM index_outbox
+             WHERE id IN ('idx_semantic_backfill', 'idx_semantic_interim')`,
+    },
+    {
+      sql: `DELETE FROM claims
+             WHERE id IN ('clm_semantic_backfill', 'clm_semantic_interim')`,
+    },
+    { sql: `DELETE FROM organizations WHERE id = 'org_semantic_backfill'` },
+  ]);
+}

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -188,7 +188,19 @@ for (const adapter of adapters)
           db,
           revision: "embedding-validation",
           runtime: adapter.name,
-          vectors: { store, embedder },
+          vectors: {
+            store,
+            embedder,
+            fingerprint: {
+              provider: "test",
+              model: embedder.model,
+              revision: "test",
+              dimensions,
+              metric: "cosine",
+              preprocessing: "none",
+              index_schema: "claims-v1",
+            },
+          },
         }),
         "http://titen.test",
       );

--- a/tests/integration/runtime-hardening.test.ts
+++ b/tests/integration/runtime-hardening.test.ts
@@ -49,14 +49,15 @@ test("a failed migration version rolls back fully and succeeds on retry", async 
     assert.equal(Number(version[0]!.version), SCHEMA_VERSION - 1);
     const integrity = await db.all<{ name: string; sql: string }>(
       `SELECT name, sql FROM sqlite_master
-        WHERE name IN ('checkpoints_scope', 'event_order') ORDER BY name`,
+        WHERE name IN ('checkpoints_scope', 'event_order', 'semantic_index_metadata')
+        ORDER BY name`,
     );
     assert.deepEqual(
       integrity.map(({ name }) => name),
-      ["checkpoints_scope"],
+      ["checkpoints_scope", "event_order"],
       `migration must roll back after statement ${failureAfter + 1}`,
     );
-    assert.doesNotMatch(integrity[0]!.sql, /UNIQUE/);
+    assert.match(integrity.find(({ name }) => name === "checkpoints_scope")!.sql, /UNIQUE/);
     assert.equal(await migrate(db), SCHEMA_VERSION);
     database.close();
   }

--- a/tests/integration/semantic-configuration.test.ts
+++ b/tests/integration/semantic-configuration.test.ts
@@ -1,0 +1,286 @@
+import { afterAll, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { tryCreateVectors } from "../../src/runtime/bun/vectors";
+import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
+import { migrate } from "../../src/core/migrations";
+import { serve } from "../../src/runtime/bun/server";
+import { tryCreateVectorize } from "../../src/runtime/cloudflare/vectors";
+import { fakeVectors, TEST_SECRET_CIPHER } from "../contract/harness";
+
+const directory = mkdtempSync(join(tmpdir(), "titen-semantic-config-"));
+afterAll(() => rmSync(directory, { recursive: true, force: true }));
+
+test("Bun distinguishes absent, partial, unavailable, and healthy semantic configuration", () => {
+  assert.deepEqual(tryCreateVectors({}).readiness, {
+    embedding: "disabled",
+    vector: "disabled",
+  });
+  assert.deepEqual(
+    tryCreateVectors({ embedBaseUrl: "http://127.0.0.1:11434/v1" }).readiness,
+    {
+      embedding: "configured_error",
+      vector: "configured_error",
+      diagnostic: "embedding_configuration_invalid",
+    },
+  );
+  assert.deepEqual(
+    tryCreateVectors({
+      vecDbPath: join(directory, "missing", "vectors.db"),
+      embedBaseUrl: "http://127.0.0.1:11434/v1",
+      embedModel: "model",
+      embedDims: 4,
+    }).readiness,
+    {
+      embedding: "enabled",
+      vector: "configured_error",
+      diagnostic: "vector_initialization_failed",
+    },
+  );
+  const healthy = tryCreateVectors({
+    vecDbPath: join(directory, "vectors.db"),
+    embedBaseUrl: "http://127.0.0.1:11434/v1",
+    embedModel: "model",
+    embedDims: 4,
+    embedRevision: "revision-1",
+  });
+  assert.deepEqual(healthy.readiness, { embedding: "enabled", vector: "enabled" });
+  assert.equal(healthy.vectors?.indexEmpty, true);
+  assert.deepEqual(healthy.vectors?.fingerprint, {
+    provider: healthy.vectors.fingerprint.provider,
+    model: "model",
+    revision: "revision-1",
+    dimensions: 4,
+    metric: "l2",
+    preprocessing: "text-v1",
+    index_schema: "claims-scope-v1",
+  });
+  assert.match(
+    healthy.vectors!.fingerprint.provider,
+    /^openai-compatible:[a-f0-9]{64}$/,
+  );
+  assert.doesNotMatch(healthy.vectors!.fingerprint.provider, /127\.0\.0\.1/);
+  const otherEndpoint = tryCreateVectors({
+    vecDbPath: join(directory, "other-endpoint.db"),
+    embedBaseUrl: "http://127.0.0.1:11435/v1",
+    embedModel: "model",
+    embedDims: 4,
+    embedRevision: "revision-1",
+  });
+  assert.notEqual(
+    otherEndpoint.vectors?.fingerprint.provider,
+    healthy.vectors?.fingerprint.provider,
+  );
+  const reopened = tryCreateVectors({
+    vecDbPath: join(directory, "vectors.db"),
+    embedBaseUrl: "http://127.0.0.1:11434/v1",
+    embedModel: "model",
+    embedDims: 4,
+    embedRevision: "revision-1",
+  });
+  assert.equal(reopened.vectors?.indexEmpty, true);
+  const incompatible = tryCreateVectors({
+    vecDbPath: join(directory, "vectors.db"),
+    embedBaseUrl: "http://127.0.0.1:11434/v1",
+    embedModel: "model",
+    embedDims: 8,
+  });
+  assert.equal(incompatible.readiness.vector, "configured_error");
+  assert.equal(incompatible.readiness.diagnostic, "vector_initialization_failed");
+});
+
+test("Bun refuses canonical database aliases before vector schema mutation", () => {
+  const canonicalPath = join(directory, "canonical.db");
+  const canonical = openDatabase(canonicalPath);
+  canonical.run("CREATE TABLE canonical_marker(value TEXT)");
+  canonical.close();
+  const aliasPath = join(directory, "canonical-alias.db");
+  symlinkSync(canonicalPath, aliasPath);
+
+  for (const vecDbPath of [canonicalPath, aliasPath]) {
+    const result = tryCreateVectors({
+      canonicalDbPath: canonicalPath,
+      vecDbPath,
+      embedBaseUrl: "http://127.0.0.1:11434/v1",
+      embedModel: "model",
+      embedDims: 4,
+    });
+    assert.deepEqual(result.readiness, {
+      embedding: "enabled",
+      vector: "configured_error",
+      diagnostic: "vector_storage_conflict",
+    });
+  }
+
+  const reopened = openDatabase(canonicalPath);
+  assert.equal(
+    reopened.query("SELECT COUNT(*) AS count FROM sqlite_master WHERE name = 'vec_claims'").get()?.count,
+    0,
+  );
+  reopened.close();
+});
+
+test("Bun rejects plain and wrong-module vec_claims lookalikes", () => {
+  const schemas = [
+    `CREATE TABLE vec_claims(
+       id TEXT PRIMARY KEY, embedding float[4], org_id TEXT, subject_id TEXT, project_id TEXT
+     )`,
+    `CREATE VIRTUAL TABLE vec_claims USING fts5(
+       id, embedding, org_id, subject_id, project_id
+     )`,
+    `CREATE VIRTUAL TABLE vec_claims USING vec0(
+       id TEXT PRIMARY KEY, embedding float[4], org_id TEXT,
+       subject_id TEXT, project_id TEXT
+     )`,
+  ];
+  for (const [index, schema] of schemas.entries()) {
+    const vecDbPath = join(directory, `lookalike-${index}.db`);
+    const handle = openDatabase(vecDbPath);
+    if (schema.includes("USING vec0")) {
+      const sqliteVec = require("sqlite-vec") as { load(db: unknown): void };
+      sqliteVec.load(handle);
+    }
+    handle.run(schema);
+    const before = handle.query("SELECT sql FROM sqlite_master WHERE name = 'vec_claims'").get()?.sql;
+    handle.close();
+
+    const result = tryCreateVectors({
+      vecDbPath,
+      embedBaseUrl: "http://127.0.0.1:11434/v1",
+      embedModel: "model",
+      embedDims: 4,
+    });
+    assert.equal(result.readiness.vector, "configured_error");
+    assert.equal(result.readiness.diagnostic, "vector_initialization_failed");
+
+    const reopened = openDatabase(vecDbPath);
+    assert.equal(
+      reopened.query("SELECT sql FROM sqlite_master WHERE name = 'vec_claims'").get()?.sql,
+      before,
+    );
+    reopened.close();
+  }
+});
+
+test("Cloudflare validates binding completeness without calling either binding", () => {
+  let calls = 0;
+  const ai = { run: async () => { calls += 1; return { data: [] }; } };
+  const vectorize = {
+    upsert: async () => { calls += 1; },
+    query: async () => { calls += 1; return { matches: [] }; },
+    deleteByIds: async () => { calls += 1; },
+  };
+  assert.deepEqual(tryCreateVectorize({}).readiness, {
+    embedding: "disabled",
+    vector: "disabled",
+  });
+  assert.deepEqual(tryCreateVectorize({ AI: ai }).readiness, {
+    embedding: "enabled",
+    vector: "configured_error",
+    diagnostic: "vector_initialization_failed",
+  });
+  assert.equal(
+    tryCreateVectorize({ AI: ai, VECTORIZE: vectorize, TITEN_EMBED_DIMS: "nope" })
+      .readiness.diagnostic,
+    "embedding_configuration_invalid",
+  );
+  const healthy = tryCreateVectorize({
+    AI: ai,
+    VECTORIZE: vectorize,
+    TITEN_EMBED_MODEL: "@cf/example/model",
+    TITEN_EMBED_DIMS: "4",
+    TITEN_EMBED_REVISION: "revision-1",
+  });
+  assert.equal(healthy.readiness.vector, "enabled");
+  assert.equal(healthy.vectors?.fingerprint.provider, "workers-ai");
+  assert.equal(calls, 0, "configuration and readiness must not call remote bindings");
+});
+
+test("Bun serves health but fails readiness for a partial semantic tuple", async () => {
+  const running = await serve({
+    dbPath: join(directory, "partial.db"),
+    port: 0,
+    hostname: "127.0.0.1",
+    quiet: true,
+    maintenanceIntervalMs: 0,
+    embedBaseUrl: "http://127.0.0.1:9/v1",
+    secretCipher: TEST_SECRET_CIPHER,
+  });
+  try {
+    assert.equal((await fetch(`${running.url}/healthz`)).status, 200);
+    const response = await fetch(`${running.url}/readyz`);
+    assert.equal(response.status, 503);
+    const body = await response.json() as any;
+    assert.equal(body.meta.capabilities.embedding, "configured_error");
+    assert.equal(body.meta.capabilities.vector, "configured_error");
+    assert.equal(body.meta.checks.semantic_index, "embedding_configuration_invalid");
+    assert.doesNotMatch(JSON.stringify(body), /127\.0\.0\.1:9/);
+  } finally {
+    await running.stop();
+  }
+});
+
+test("Bun consumes prepared semantic state after pending work drains", async () => {
+  const dbPath = join(directory, "prepared-state.db");
+  const handle = openDatabase(dbPath);
+  const db = createSqliteDb(handle);
+  await migrate(db);
+  await db.batch([
+    {
+      sql: `INSERT INTO organizations (id, name, created_at)
+            VALUES ('org_prepared', 'Prepared', '2026-07-31T00:00:00.000Z')`,
+    },
+    {
+      sql: `INSERT INTO claims
+              (id, org_id, subject_id, project_id, workspace_id, observer_id,
+               actor_id, kind, statement, confidence, trust, visibility, status,
+               version, valid_from, valid_to, created_at)
+            VALUES ('clm_prepared', 'org_prepared', 'subject', NULL, NULL, NULL,
+                    'agent', 'semantic_fact', 'Prepared semantic state', 1,
+                    'asserted', 'private', 'active', 1,
+                    '2026-07-31T00:00:00.000Z', NULL,
+                    '2026-07-31T00:00:00.000Z')`,
+    },
+    {
+      sql: `INSERT INTO index_outbox
+              (id, org_id, record_type, record_id, operation, state, attempts, created_at)
+            VALUES ('idx_prepared', 'org_prepared', 'claim', 'clm_prepared',
+                    'upsert', 'pending', 0, '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+  handle.close();
+
+  const vectors = fakeVectors();
+  vectors.indexEmpty = true;
+  const running = await serve({
+    dbPath,
+    port: 0,
+    hostname: "127.0.0.1",
+    quiet: true,
+    maintenanceIntervalMs: 10,
+    vectors,
+    secretCipher: TEST_SECRET_CIPHER,
+  });
+  try {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const state = running.database
+        .query("SELECT state FROM index_outbox WHERE id = 'idx_prepared'")
+        .get() as { state: string } | null;
+      if (state?.state === "done") break;
+      await Bun.sleep(10);
+    }
+    assert.equal(
+      (running.database
+        .query("SELECT state FROM index_outbox WHERE id = 'idx_prepared'")
+        .get() as { state: string }).state,
+      "done",
+    );
+    const response = await fetch(`${running.url}/readyz`);
+    assert.equal(response.status, 200);
+    assert.equal((await response.json() as any).data.capabilities.vector, "enabled");
+  } finally {
+    await running.stop();
+  }
+});

--- a/tests/integration/sqlite-vec.test.ts
+++ b/tests/integration/sqlite-vec.test.ts
@@ -179,6 +179,15 @@ test("the real store drives compilation through the shared core", async () => {
 
   const capability = {
     store: store!,
+    fingerprint: {
+      provider: "integration",
+      model: "stub",
+      revision: "v1",
+      dimensions: DIMENSIONS,
+      metric: "l2",
+      preprocessing: "text-v1",
+      index_schema: "claims-scope-v1",
+    },
     embedder: createHttpEmbedder({
       baseUrl: `http://127.0.0.1:${server.port}/v1`,
       model: "stub",


### PR DESCRIPTION
## Summary

- distinguish intentional FTS-only operation from configured semantic failure
- persist and compare a credential-free provider/index fingerprint locally with migration 13
- reject endpoint drift, model/dimension drift, canonical/vector path aliasing, malformed vec0 schemas, and missing historical reindex work before readiness
- expose versioned embedding, extraction, and background-enrichment capability states while retaining the deprecated model alias
- keep sqlite-vec opt-in through an optional peer and package-test the exact documented install path

Fixes #138
Fixes #140

## Verification

- independent correctness/security/backward-compat review: PASS
- Cloudflare D1 contract: 93 passed
- Bun contract, vectors, and SDK: 114 passed
- integration: 139 passed
- browser: 10 passed
- Worker/Astro builds, live-dashboard adapter smoke, clean package negative/positive vector smoke, workflow 46, routes 56, frozen lockfile, and diff check: passed

GitHub Actions remains disabled; all gates are manual to keep hosted automation cost at zero.