### PR TITLE
test: retain D1 contention diagnostics

### DIFF
--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -68,6 +68,11 @@ evidence.
   project scope to unscoped-only at the shared compiler boundary, capability-
   gate explicit cross-project mode, return effective scope/reason, and prove
   REST, SDK, MCP, OpenClaw guidance, and dual-runtime authorization parity.
+- [x] Retain safe diagnostics for every unexpected non-200/201 response from the
+  reopened #102 D1 concurrency contract while preserving exact aggregate and
+  one-head/one-winner assertions. Instrumentation is ready; the checkpoint
+  recurrence remains unclassified, while only emulator transport instability
+  is separately tracked in #157.
 - [x] Rewrite and human-review README.md, verify `titen.dev`, run `seng-jelas`
   strictly, and prove the packaged README contains only stable external links.
 - [x] Run focused checks after each integration, then the complete local manual
@@ -118,6 +123,7 @@ to its merged evidence or to the concrete decision recorded here.
 | #138 | Distinguish intentional FTS-only operation from configured semantic failure; persist/compare the migration-13 index fingerprint, fail local readiness closed on incompatible or unavailable vector state, and expose separate embedding/extraction/background capability fields without implementing planned enrichment. |
 | #140 | Keep the default package dependency-free, publish one explicit `sqlite-vec@0.1.9` install command, and exercise both missing-dependency failure and vector-ready success from the clean packed consumer. |
 | #141 | Make omitted project scope select only unscoped claims; add explicit `cross_project` mode guarded by `context:compile:all`, report `project_mode` and the capability-backed broad reason, and make every distributed agent skill resolve a repository project before compile. |
+| #102 recurrence | Keep the atomic UPSERT and handoff fence; retain safe diagnostics for each unexpected D1 contention response, keep the issue open until isolated repeated evidence classifies the recurrence, and add no product retry without a reproducible database failure. |
 
 ## Acceptance evidence mapping
 
@@ -183,6 +189,10 @@ to its merged evidence or to the concrete decision recorded here.
 - AC-SWP-022: portable-skill copy parity and OpenClaw host-kit integration test
   proving repository scope is resolved before compile and cross-project mode is
   never the default.
+- AC-SWP-023: exact aggregate concurrent checkpoint assertions plus safe
+  status/error diagnostics for each unexpected response and one durable head;
+  the unclassified #102 recurrence remains distinct from #157 emulator
+  transport failures.
 
 ## Security, migration, deployment, smoke, and rollback
 

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -56,6 +56,13 @@ authenticated organization. The patch must make omission unscoped-only and
 reserve cross-project compilation for an explicit request backed by a separate
 credential capability.
 
+Issue #102 was reopened after one complete Cloudflare/D1 contract run returned
+only ten successful updates from twelve concurrent checkpoint saves. Isolated
+repetition did not reproduce the result, so the release gate must retain the
+status and safe error envelope of every loser, distinguish a product race from
+a Miniflare/runtime transient, and never hide an unexplained non-success behind
+an aggregate count.
+
 Treating every report as a feature request would add speculative machinery;
 closing every report without checking it would hide real defects. The release
 needs an issue-by-issue resolution, current branch integration, accurate public
@@ -108,6 +115,9 @@ documentation, and an install smoke against the immutable npm artifact.
   broader compile, and report the effective project mode and grant reason.
 - Keep REST, SDK, MCP, and the portable OpenClaw-compatible skill aligned so a
   repository task resolves and supplies its canonical project by default.
+- Diagnose the reopened D1 checkpoint contention result from complete-suite
+  evidence; keep the one-head invariant and make expected concurrent outcomes
+  explicit without weakening the canonical integrity assertion.
 - Preserve the user's dirty original checkout and existing stash byte-for-byte.
 
 ## Out of scope
@@ -249,6 +259,11 @@ documentation, and an install smoke against the immutable npm artifact.
   OpenClaw distribution, shall resolve the active canonical project and pass its
   opaque ID for repository work; it shall use unscoped compilation only outside
   a project and shall not request cross-project mode by default.
+- **AC-SWP-023 — Event-driven:** When concurrent checkpoint saves are exercised
+  through the Cloudflare/D1 contract, every unexpected non-200/201 response
+  shall be retained in assertion-failure evidence, exact aggregate status
+  counts shall remain asserted, exactly one durable head shall remain, and no
+  unexplained non-success shall be hidden behind an aggregate count.
 
 ## Done conditions
 

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -3953,6 +3953,20 @@ export const CASES: Case[] = [
             ttl_seconds: 600,
           },
         })));
+      const failedSaves = saves
+        .map((result, index) => ({
+          index,
+          status: result.status,
+          code: result.body?.error?.code,
+          message: result.body?.error?.message,
+          request_id: result.body?.meta?.request_id,
+        }))
+        .filter(({ status }) => status !== 200 && status !== 201);
+      assert.deepEqual(
+        failedSaves,
+        [],
+        `unexpected checkpoint responses: ${JSON.stringify(failedSaves)}`,
+      );
       assert.equal(saves.filter((result) => result.status === 201).length, 1);
       assert.equal(saves.filter((result) => result.status === 200).length, 11);
       assert.equal(new Set(saves.map((result) => result.body.data.checkpoint_id)).size, 1);


### PR DESCRIPTION
## Summary

- retain safe diagnostics for every unexpected concurrent checkpoint response
- keep exact aggregate, one-head, current-state, and handoff-winner assertions unchanged
- add no retry or speculative product behavior

Refs #102

## Verification

- independent review of the diagnostic patch: PASS
- named checkpoint contention case: Bun 1/1 and Cloudflare/D1 1/1 on rebased head
- prior named Cloudflare/D1 repetition: 20/20
- workflow 48, self-test, diff check, and Worker dry build: passed

The checkpoint recurrence remains unclassified and #102 stays open. Issue #157 separately tracks invalid Miniflare RPC/hang failures; it does not replace the product-integrity investigation.

GitHub Actions remains disabled; these gates are manual so the repository incurs no hosted automation cost.