### PR TITLE
fix: report observed semantic dependency outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 - Semantic readiness now distinguishes intentional FTS-only operation from
   partial configuration, unavailable vector initialization, legacy untracked
   vectors, missing requeue work, unsafe storage aliasing, empty restored
-  projections, and incompatible fingerprints; configured failures return a
-  fixed local diagnostic without probing providers.
+  projections, incompatible fingerprints, and locally observed indexing
+  dependency failures; configured failures return a fixed local diagnostic
+  without probing providers.
 
 ### Changed
 
@@ -42,7 +43,9 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
   enrichment separately while retaining `model` as a deprecated `0.3.x`
   embedding alias. Migration 13 persists the claim-index provider, model,
   revision, dimensions, metric, preprocessing, and schema fingerprint and
-  requires an explicit reindex after incompatibility.
+  requires an explicit reindex after incompatibility. Migration 14 retains only
+  safe embedder/vector-store failure timestamps in semantic metadata until a
+  later complete embed/upsert proves recovery.
 - `sqlite-vec@0.1.9` is a pinned optional peer: default installs remain
   dependency-light while the documented vector install is machine-verifiable.
 - Context compilation now treats a missing `project_id` as unscoped-only;

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -118,8 +118,10 @@ invalid dimension, or binding object without the required methods returns
 Migration 13 persists provider `workers-ai`, model, revision, dimensions,
 cosine metric, preprocessing `text-v1`, and index schema `claims-scope-v1` in
 D1. Readiness compares those local facts without calling Workers AI or
-Vectorize. `enabled` is therefore not provider-reachability evidence; a real
-index drain/query smoke supplies that evidence.
+Vectorize. Migration 14 retains only safe embedder/vector-store failure
+timestamps in semantic metadata, so `/readyz` fails without a provider probe
+until a later complete embed/upsert proves recovery. A real drain/query smoke
+supplies the initial reachability evidence and proves recovery.
 
 Changing any fingerprint field requires an explicit reindex. Provision a fresh
 compatible Vectorize index (or clear the rebuildable old projection), stop

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -182,6 +182,12 @@ dimensions, L2 metric, preprocessing `text-v1`, and index schema
 `claims-scope-v1`. A missing legacy fingerprint or any change fails readiness.
 Titen never rewrites this metadata or deletes vectors automatically.
 
+Migration 14 records only safe embedder/vector-store failure timestamps in
+semantic metadata. That local evidence fails `/readyz` without probing either
+dependency until a later complete embed/upsert proves recovery. After repairing
+an outage, drain eligible upsert work, require `/readyz`, then perform a semantic
+query smoke.
+
 To adopt a new fingerprint, stop Titen, take a verified canonical backup, then
 reset only the rebuildable projection and requeue claim index work:
 

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -39,10 +39,10 @@ evidence.
   readiness, and maintenance through both runtime adapters; add migration 13
   for the minimal index fingerprint and fail configured semantic startup closed
   without adding provider probes or abstractions.
-- [ ] Extend semantic metadata with the last safe dependency failure kind/time;
-  record it from manual and background index drains, make `/readyz` fail locally
-  after the observed outage, and clear it only after a successful embed/upsert
-  recovery on both SQL runtimes.
+- [x] Extend semantic metadata with independent safe embedder/vector-store
+  failure timestamps; increment attempts on affected pending work, make
+  `/readyz` fail locally after an observed outage, and clear both markers only
+  after a successful embed/upsert recovery on both SQL runtimes.
 - [x] Bind Bun fingerprints to the normalized endpoint without storing topology,
   reject canonical/vector path aliasing before extension mutation, and fail
   readiness closed when historical indexable claims lack requeue work.
@@ -150,13 +150,16 @@ to its merged evidence or to the concrete decision recorded here.
 - AC-SWP-013: table-driven adapter and normalized-core validator cases plus Bun
   HTTP, Cloudflare Workers AI, and injected-provider regressions for missing/
   extra/index/sparse/type/finite/dimension failures, no vector query or write,
-  unchanged pending outbox rows, sanitized `503` metadata, and successful
-  authorized FTS-only compile.
+  pending state/count preserved while only safe attempt/failure evidence changes,
+  sanitized `503` metadata, and successful authorized FTS-only compile.
 - AC-SWP-014: dual-runtime FTS-only readiness tests plus a clean production
   install without `sqlite-vec` or semantic configuration.
 - AC-SWP-015: table-driven partial/invalid configuration, missing
-  extension/backend/schema, and fingerprint-mismatch readiness tests with
-  sanitized diagnostics.
+  extension/backend/schema, fingerprint mismatch, independent and combined
+  observed dependency markers, cross-organization non-clear, delete-only
+  non-recovery, pre-v14 sanitized readiness, and manual/background recovery;
+  the marker lifecycle runs through the shared Bun/D1 contract without provider
+  I/O or sensitive diagnostics.
 - AC-SWP-016: migration-13 schema inspection, first-initialization persistence,
   exact fingerprint comparison, mismatch recovery only after an explicit
   reindex, and dual-runtime contract evidence.
@@ -192,6 +195,9 @@ Migration 13 adds only semantic index metadata; SQL remains canonical and
 vectors remain rebuildable. A semantic fingerprint mismatch is not repaired
 implicitly: rollback is disabling semantic configuration for explicit FTS-only
 operation or running the documented reindex path with the intended fingerprint.
+Migration 14 adds only two nullable dependency-failure timestamps to the
+singleton semantic metadata row. Delete-only completion or retirement cannot
+clear them; disabling semantic configuration remains the fail-closed rollback.
 
 Before merge, rollback is branch deletion. After merge and before npm publish,
 rollback is a reviewed revert. After npm publish, a bad immutable artifact must

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -39,6 +39,10 @@ evidence.
   readiness, and maintenance through both runtime adapters; add migration 13
   for the minimal index fingerprint and fail configured semantic startup closed
   without adding provider probes or abstractions.
