### PR TITLE
fix: validate injected embedding providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 - Successful SDK responses now reject array, `null`, and primitive JSON
   envelopes with an `INVALID_RESPONSE` `TitenError` while preserving the HTTP
   status, request ID, and safe response metadata.
-- Bun HTTP and Cloudflare Workers AI embedding responses now require exact
-  output cardinality, ordered provider indices when present, dense configured
-  dimensions, and finite numeric coordinates before vector query or indexing.
+- Bun HTTP, Cloudflare Workers AI, and injected embedding-provider results now
+  require exact output cardinality, ordered provider indices when present,
+  dense configured dimensions, and finite numeric coordinates before vector
+  query or indexing.
 - Semantic readiness now distinguishes intentional FTS-only operation from
   partial configuration, unavailable vector initialization, legacy untracked
   vectors, missing requeue work, unsafe storage aliasing, empty restored

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -31,6 +31,10 @@ evidence.
   shared output validator; reject malformed shape, cardinality, indices,
   density, dimensions, and values before vector query/upsert, then prove outbox
   retryability and FTS degradation behavior in both runtimes.
+- [x] Validate the normalized result at every shared-core `EmbeddingProvider`
+  consumer so an injected provider cannot send missing, wrong-dimension, or
+  non-finite vectors to query/upsert or mark index work done; cover manual drain,
+  background maintenance, and lexical degradation without duplicating adapters.
 - [x] Trace semantic configuration, vector initialization, index metadata,
   readiness, and maintenance through both runtime adapters; add migration 13
   for the minimal index fingerprint and fail configured semantic startup closed
@@ -134,10 +138,11 @@ to its merged evidence or to the concrete decision recorded here.
 - AC-SWP-012: changelog and package version diff, frozen-lockfile verification,
   focused SDK and package gates, annotated-tag peel, npm/GitHub metadata, and
   clean `0.3.1` registry smoke against the exact reviewed source.
-- AC-SWP-013: table-driven shared-validator cases plus Bun HTTP and Cloudflare
-  Workers AI contract regressions for missing/extra/index/sparse/type/finite/
-  dimension failures, no vector writes, unchanged pending outbox rows,
-  sanitized `503` metadata, and successful authorized FTS-only compile.
+- AC-SWP-013: table-driven adapter and normalized-core validator cases plus Bun
+  HTTP, Cloudflare Workers AI, and injected-provider regressions for missing/
+  extra/index/sparse/type/finite/dimension failures, no vector query or write,
+  unchanged pending outbox rows, sanitized `503` metadata, and successful
+  authorized FTS-only compile.
 - AC-SWP-014: dual-runtime FTS-only readiness tests plus a clean production
   install without `sqlite-vec` or semantic configuration.
 - AC-SWP-015: table-driven partial/invalid configuration, missing

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -29,9 +29,11 @@ verified publication evidence.
 Issue #137 subsequently demonstrated that both embedding adapters trust
 successful provider payloads too far: missing or extra outputs, invalid
 provider indices, and sparse or non-finite vectors can reach the rebuildable
-semantic-index path. The same patch candidate must reject malformed embedding
-output at one shared boundary while retaining canonical SQL, FTS, and retryable
-index work.
+semantic-index path. Post-merge review also proved that the documented injected
+`EmbeddingProvider` boundary can bypass adapter validation. The same patch
+candidate must validate normalized provider results in shared core immediately
+before query or mutation while retaining canonical SQL, FTS, and retryable index
+work.
 
 Issue #138 then demonstrated that a configured semantic deployment can report
 ready while silently falling back to FTS because invalid embedding settings,
@@ -70,8 +72,9 @@ documentation, and an install smoke against the immutable npm artifact.
 - Reject non-object successful SDK envelopes at the shared response boundary,
   preserve diagnostic status, request ID, and safe response metadata in the
   resulting `TitenError`, and publish the verified correction as `0.3.1`.
-- Validate Bun HTTP and Cloudflare Workers AI embedding output through one
-  shared boundary before any vector query or mutation can consume it.
+- Validate Bun HTTP, Cloudflare Workers AI, and injected embedding-provider
+  output through shared adapter parsing plus one normalized core boundary before
+  any vector query or mutation can consume it.
 - Make semantic readiness fail closed when embedding or vector operation is
   requested but cannot be initialized safely; persist and compare the minimum
   compatible index fingerprint while preserving intentional FTS-only startup.
@@ -176,10 +179,11 @@ documentation, and an install smoke against the immutable npm artifact.
 - **AC-SWP-013 — Unwanted behavior:** If an embedding provider returns anything
   other than exactly one dense configured-dimension vector per input containing
   only finite JavaScript numbers, or supplies indices that are not unique,