+- [ ] Extend semantic metadata with the last safe dependency failure kind/time;
+  record it from manual and background index drains, make `/readyz` fail locally
+  after the observed outage, and clear it only after a successful embed/upsert
+  recovery on both SQL runtimes.
 - [x] Bind Bun fingerprints to the normalized endpoint without storing topology,
   reject canonical/vector path aliasing before extension mutation, and fail
   readiness closed when historical indexable claims lack requeue work.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -615,15 +615,19 @@ provider identity, model, revision, dimensions, metric, preprocessing version,
 and index-schema version with migration-13 metadata. Partial/invalid
 configuration, unavailable or aliased local vector storage, an untracked legacy
 index, missing historical requeue work, an empty projection after canonical-only
-restore, or fingerprint mismatch returns `503 NOT_READY`, marks the affected
+restore, fingerprint mismatch, or a migration-14 locally recorded embedder/
+vector-store indexing failure returns `503 NOT_READY`, marks the affected
 capability `configured_error`, and supplies one fixed
 `checks.semantic_index` diagnostic. The response does not expose the
 fingerprint, endpoint, database path, or provider error.
 
 Readiness performs bounded local configuration/path/schema/metadata checks only. It
-makes no embedding-provider or vector-index network call. `enabled` therefore
-means locally initialized and fingerprint-compatible, not that a remote provider
-was reachable; indexing and context degradation report runtime provider failure.
+makes no embedding-provider or vector-index network call. Before a dependency is
+used, `enabled` means locally initialized and fingerprint-compatible. A failed
+manual or background index attempt stores only a safe dependency timestamp in
+semantic metadata, increments affected outbox attempts, and makes readiness fail
+locally. Only a later complete embed/upsert clears the observed failure; delete
+or retirement work cannot report recovery.
 
 `capabilities.background_repair` is canonical scheduler evidence. `enabled`
 means a configured scheduler recorded a successful pass within its bounded

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -3,8 +3,9 @@
 Status: logical target schema. Current migrations implement the canonical
 kernel, `index_outbox`, and delivery state; model-assisted `enrichment_jobs`,
 their worker lease/fingerprint semantics, and vector `submitted/ready` states
-remain proposed. Migration 13 implements the singleton semantic-index
-fingerprint; collaboration leases described below are implemented.
+remain proposed. Migrations 13–14 implement the singleton semantic-index
+fingerprint and safe observed-failure marker; collaboration leases described
+below are implemented.
 
 ## Authority and precedence
 
@@ -432,7 +433,8 @@ canonical version or the deletion is confirmed.
 
 The current physical `index_outbox` has a smaller `pending/done/failed` shape
 and marks an accepted upsert complete. Migration 13 fingerprints the index as a
-whole; per-row leased/fingerprinted outbox state remains proposed.
+whole. Failed dependency attempts increment the existing `attempts` counter;
+leased/fingerprinted outbox state remains proposed.
 
 ### `event_outbox`
 
@@ -482,12 +484,15 @@ order even when timestamps are identical.
 
 Migration 13 stores one immutable `claims` row containing credential-free
 provider identity, model, revision, dimensions, metric, preprocessing, index
-schema, and creation time. `/readyz` fails semantic readiness when configured
-values differ, when indexable claims lack durable work, when legacy completed
-index work has no fingerprint, when a restored projection is empty, or when
-local vector initialization cannot satisfy the contract. Recovery is an
-explicit vector rebuild plus metadata reset and complete claim-work requeue;
-startup never rewrites a mismatch.
+schema, and creation time. Migration 14 adds nullable
+`embedder_failure_at`/`vector_store_failure_at` fields containing no provider
+output to that singleton row. `/readyz` fails semantic readiness when configured
+values differ, indexable claims lack durable work, legacy completed index work
+has no fingerprint, a restored projection is empty, local vector initialization
+cannot satisfy the contract, or an observed dependency failure lacks a later
+complete embed/upsert. Recovery from incompatibility is an explicit vector
+rebuild plus metadata reset and complete claim-work requeue; startup never
+rewrites a mismatch.
 Extraction pipeline metadata remains separate and proposed.
 
 ### `audit_events`

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -38,7 +38,11 @@ work.
 Issue #138 then demonstrated that a configured semantic deployment can report
 ready while silently falling back to FTS because invalid embedding settings,
 an unavailable vector backend, and an incompatible vector fingerprint are not
-distinguished from an intentionally unconfigured FTS-only deployment.
+distinguished from an intentionally unconfigured FTS-only deployment. Review of
+the merged local-readiness fix further proved that a scheduler-observed embedder
+or vector-store failure is retained only as pending work and does not change
+`/readyz`; readiness must project that safe durable failure evidence without
+probing the provider.
 
 Issue #140 requires the public npm path to prove both sides of that contract:
 the default tarball must stay dependency-light, while following the documented
@@ -85,6 +89,9 @@ documentation, and an install smoke against the immutable npm artifact.
 - Make semantic readiness fail closed when embedding or vector operation is
   requested but cannot be initialized safely; persist and compare the minimum
   compatible index fingerprint while preserving intentional FTS-only startup.
+- Persist only the dependency kind and time after an indexing failure, project
+  it into local readiness, and clear it only after a later complete embed/upsert
+  succeeds; never store provider output or require a readiness network call.
 - Bind the Bun fingerprint to a credential-free digest of the normalized
   embedding endpoint, refuse a vector file that aliases the canonical database,
   and require explicit requeue before historical FTS-only claims can be called