-  contiguous, and in input order, then the shared Bun/Cloudflare validator shall
-  reject the output as a sanitized retryable embedder dependency failure, write
-  no vector, leave selected index work pending, and keep authorized FTS recall
-  available.
+  contiguous, and in input order, then shared adapter parsing and the normalized
+  core consumer boundary shall reject the output as a sanitized retryable
+  embedder dependency failure, write or query no vector, leave selected index
+  work pending, and keep authorized FTS recall available. The rule shall also
+  hold for a caller-supplied `EmbeddingProvider` that bypasses built-in adapters.
 - **AC-SWP-014 — Optional feature:** Where no embedding or vector capability is
   configured, Titen shall keep `/readyz` ready with FTS `enabled` and semantic
   capabilities explicitly `disabled`.

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -10,6 +10,7 @@ import { planFtsQuery, retrieveClaimCandidates, retrieveClaimsByIds } from "./re
 import { loadAuthorizedEvidenceIds } from "./evidence";
 import { estimateJsonTokens } from "./tokens";
 import type { RequestContext, Result } from "./http";
+import { validateEmbeddingVectors } from "./vectors";
 import {
   FEEDBACK_OUTCOMES,
   LIMITS,
@@ -74,7 +75,11 @@ export async function compileContext(ctx: RequestContext): Promise<Result> {
   let vectorUsed = false;
   if (ctx.app.vectors) {
     try {
-      const queryVec = (await ctx.app.vectors.embedder.embed([task]))[0];
+      const queryVec = validateEmbeddingVectors(
+        await ctx.app.vectors.embedder.embed([task]),
+        1,
+        ctx.app.vectors.embedder.dimensions,
+      )[0];
       if (queryVec) {
         const hits = await ctx.app.vectors.store.query(queryVec, {
           topK: LIMITS.candidates,

--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -1,6 +1,7 @@
 import { first } from "./db";
 import { unavailable, validationError } from "./errors";
 import type { RequestContext, Result } from "./http";
+import { validateEmbeddingVectors } from "./vectors";
 
 /**
  * Drains the indexing outbox into the vector store.
@@ -98,8 +99,12 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
     // One embedding request for the batch, then one index write.
     let vectors;
     try {
-      vectors = await ctx.app.vectors.embedder.embed(
-        eligible.map((entry) => entry.statement),
+      vectors = validateEmbeddingVectors(
+        await ctx.app.vectors.embedder.embed(
+          eligible.map((entry) => entry.statement),
+        ),
+        eligible.length,
+        ctx.app.vectors.embedder.dimensions,
       );
     } catch {
       throw unavailable("Indexing dependency is unavailable.", {

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -1,6 +1,6 @@
 import type { Db } from "./db";
 import { processWebhooks } from "./webhooks";
-import type { VectorCapability } from "./vectors";
+import { validateEmbeddingVectors, type VectorCapability } from "./vectors";
 import type { WebhookSecurity } from "./webhook-security";
 import type { SecretCipher } from "./secrets";
 import { eventAccessSql } from "./events";
@@ -180,7 +180,11 @@ export async function indexPendingForOrg(
 
   let indexed = 0;
   if (eligible.length > 0) {
-    const embeddings = await vectors.embedder.embed(eligible.map((entry) => entry.statement));
+    const embeddings = validateEmbeddingVectors(
+      await vectors.embedder.embed(eligible.map((entry) => entry.statement)),
+      eligible.length,
+      vectors.embedder.dimensions,
+    );
     await vectors.store.upsert(
       eligible.map((entry, index) => ({
         id: entry.claimId,

--- a/src/core/vectors.ts
+++ b/src/core/vectors.ts
@@ -46,6 +46,25 @@ function invalidEmbeddingResponse(): never {
   throw new Error("Invalid embedding response.");
 }
 
+/** Validate the normalized extension boundary used by every core consumer. */
+export function validateEmbeddingVectors(
+  response: unknown,
+  expectedCount: number,
+  dimensions: number,
+): Float32Array[] {
+  if (!Array.isArray(response) || response.length !== expectedCount)
+    invalidEmbeddingResponse();
+  for (let position = 0; position < response.length; position += 1) {
+    if (!Object.hasOwn(response, position)) invalidEmbeddingResponse();
+    const vector = response[position];
+    if (!(vector instanceof Float32Array) || vector.length !== dimensions)
+      invalidEmbeddingResponse();
+    for (const value of vector)
+      if (!Number.isFinite(value)) invalidEmbeddingResponse();
+  }
+  return response;
+}
+
 /** Validate untrusted provider output before it can reach a vector backend. */
 export function validateEmbeddingResponse(
   response: unknown,
@@ -96,7 +115,7 @@ export function validateEmbeddingResponse(
     }
     vectors.push(vector);
   }
-  return vectors;
+  return validateEmbeddingVectors(vectors, expectedCount, dimensions);
 }
 
 /**

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -4,9 +4,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "../../src/core/app";
+import { runMaintenance } from "../../src/core/maintenance";
 import { migrate } from "../../src/core/migrations";
 import {
   validateEmbeddingResponse,
+  validateEmbeddingVectors,
   type EmbeddingProvider,
   type VectorStore,
 } from "../../src/core/vectors";
@@ -106,6 +108,24 @@ test("shared embedding validator accepts both provider shapes in input order", (
   );
 });
 
+const invalidNormalized = [
+  ["missing output", () => []],
+  ["extra output", () => [new Float32Array(dense()), new Float32Array(dense())]],
+  ["sparse output list", () => Array(1)],
+  ["plain numeric array", () => [dense()]],
+  ["wrong dimensions", () => [new Float32Array(2)]],
+  ["NaN coordinate", () => [new Float32Array([1, Number.NaN, 0, 0])]],
+  ["infinite coordinate", () => [new Float32Array([1, Number.POSITIVE_INFINITY, 0, 0])]],
+] as const;
+
+for (const [name, response] of invalidNormalized)
+  test(`normalized embedding boundary rejects ${name}`, () => {
+    assert.throws(
+      () => validateEmbeddingVectors(response(), 1, dimensions),
+      /^Error: Invalid embedding response\.$/,
+    );
+  });
+
 const adapters: {
   name: string;
   create: (response: unknown) => {
@@ -144,6 +164,23 @@ const adapters: {
   },
 ];
 
+const consumers: typeof adapters = [
+  ...adapters,
+  {
+    name: "Injected provider",
+    create: () => ({
+      embedder: {
+        dimensions,
+        model: "malformed",
+        async embed(): Promise<Float32Array[]> {
+          return [];
+        },
+      },
+      close: () => {},
+    }),
+  },
+];
+
 for (const adapter of adapters)
   for (const [name, response, expectedCount] of invalid)
     test(`${adapter.name} rejects ${name}`, async () => {
@@ -161,7 +198,7 @@ for (const adapter of adapters)
       }
     });
 
-for (const adapter of adapters)
+for (const adapter of consumers)
   test(`${adapter.name} malformed output stays retryable and degrades to FTS`, async () => {
     const directory = mkdtempSync(join(tmpdir(), "titen-embed-validation-"));
     const handle = openDatabase(join(directory, "titen.db"));
@@ -183,24 +220,25 @@ for (const adapter of adapters)
     try {
       await migrate(db);
       const provisioned = await provisionWith(db, { scopes: ["*"] });
+      const vectors = {
+        store,
+        embedder,
+        fingerprint: {
+          provider: "test",
+          model: embedder.model,
+          revision: "test",
+          dimensions,
+          metric: "cosine",
+          preprocessing: "none",
+          index_schema: "claims-v1",
+        },
+      };
       const client = clientVia(
         createApp({
           db,
           revision: "embedding-validation",
           runtime: adapter.name,
-          vectors: {
-            store,
-            embedder,
-            fingerprint: {
-              provider: "test",
-              model: embedder.model,
-              revision: "test",
-              dimensions,
-              metric: "cosine",
-              preprocessing: "none",
-              index_schema: "claims-v1",
-            },
-          },
+          vectors,
         }),
         "http://titen.test",
       );
@@ -257,6 +295,18 @@ for (const adapter of adapters)
       assert.equal(failed.body.meta.retryable, true);
       assert.equal(failed.body.meta.pending, before);
       assert.doesNotMatch(JSON.stringify(failed.body), /Invalid embedding response/);
+      assert.equal(await pending(), before);
+      assert.equal(vectorWrites, 0);
+
+      const background = await runMaintenance({
+        db,
+        vectors,
+        limit: 50,
+        now: new Date("2026-07-31T00:00:00.000Z"),
+        deliverWebhooks: false,
+      });
+      assert.equal(background.indexed, 0);
+      assert.deepEqual(background.errors, [`index:${provisioned.orgId.slice(0, 12)}`]);
       assert.equal(await pending(), before);
       assert.equal(vectorWrites, 0);
 


### PR DESCRIPTION
## Summary

- validate normalized `EmbeddingProvider` results at all three shared-core consumers
- prevent injected providers from sending missing, wrong-dimension, or non-finite vectors to query/upsert
- preserve retryable pending index work and authorized FTS degradation for manual and background drains

Fixes #137

## Verification

- embedding validation matrix: 59 passed
- affected Bun/vector/maintenance set: 164 passed
- Cloudflare D1 contract: 93 passed
- Worker dry build, workflow 46, and diff check: passed

GitHub Actions remains disabled; all gates are manual to keep hosted automation cost at zero.