@@ -204,9 +211,10 @@ documentation, and an install smoke against the immutable npm artifact.
   database, or schema, the vector path aliases canonical SQL, historical active
   claims lack reindex work, restored canonical metadata points at a newly
   created empty vector projection, or the active index fingerprint is
-  incompatible with stored metadata, then Titen shall return `ready: false`,
-  mark the affected semantic capability `configured_error`, and expose only a
-  sanitized local diagnostic.
+  incompatible with stored metadata, or indexing has durably observed an
+  embedder/vector-store failure not followed by a successful embed/upsert, then
+  Titen shall return `ready: false`, mark the affected semantic capability
+  `configured_error`, and expose only a sanitized local diagnostic.
 - **AC-SWP-016 — Event-driven:** When a semantic index is first initialized,
   Titen shall persist a fingerprint containing credential-free provider
   endpoint identity, model, revision, dimensions, metric, preprocessing

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -34,6 +34,7 @@ import type { Db } from "./db";
 import {
   CAPABILITY_VERSION,
   SEMANTIC_DISABLED,
+  observedSemanticReadiness,
   prepareSemanticReadiness,
   type CapabilityState,
   type SemanticReadiness,
@@ -68,16 +69,19 @@ export interface AppContext {
 }
 
 /** Capabilities are reported honestly based on what's configured. */
-export async function capabilities(app: AppContext) {
+export async function capabilities(
+  app: AppContext,
+  semanticReadiness = app.semanticReadiness,
+) {
   return {
     version: CAPABILITY_VERSION,
     fts: "enabled",
-    vector: app.semanticReadiness.vector,
-    embedding: app.semanticReadiness.embedding,
+    vector: semanticReadiness.vector,
+    embedding: semanticReadiness.embedding,
     extraction: app.modelCapabilities.extraction,
     background_enrichment: app.modelCapabilities.backgroundEnrichment,
     /** @deprecated Use `embedding`; this alias remains for the 0.3.x API. */
-    model: app.semanticReadiness.embedding,
+    model: semanticReadiness.embedding,
     background_repair: await backgroundRepairState({
       db: app.db,
       configured: app.backgroundRepair.configured,
@@ -235,19 +239,22 @@ export const ROUTE_INVENTORY: RouteInventoryEntry[] = ROUTES.map(({ method, path
 async function readiness(ctx: RequestContext): Promise<Result> {
   const checks: Record<string, string> = {};
   let ready = true;
+  let canonicalReady = true;
   try {
     await ctx.app.db.all(`SELECT 1 AS ok`);
     checks.canonical_sql = "ok";
   } catch {
     checks.canonical_sql = "unavailable";
+    canonicalReady = false;
     ready = false;
   }
   const schema = await schemaState(ctx.app.db);
+  const schemaReady = schema.applied === schema.expected && schema.verified;
   checks.migrations =
-    schema.applied === schema.expected && schema.verified
+    schemaReady
       ? "ok"
       : `invalid or pending (applied ${schema.applied}, expected ${schema.expected})`;
-  if (schema.applied !== schema.expected || !schema.verified) ready = false;
+  if (!schemaReady) ready = false;
   if (!ctx.app.migrationsReady) {
     checks.migrations = "failed";
     ready = false;
@@ -255,13 +262,28 @@ async function readiness(ctx: RequestContext): Promise<Result> {
   checks.signing_secrets = ctx.app.secretStorageReady ? "ok" : "failed";
   if (!ctx.app.secretStorageReady) ready = false;
 
-  const caps = await capabilities(ctx.app);
-  checks.semantic_index = ctx.app.semanticReadiness.diagnostic ??
-    (ctx.app.semanticReadiness.vector === "enabled" ? "ok" : "disabled");
+  let semanticReadiness = ctx.app.semanticReadiness;
+  if (canonicalReady && schemaReady && ctx.app.migrationsReady) {
+    try {
+      semanticReadiness = await observedSemanticReadiness(
+        ctx.app.db,
+        semanticReadiness,
+      );
+    } catch {
+      semanticReadiness = {
+        embedding: "enabled",
+        vector: "configured_error",
+        diagnostic: "index_metadata_unavailable",
+      };
+    }
+  }
+  const caps = await capabilities(ctx.app, semanticReadiness);
+  checks.semantic_index = semanticReadiness.diagnostic ??
+    (semanticReadiness.vector === "enabled" ? "ok" : "disabled");
   if (
-    ctx.app.semanticReadiness.diagnostic ||
-    ctx.app.semanticReadiness.embedding === "configured_error" ||
-    ctx.app.semanticReadiness.vector === "configured_error"
+    semanticReadiness.diagnostic ||
+    semanticReadiness.embedding === "configured_error" ||
+    semanticReadiness.vector === "configured_error"
   )
     ready = false;
   checks.extraction = ctx.app.modelCapabilities.extraction;

--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -1,7 +1,11 @@
 import { first } from "./db";
 import { unavailable, validationError } from "./errors";
 import type { RequestContext, Result } from "./http";
-import { validateEmbeddingVectors } from "./vectors";
+import {
+  completeSemanticIndexWork,
+  recordSemanticDependencyFailure,
+  validateEmbeddingVectors,
+} from "./vectors";
 
 /**
  * Drains the indexing outbox into the vector store.
@@ -86,6 +90,12 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
     try {
       await ctx.app.vectors.store.remove([...new Set(removals.map((row) => row.record_id))]);
     } catch {
+      await recordSemanticDependencyFailure(
+        ctx.app.db,
+        "vector_store",
+        ctx.app.now().toISOString(),
+        removals.map((row) => row.id),
+      );
       throw unavailable("Indexing dependency is unavailable.", {
         dependency: "vector_store",
         retryable: true,
@@ -107,6 +117,12 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
         ctx.app.vectors.embedder.dimensions,
       );
     } catch {
+      await recordSemanticDependencyFailure(
+        ctx.app.db,
+        "embedder",
+        ctx.app.now().toISOString(),
+        eligible.map((entry) => entry.outboxId),
+      );
       throw unavailable("Indexing dependency is unavailable.", {
         dependency: "embedder",
         retryable: true,
@@ -126,6 +142,12 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
         })),
       );
     } catch {
+      await recordSemanticDependencyFailure(
+        ctx.app.db,
+        "vector_store",
+        ctx.app.now().toISOString(),
+        eligible.map((entry) => entry.outboxId),
+      );
       throw unavailable("Indexing dependency is unavailable.", {
         dependency: "vector_store",
         retryable: true,
@@ -143,15 +165,7 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
     ...others.map((row) => row.id),
   ];
   const at = ctx.app.now().toISOString();
-  for (let index = 0; index < done.length; index += 50) {
-    const group = done.slice(index, index + 50);
-    await ctx.app.db.batch(
-      group.map((id) => ({
-        sql: `UPDATE index_outbox SET state = 'done', attempts = attempts + 1 WHERE id = ?`,
-        params: [id],
-      })),
-    );
-  }
+  await completeSemanticIndexWork(ctx.app.db, done, indexed > 0);
 
   const remaining = await first<{ count: number }>(
     ctx.app.db,

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -1,6 +1,11 @@
 import type { Db } from "./db";
 import { processWebhooks } from "./webhooks";
-import { validateEmbeddingVectors, type VectorCapability } from "./vectors";
+import {
+  completeSemanticIndexWork,
+  recordSemanticDependencyFailure,
+  validateEmbeddingVectors,
+  type VectorCapability,
+} from "./vectors";
 import type { WebhookSecurity } from "./webhook-security";
 import type { SecretCipher } from "./secrets";
 import { eventAccessSql } from "./events";
@@ -123,6 +128,7 @@ export async function indexPendingForOrg(
   orgId: string,
   vectors: VectorCapability,
   limit: number,
+  at: string,
 ): Promise<number> {
   const pending = await db.all<{ id: string; record_type: string; record_id: string; operation: string }>(
     `SELECT id, record_type, record_id, operation FROM index_outbox
@@ -175,38 +181,64 @@ export async function indexPendingForOrg(
     else removals.push({ outboxId: row.id, recordId: row.record_id });
   }
 
-  if (removals.length > 0)
-    await vectors.store.remove([...new Set(removals.map((entry) => entry.recordId))]);
+  if (removals.length > 0) {
+    try {
+      await vectors.store.remove([...new Set(removals.map((entry) => entry.recordId))]);
+    } catch (error) {
+      await recordSemanticDependencyFailure(
+        db,
+        "vector_store",
+        at,
+        removals.map((entry) => entry.outboxId),
+      );
+      throw error;
+    }
+  }
 
   let indexed = 0;
   if (eligible.length > 0) {
-    const embeddings = validateEmbeddingVectors(
-      await vectors.embedder.embed(eligible.map((entry) => entry.statement)),
-      eligible.length,
-      vectors.embedder.dimensions,
-    );
-    await vectors.store.upsert(
-      eligible.map((entry, index) => ({
-        id: entry.claimId,
-        vector: embeddings[index]!,
-        metadata: {
-          org_id: orgId,
-          subject_id: entry.subjectId,
-          project_id: entry.projectId ?? "",
-        },
-      })),
-    );
+    let embeddings: Float32Array[];
+    try {
+      embeddings = validateEmbeddingVectors(
+        await vectors.embedder.embed(eligible.map((entry) => entry.statement)),
+        eligible.length,
+        vectors.embedder.dimensions,
+      );
+    } catch (error) {
+      await recordSemanticDependencyFailure(
+        db,
+        "embedder",
+        at,
+        eligible.map((entry) => entry.outboxId),
+      );
+      throw error;
+    }
+    try {
+      await vectors.store.upsert(
+        eligible.map((entry, index) => ({
+          id: entry.claimId,
+          vector: embeddings[index]!,
+          metadata: {
+            org_id: orgId,
+            subject_id: entry.subjectId,
+            project_id: entry.projectId ?? "",
+          },
+        })),
+      );
+    } catch (error) {
+      await recordSemanticDependencyFailure(
+        db,
+        "vector_store",
+        at,
+        eligible.map((entry) => entry.outboxId),
+      );
+      throw error;
+    }
     indexed = eligible.length;
   }
 
   const done = [...eligible.map((entry) => entry.outboxId), ...removals.map((entry) => entry.outboxId), ...retire];
-  for (let index = 0; index < done.length; index += 50)
-    await db.batch(
-      done.slice(index, index + 50).map((id) => ({
-        sql: `UPDATE index_outbox SET state = 'done', attempts = attempts + 1 WHERE id = ?`,
-        params: [id],
-      })),
-    );
+  await completeSemanticIndexWork(db, done, indexed > 0);
 
   return indexed;
 }
@@ -322,6 +354,7 @@ export async function runMaintenance(options: {
             orgId,
             options.vectors,
             limit,
+            now.toISOString(),
           );
         } catch (error) {
           // Named by organization, without the message, which can carry content.

--- a/src/core/migrations.ts
+++ b/src/core/migrations.ts
@@ -751,7 +751,14 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
          preprocessing TEXT NOT NULL,
          index_schema TEXT NOT NULL,
          created_at TEXT NOT NULL
-       )`,
+      )`,
+    ],
+  },
+  {
+    version: 14,
+    statements: [
+      `ALTER TABLE semantic_index_metadata ADD COLUMN embedder_failure_at TEXT`,
+      `ALTER TABLE semantic_index_metadata ADD COLUMN vector_store_failure_at TEXT`,
     ],
   },
 ];

--- a/src/core/vectors.ts
+++ b/src/core/vectors.ts
@@ -136,7 +136,10 @@ export type CapabilityState = "disabled" | "enabled" | "configured_error";
 
 export type SemanticDiagnostic =
   | "embedding_configuration_invalid"
+  | "embedding_dependency_unavailable"
+  | "semantic_dependencies_unavailable"
   | "vector_initialization_failed"
+  | "vector_dependency_unavailable"
   | "vector_storage_conflict"
   | "index_backfill_required"
   | "index_fingerprint_missing"
@@ -158,6 +161,102 @@ export interface SemanticReadiness {
   embedding: CapabilityState;
   vector: CapabilityState;
   diagnostic?: SemanticDiagnostic;
+}
+
+export type SemanticDependency = "embedder" | "vector_store";
+
+/** Persist only safe local failure evidence; provider output never enters SQL. */
+export async function recordSemanticDependencyFailure(
+  db: Db,
+  dependency: SemanticDependency,
+  at: string,
+  outboxIds: string[],
+): Promise<void> {
+  const ids = [...new Set(outboxIds)];
+  if (ids.length === 0) return;
+  const column = dependency === "embedder"
+    ? "embedder_failure_at"
+    : "vector_store_failure_at";
+  const statements = [{
+    sql: `UPDATE semantic_index_metadata SET ${column} = ? WHERE id = 'claims'`,
+    params: [at],
+  }];
+  for (let index = 0; index < ids.length; index += 100) {
+    const group = ids.slice(index, index + 100);
+    statements.push({
+      sql: `UPDATE index_outbox
+               SET attempts = attempts + 1
+             WHERE state = 'pending' AND id IN (${group.map(() => "?").join(", ")})`,
+      params: group,
+    });
+  }
+  await db.batch(statements);
+}
+
+/** Complete selected work and clear outage evidence only after global recovery. */
+export async function completeSemanticIndexWork(
+  db: Db,
+  outboxIds: string[],
+  recovered: boolean,
+): Promise<void> {
+  for (let index = 0; index < outboxIds.length; index += 50) {
+    const statements = outboxIds.slice(index, index + 50).map((id) => ({
+      sql: `UPDATE index_outbox SET state = 'done', attempts = attempts + 1 WHERE id = ?`,
+      params: [id],
+    }));
+    if (recovered && index + 50 >= outboxIds.length)
+      statements.push({
+        sql: `UPDATE semantic_index_metadata
+                 SET embedder_failure_at = NULL, vector_store_failure_at = NULL
+               WHERE id = 'claims'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM index_outbox
+                    WHERE state = 'pending' AND attempts > 0
+                 )`,
+        params: [],
+      });
+    await db.batch(statements);
+  }
+}
+
+/** Project durable dependency evidence into readiness without provider I/O. */
+export async function observedSemanticReadiness(
+  db: Db,
+  readiness: SemanticReadiness,
+): Promise<SemanticReadiness> {
+  if (readiness.embedding !== "enabled" || readiness.vector !== "enabled")
+    return readiness;
+  const state = (
+    await db.all<{
+      embedder_failure_at: string | null;
+      vector_store_failure_at: string | null;
+    }>(
+      `SELECT embedder_failure_at, vector_store_failure_at
+         FROM semantic_index_metadata WHERE id = 'claims'`,
+    )
+  )[0];
+  if (!state) throw new Error("Semantic index metadata is unavailable.");
+  const embedderFailed = state.embedder_failure_at !== null;
+  const vectorFailed = state.vector_store_failure_at !== null;
+  if (embedderFailed && vectorFailed)
+    return {
+      embedding: "configured_error",
+      vector: "configured_error",
+      diagnostic: "semantic_dependencies_unavailable",
+    };
+  if (embedderFailed)
+    return {
+      embedding: "configured_error",
+      vector: "enabled",
+      diagnostic: "embedding_dependency_unavailable",
+    };
+  if (vectorFailed)
+    return {
+      embedding: "enabled",
+      vector: "configured_error",
+      diagnostic: "vector_dependency_unavailable",
+    };
+  return readiness;
 }
 
 export interface VectorInitialization {

--- a/tests/contract/cloudflare-d1.test.ts
+++ b/tests/contract/cloudflare-d1.test.ts
@@ -204,8 +204,16 @@ test("a D1 migration batch rolls back on fault and concurrent retries converge",
         WHERE name IN ('checkpoints_scope', 'event_order', 'semantic_index_metadata')
         ORDER BY name`,
     );
-    assert.deepEqual(integrity.map(({ name }) => name), ["checkpoints_scope", "event_order"]);
+    assert.deepEqual(
+      integrity.map(({ name }) => name),
+      ["checkpoints_scope", "event_order", "semantic_index_metadata"],
+    );
     assert.match(integrity.find(({ name }) => name === "checkpoints_scope")!.sql, /UNIQUE/);
+    assert.deepEqual(
+      (await real.all<{ name: string }>("PRAGMA table_info(semantic_index_metadata)"))
+        .filter(({ name }) => name.endsWith("_failure_at")),
+      [],
+    );
     assert.deepEqual(await Promise.all([migrate(real), migrate(real)]), [SCHEMA_VERSION, SCHEMA_VERSION]);
   } finally {
     await fault.dispose();

--- a/tests/contract/integrity-migration.ts
+++ b/tests/contract/integrity-migration.ts
@@ -172,7 +172,7 @@ export async function assertPopulatedV11IntegrityMigration(db: Db): Promise<void
   }
 
   assert.equal(await migrate(db), SCHEMA_VERSION);
-  assert.equal(SCHEMA_VERSION, 13);
+  assert.equal(SCHEMA_VERSION, 14);
   assert.deepEqual(
     await db.all(`SELECT name FROM sqlite_master WHERE name = 'semantic_index_metadata'`),
     [{ name: "semantic_index_metadata" }],

--- a/tests/contract/semantic-readiness.ts
+++ b/tests/contract/semantic-readiness.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { createApp } from "../../src/core/app";
 import type { Db } from "../../src/core/db";
+import {
+  completeSemanticIndexWork,
+  recordSemanticDependencyFailure,
+} from "../../src/core/vectors";
 import { clientVia, fakeVectors } from "./harness";
 
 const readyWith = (db: Db, runtime: string, vectors?: ReturnType<typeof fakeVectors>) =>
@@ -86,7 +90,11 @@ export async function assertSemanticReadiness(db: Db, runtime: string) {
                     '2026-07-31T00:00:00.000Z')`,
     },
   ]);
-  const healthy = await readyWith(db, runtime, vectors);
+  const persistent = clientVia(
+    createApp({ db, runtime, revision: "semantic-readiness", vectors }),
+    "http://titen.test",
+  );
+  const healthy = await persistent.call("GET", "/readyz");
   assert.equal(healthy.status, 200);
   assert.equal(healthy.body.data.capabilities.version, 1);
   assert.equal(healthy.body.data.capabilities.embedding, "enabled");
@@ -100,6 +108,102 @@ export async function assertSemanticReadiness(db: Db, runtime: string) {
        FROM semantic_index_metadata WHERE id = 'claims'`,
   );
   assert.deepEqual(persisted, [{ ...vectors.fingerprint }]);
+
+  await db.batch([{ sql: `DELETE FROM semantic_index_metadata WHERE id = 'claims'` }]);
+  const lostMetadata = await persistent.call("GET", "/readyz");
+  assert.equal(lostMetadata.status, 503);
+  assert.equal(lostMetadata.body.meta.checks.semantic_index, "index_metadata_unavailable");
+  assert.equal(vectors.embedCalls(), 0, "metadata loss readiness stays local");
+  assert.equal((await readyWith(db, runtime, vectors)).status, 200);
+
+  for (const dependency of ["embedder", "vector_store"] as const) {
+    await db.batch([
+      {
+        sql: `UPDATE semantic_index_metadata
+                 SET ${dependency === "embedder" ? "embedder_failure_at" : "vector_store_failure_at"} = ?
+               WHERE id = 'claims'`,
+        params: ["2026-07-31T00:00:01.000Z"],
+      },
+    ]);
+    const observedFailure = await readyWith(db, runtime, vectors);
+    assert.equal(observedFailure.status, 503);
+    assert.equal(
+      observedFailure.body.meta.checks.semantic_index,
+      dependency === "embedder"
+        ? "embedding_dependency_unavailable"
+        : "vector_dependency_unavailable",
+    );
+    assert.equal(vectors.embedCalls(), 0, "observed failure readiness stays local");
+    await db.batch([
+      {
+        sql: `UPDATE semantic_index_metadata
+                 SET ${dependency === "embedder" ? "embedder_failure_at" : "vector_store_failure_at"} = NULL
+               WHERE id = 'claims'`,
+      },
+    ]);
+    assert.equal((await readyWith(db, runtime, vectors)).status, 200);
+  }
+  await db.batch([
+    {
+      sql: `UPDATE semantic_index_metadata
+               SET embedder_failure_at = '2026-07-31T00:00:02.000Z',
+                   vector_store_failure_at = '2026-07-31T00:00:03.000Z'
+             WHERE id = 'claims'`,
+    },
+  ]);
+  const dualFailure = await readyWith(db, runtime, vectors);
+  assert.equal(dualFailure.status, 503);
+  assert.equal(
+    dualFailure.body.meta.checks.semantic_index,
+    "semantic_dependencies_unavailable",
+  );
+  assert.equal(dualFailure.body.meta.capabilities.embedding, "configured_error");
+  assert.equal(dualFailure.body.meta.capabilities.vector, "configured_error");
+  await db.batch([
+    {
+      sql: `UPDATE semantic_index_metadata
+               SET embedder_failure_at = NULL, vector_store_failure_at = NULL
+             WHERE id = 'claims'`,
+    },
+  ]);
+
+  await db.batch([
+    {
+      sql: `INSERT INTO organizations (id, name, created_at)
+            VALUES ('org_semantic_recovery_other', 'Other recovery org',
+                    '2026-07-31T00:00:00.000Z')`,
+    },
+    {
+      sql: `INSERT INTO index_outbox
+              (id, org_id, record_type, record_id, operation, state, attempts, created_at)
+            VALUES ('idx_semantic_recovery_other', 'org_semantic_recovery_other',
+                    'claim', 'clm_semantic_recovery_other', 'upsert', 'pending', 0,
+                    '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+  await recordSemanticDependencyFailure(
+    db,
+    "embedder",
+    "2026-07-31T00:00:04.000Z",
+    ["idx_semantic_backfill"],
+  );
+  assert.deepEqual(
+    await db.all(`SELECT attempts FROM index_outbox WHERE id = 'idx_semantic_backfill'`),
+    [{ attempts: 1 }],
+  );
+  assert.equal((await readyWith(db, runtime, vectors)).status, 503);
+  await completeSemanticIndexWork(db, ["idx_semantic_recovery_other"], true);
+  assert.equal(
+    (await readyWith(db, runtime, vectors)).status,
+    503,
+    "another organization cannot clear unresolved failure evidence",
+  );
+  await completeSemanticIndexWork(db, ["idx_semantic_backfill"], true);
+  assert.equal((await readyWith(db, runtime, vectors)).status, 200);
+  await db.batch([
+    { sql: `DELETE FROM index_outbox WHERE id = 'idx_semantic_recovery_other'` },
+    { sql: `DELETE FROM organizations WHERE id = 'org_semantic_recovery_other'` },
+  ]);
 
   await db.batch([
     {

--- a/tests/contract/vectors.test.ts
+++ b/tests/contract/vectors.test.ts
@@ -343,12 +343,89 @@ test("index drain reports embedder outages as retryable and preserves pending ro
   assert.equal(failed.body.meta.retryable, true);
   assert.equal(failed.body.meta.pending, before);
   assert.equal(await pendingCount(), before);
+  const unavailable = await app.call("GET", "/readyz");
+  assert.equal(unavailable.status, 503);
+  assert.equal(unavailable.body.meta.capabilities.embedding, "configured_error");
+  assert.equal(unavailable.body.meta.capabilities.vector, "enabled");
+  assert.equal(unavailable.body.meta.checks.semantic_index, "embedding_dependency_unavailable");
 
+  const other = await provisionWith(db, { scopes: ["*"] });
+  const otherObservation = await app.call("POST", "/v1/observations", {
+    key: other.key,
+    body: {
+      subject_id: "other_org_recovery",
+      kind: "tool_result",
+      content: "One tenant cannot clear another tenant's dependency outage.",
+      source: { type: "tool", ref: "cross-org-recovery" },
+      trust: "verified",
+    },
+  });
+  assert.equal(otherObservation.status, 201);
+  assert.equal(
+    (
+      await app.call("POST", "/v1/consolidations", {
+        key: other.key,
+        body: {
+          subject_id: "other_org_recovery",
+          claims: [{
+            kind: "procedural",
+            statement: "Cross-organization recovery remains isolated.",
+            sources: [{
+              observation_id: otherObservation.body.data.observation_id,
+              relation: "supports",
+            }],
+          }],
+        },
+      })
+    ).status,
+    201,
+  );
+  broken.restoreEmbedder();
+  const otherRecovery = await app.call("POST", "/v1/index/drain", { key: other.key });
+  assert.equal(otherRecovery.status, 200);
+  assert.ok(otherRecovery.body.data.indexed > 0);
+  assert.equal((await app.call("GET", "/readyz")).status, 503);
+
+  const retiring = await db.all<{ id: string; record_id: string; status: string }>(
+    `SELECT queued.id, queued.record_id, c.status
+       FROM (
+         SELECT id, record_id FROM index_outbox
+          WHERE org_id = ? AND state = 'pending'
+          ORDER BY created_at, id LIMIT 50
+       ) queued
+       JOIN claims c ON c.id = queued.record_id
+      WHERE c.status IN ('active', 'disputed')`,
+    [orgId],
+  );
+  assert.ok(retiring.length > 0);
+  await db.batch(
+    [...new Set(retiring.map(({ record_id }) => record_id))].map((id) => ({
+      sql: `UPDATE claims SET status = 'expired' WHERE id = ?`,
+      params: [id],
+    })),
+  );
+  const deleteOnly = await app.call("POST", "/v1/index/drain", { key });
+  assert.equal(deleteOnly.status, 200);
+  assert.equal(deleteOnly.body.data.indexed, 0);
+  assert.equal((await app.call("GET", "/readyz")).status, 503);
+
+  const originalStatus = new Map(retiring.map(({ record_id, status }) => [record_id, status]));
+  await db.batch([
+    ...[...originalStatus].map(([id, status]) => ({
+      sql: `UPDATE claims SET status = ? WHERE id = ?`,
+      params: [status, id],
+    })),
+    ...retiring.map(({ id }) => ({
+      sql: `UPDATE index_outbox SET state = 'pending' WHERE id = ?`,
+      params: [id],
+    })),
+  ]);
   broken.restoreEmbedder();
   const recovered = await app.call("POST", "/v1/index/drain", { key });
   assert.equal(recovered.status, 200);
   assert.ok(recovered.body.data.indexed > 0);
   assert.ok((await pendingCount()) < before);
+  assert.equal((await app.call("GET", "/readyz")).status, 200);
   assert.deepEqual(broken.metadataFor(claimIds[0]!), {
     org_id: orgId,
     subject_id: subjectId,
@@ -369,12 +446,18 @@ test("index drain reports vector-store outages as retryable and preserves pendin
   assert.equal(failed.body.meta.retryable, true);
   assert.equal(failed.body.meta.pending, before);
   assert.equal(await pendingCount(), before);
+  const unavailable = await app.call("GET", "/readyz");
+  assert.equal(unavailable.status, 503);
+  assert.equal(unavailable.body.meta.capabilities.embedding, "enabled");
+  assert.equal(unavailable.body.meta.capabilities.vector, "configured_error");
+  assert.equal(unavailable.body.meta.checks.semantic_index, "vector_dependency_unavailable");
 
   broken.restoreStore();
   const recovered = await app.call("POST", "/v1/index/drain", { key });
   assert.equal(recovered.status, 200);
   assert.ok(recovered.body.data.indexed > 0);
   assert.ok((await pendingCount()) < before);
+  assert.equal((await app.call("GET", "/readyz")).status, 200);
 });
 
 test("purge drain removes an already indexed claim", async () => {

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -204,6 +204,15 @@ for (const adapter of consumers)
     const handle = openDatabase(join(directory, "titen.db"));
     const db = createSqliteDb(handle);
     const { embedder, close } = adapter.create({ data: [] });
+    let providerRecovered = false;
+    const recoverableEmbedder: EmbeddingProvider = {
+      dimensions: embedder.dimensions,
+      model: embedder.model,
+      embed: (texts) =>
+        providerRecovered
+          ? Promise.resolve(texts.map(() => new Float32Array(dense())))
+          : embedder.embed(texts),
+    };
     let vectorWrites = 0;
     let vectorQueries = 0;
     const store: VectorStore = {
@@ -222,10 +231,10 @@ for (const adapter of consumers)
       const provisioned = await provisionWith(db, { scopes: ["*"] });
       const vectors = {
         store,
-        embedder,
+        embedder: recoverableEmbedder,
         fingerprint: {
           provider: "test",
-          model: embedder.model,
+          model: recoverableEmbedder.model,
           revision: "test",
           dimensions,
           metric: "cosine",
@@ -309,6 +318,10 @@ for (const adapter of consumers)
       assert.deepEqual(background.errors, [`index:${provisioned.orgId.slice(0, 12)}`]);
       assert.equal(await pending(), before);
       assert.equal(vectorWrites, 0);
+      const notReady = await client.call("GET", "/readyz");
+      assert.equal(notReady.status, 503);
+      assert.equal(notReady.body.meta.capabilities.embedding, "configured_error");
+      assert.equal(notReady.body.meta.checks.semantic_index, "embedding_dependency_unavailable");
 
       const compiled = await client.call("POST", "/v1/context/compile", {
         key: provisioned.key,
@@ -321,6 +334,18 @@ for (const adapter of consumers)
       );
       assert.equal(vectorQueries, 0);
       assert.equal(vectorWrites, 0);
+
+      providerRecovered = true;
+      const recovered = await runMaintenance({
+        db,
+        vectors,
+        limit: 50,
+        now: new Date("2026-07-31T00:01:00.000Z"),
+        deliverWebhooks: false,
+      });
+      assert.ok(recovered.indexed > 0);
+      assert.deepEqual(recovered.errors, []);
+      assert.equal((await client.call("GET", "/readyz")).status, 200);
     } finally {
       await close();
       handle.close();

--- a/tests/integration/runtime-hardening.test.ts
+++ b/tests/integration/runtime-hardening.test.ts
@@ -9,6 +9,7 @@ import { MIGRATIONS, migrate, SCHEMA_VERSION } from "../../src/core/migrations";
 import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
 import { serve } from "../../src/runtime/bun/server";
 import { assertPopulatedV11IntegrityMigration } from "../contract/integrity-migration";
+import { fakeVectors } from "../contract/harness";
 
 const directories: string[] = [];
 const temporary = () => {
@@ -54,10 +55,15 @@ test("a failed migration version rolls back fully and succeeds on retry", async 
     );
     assert.deepEqual(
       integrity.map(({ name }) => name),
-      ["checkpoints_scope", "event_order"],
+      ["checkpoints_scope", "event_order", "semantic_index_metadata"],
       `migration must roll back after statement ${failureAfter + 1}`,
     );
     assert.match(integrity.find(({ name }) => name === "checkpoints_scope")!.sql, /UNIQUE/);
+    assert.deepEqual(
+      (await db.all<{ name: string }>("PRAGMA table_info(semantic_index_metadata)"))
+        .filter(({ name }) => name.endsWith("_failure_at")),
+      [],
+    );
     assert.equal(await migrate(db), SCHEMA_VERSION);
     database.close();
   }
@@ -144,6 +150,48 @@ test("a stale schema exposes diagnostics but blocks API traffic", async () => {
   assert.equal(blocked.status, 503);
   assert.equal(((await blocked.json()) as any).error.code, "UNAVAILABLE");
   await running.stop();
+});
+
+test("a pre-v14 schema with vectors still returns sanitized migration readiness", async () => {
+  const path = join(temporary(), "titen.db");
+  const database = openDatabase(path);
+  const db = createSqliteDb(database);
+  await db.exec(
+    `CREATE TABLE titen_migrations (
+       version INTEGER PRIMARY KEY,
+       applied_at TEXT NOT NULL
+     )`,
+  );
+  for (const migration of MIGRATIONS.filter(({ version }) => version < SCHEMA_VERSION))
+    await db.batch([
+      ...migration.statements.map((sql) => ({ sql })),
+      {
+        sql: `INSERT INTO titen_migrations (version, applied_at) VALUES (?, ?)`,
+        params: [migration.version, "2026-07-31T00:00:00.000Z"],
+      },
+    ]);
+  database.close();
+
+  const running = await serve({
+    dbPath: path,
+    port: 0,
+    hostname: "127.0.0.1",
+    quiet: true,
+    autoMigrate: false,
+    maintenanceIntervalMs: 0,
+    vectors: fakeVectors(),
+  });
+  try {
+    const readiness = await fetch(`${running.url}/readyz`);
+    assert.equal(readiness.status, 503);
+    const body = (await readiness.json()) as any;
+    assert.equal(body.error.code, "NOT_READY");
+    assert.equal(body.meta.schema.applied, SCHEMA_VERSION - 1);
+    assert.equal(body.meta.schema.expected, SCHEMA_VERSION);
+    assert.equal(body.meta.checks.migrations, "failed");
+  } finally {
+    await running.stop();
+  }
 });
 
 test("background repair reports enabled, stale, and disabled from canonical evidence", async () => {


### PR DESCRIPTION
## Summary

- persist safe embedder and vector-store outage timestamps in local semantic metadata
- keep readiness failed across delete-only work and unrelated tenant recovery
- clear outage evidence only after a complete embed/upsert and no attempted pending work remains
- fail readiness closed for stale migrations or missing semantic metadata without provider I/O

Fixes #138

## Verification

- independent review: PASS
- targeted Bun/vector/validator/runtime: 168 passed
- full integration: 148 passed
- Cloudflare D1 full contract: 94 passed; final shared lifecycle: 1 passed, 93 filtered
- Worker dry build, workflow 48, routes 56, and diff check: passed

GitHub Actions remains disabled; all gates are manual so the repository incurs no hosted automation cost.