### PR TITLE
fix: calibrate semantic retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
   projections, incompatible fingerprints, and locally observed indexing
   dependency failures; configured failures return a fixed local diagnostic
   without probing providers.
+- Semantic retrieval now discards sub-threshold cosine hits before canonical
+  hydration, so relative ranking cannot turn a best bad neighbor into useful
+  context. Bun and Cloudflare share the same validated unit-vector boundary.
 
 ### Changed
 
@@ -52,6 +55,10 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
   explicit cross-project recall requires `cross_project: true` plus the separate
   `context:compile:all` capability and reports its effective scope and grant
   reason across REST, SDK, and MCP.
+- Semantic configuration now requires an immutable model revision, a named
+  role-aware preprocessing profile, and an operator-calibrated cosine floor in
+  the existing index fingerprint. EmbeddingGemma uses its official asymmetric
+  query/document prompts; Titen ships no universal threshold.
 
 ## [0.3.0] — 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,16 @@ TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1 \
 TITEN_EMBED_MODEL=embeddinggemma \
 TITEN_EMBED_DIMS=768 \
 TITEN_EMBED_REVISION=local-pinned \
+TITEN_EMBED_PROFILE=embeddinggemma-retrieval-v1 \
+TITEN_EMBED_MIN_COSINE="$CALIBRATED_COSINE_FLOOR" \
 bunx titen-memory serve
 ```
+
+Set `CALIBRATED_COSINE_FLOOR` from a locked evaluation of that exact provider,
+model revision, and profile. Titen ships no universal threshold: missing or
+incompatible policy values fail readiness instead of returning a best bad
+neighbor. Use `raw-unit-v1` only for models whose retrieval contract is raw
+text; EmbeddingGemma requires the role-aware profile shown above.
 
 The packaged vector path is verified on glibc Linux x64 with Bun 1.3.13.
 Other `sqlite-vec` prebuilt platforms need the same local ready/drain/query

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -107,10 +107,17 @@ Set environment variables in the systemd unit or an env file:
 TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1
 TITEN_EMBED_MODEL=bge-m3
 TITEN_EMBED_DIMS=1024
+TITEN_EMBED_REVISION=<immutable-provider-revision>
+TITEN_EMBED_PROFILE=raw-unit-v1
+TITEN_EMBED_MIN_COSINE=<calibrated-cosine-floor>
 TITEN_EMBED_API_KEY=<optional-bearer-secret>
 ```
 
 Requires an OpenAI-compatible embedding endpoint (e.g., Ollama, vLLM).
+Revision, profile, and cosine floor are required for semantic readiness. Choose
+the floor from a locked evaluation of the exact model/profile; Titen has no
+universal default. EmbeddingGemma uses `embeddinggemma-retrieval-v1`, not the
+raw profile.
 This config enables retrieval/indexing only. Automatic LLM extraction and
 reflection are planned and the current service has no `TITEN_EXTRACT_*`
 configuration. In rootless containers, use `host.containers.internal`, host

--- a/docs/FRD.md
+++ b/docs/FRD.md
@@ -392,11 +392,13 @@ Required behavior:
 - bound candidate counts and canonical hydration;
 - repair vector mutations from a durable outbox.
 
-Current implementation note: adapters carry the configured embedding model and
-dimensions. Bun HTTP and Cloudflare Workers AI share validation for exact output
-cardinality, ordered provider indices when present, dense dimensions, and finite
-numeric coordinates. Titen persists and compares the configured semantic index
-fingerprint before exposing vector retrieval.
+Current implementation note: adapters carry an immutable model revision, named
+role-aware input profile, dimensions, and operator-calibrated cosine floor. Bun
+HTTP and Cloudflare Workers AI share the exact query/document transforms, unit
+normalization, and validation for output cardinality, ordered provider indices
+when present, dense dimensions, and finite numeric coordinates. Sub-threshold
+IDs are discarded before canonical hydration. Titen persists and compares that
+semantic contract before exposing vector retrieval.
 
 Implemented compatibility requirements:
 
@@ -404,6 +406,8 @@ Implemented compatibility requirements:
   preprocessing/template, and semantic-unit schema as a versioned fingerprint;
 - compare that fingerprint with the configured index before declaring semantic
   readiness or running indexing/querying.
+- reject a best available vector neighbor when its absolute cosine falls below
+  the fingerprinted model/profile calibration policy.
 
 Acceptance:
 

--- a/docs/architecture/memory-lifecycle.md
+++ b/docs/architecture/memory-lifecycle.md
@@ -473,8 +473,9 @@ canonical SQL hydration and context compilation
 ```
 
 The backend does not understand text by itself. It stores vectors and searches
-for nearby vectors. The same compatible embedding model and preprocessing must
-be used for indexed records and queries.
+for nearby vectors. Indexed records and queries use the same immutable model but
+may require different role prompts under one fingerprinted profile. Both roles
+are unit-normalized before storage/query.
 
 ### Which features need a model?
 
@@ -596,8 +597,9 @@ instead of hiding the delay.
 
 ### Embedding fingerprint contract
 
-Current adapters carry a configured model identifier and dimensions. Bun HTTP
-and Cloudflare Workers AI share one validator for exact output cardinality,
+Current adapters carry an immutable model revision, dimensions, named
+query/document profile, and calibrated cosine floor. Bun HTTP and Cloudflare
+Workers AI share the role transforms, unit normalization, and one validator for exact output cardinality,
 ordered provider indices when present, dense dimensions, and finite numeric
 coordinates. Capability contract version 1 reports embedding separately from
 planned extraction/background enrichment, and the deprecated `model` field
@@ -606,10 +608,11 @@ mirrors embedding for `0.3.x` compatibility.
 Every semantic index is bound to a fingerprint containing:
 
 - provider and model identifier;
-- immutable revision when available;
+- immutable revision;
 - output dimensions;
 - distance metric;
-- preprocessing version, including normalization and text formatting;
+- preprocessing version, including role-aware text formatting, unit
+  normalization, and the operator-calibrated cosine floor;
 - Titen semantic-unit schema version.
 
 Startup compares the locally configured contract with migration-13 metadata
@@ -617,6 +620,11 @@ without a provider request. Titen does not pad or truncate mismatched vectors.
 Changing the fingerprint requires an explicit re-index and fails semantic
 readiness until the vector backend is rebuilt, metadata is reset, and claim
 index work is requeued.
+
+The compiler rejects vector hits below the fingerprinted floor before canonical
+SQL hydration. Relative ranking may order eligible hits; it cannot promote the
+best member of an irrelevant candidate set into evidence. Titen intentionally
+ships no model-independent threshold.
 
 Canonical export excludes embeddings by default. A destination rebuilds its
 semantic projection only with a declared, verified fingerprint. Changing

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -109,15 +109,20 @@ Cron binding, so those capabilities are not active by default or live-verified.
 
 With no AI/Vectorize binding or embedding variables, the Worker remains ready
 in intentional FTS-only mode. Semantic opt-in requires both native bindings and
-a valid local contract. Configure `TITEN_EMBED_MODEL`, `TITEN_EMBED_DIMS`, and,
-when the provider exposes one, `TITEN_EMBED_REVISION`; the bound Vectorize index
-must use the same dimensions and cosine metric. A partial binding/variable set,
-invalid dimension, or binding object without the required methods returns
-`configured_error` and fails `/readyz`.
+a valid local contract. Configure `TITEN_EMBED_MODEL`, `TITEN_EMBED_DIMS`,
+`TITEN_EMBED_REVISION`, `TITEN_EMBED_PROFILE`, and
+`TITEN_EMBED_MIN_COSINE`; the bound Vectorize index must use the same dimensions
+and cosine metric. Revision must identify immutable provider weights. The floor
+must come from a locked evaluation of that exact model/profile; Titen bundles no
+universal threshold. A partial binding/variable set, invalid dimension/policy,
+or binding object without the required methods returns `configured_error` and
+fails `/readyz`.
 
 Migration 13 persists provider `workers-ai`, model, revision, dimensions,
-cosine metric, preprocessing `text-v1`, and index schema `claims-scope-v1` in
-D1. Readiness compares those local facts without calling Workers AI or
+cosine metric, the named role/normalization profile plus calibrated floor, and
+index schema `claims-scope-v1` in D1. `embeddinggemma-retrieval-v1` applies
+EmbeddingGemma's asymmetric prompts; `raw-unit-v1` remains explicit for raw-text
+models. Readiness compares those local facts without calling Workers AI or
 Vectorize. Migration 14 retains only safe embedder/vector-store failure
 timestamps in semantic metadata, so `/readyz` fails without a provider probe
 until a later complete embed/upsert proves recovery. A real drain/query smoke

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -117,6 +117,8 @@ TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1
 TITEN_EMBED_MODEL=bge-m3
 TITEN_EMBED_DIMS=1024
 TITEN_EMBED_REVISION=<immutable-provider-revision>
+TITEN_EMBED_PROFILE=raw-unit-v1
+TITEN_EMBED_MIN_COSINE=<calibrated-cosine-floor>
 TITEN_MAINTENANCE_INTERVAL_MS=15000
 TITEN_SECRET_KEYS={"active":"v1","keys":{"v1":"<32-byte-base64url-key>"}}
 TITEN_WEBHOOK_ALLOWED_HOSTNAMES=hooks.example.com
@@ -125,11 +127,17 @@ TITEN_WEBHOOK_ALLOWED_HOSTNAMES=hooks.example.com
 Embedding variables are optional. Observations and lexical context work without
 them. Put `TITEN_EMBED_API_KEY` only in the mode-`0600` service environment; it
 is required only when the configured embedder requires bearer authentication.
-Base URL, model, and dimensions form one opt-in tuple. Supplying only part of
-that tuple, or supplying API-key/revision settings without it, returns
-`configured_error` and makes `/readyz` fail. If no immutable revision is
-available, omit `TITEN_EMBED_REVISION`; Titen records `unspecified`, and adding a
-revision later intentionally requires a reindex.
+Base URL, model, dimensions, immutable revision, named profile, and calibrated
+cosine floor form one opt-in contract. Supplying only part of that contract, or
+supplying an API key without it, returns `configured_error` and makes `/readyz`
+fail. A provider without an immutable revision remains FTS-only; Titen does not
+pretend an `unspecified` model is safe to calibrate.
+
+`raw-unit-v1` sends raw query/document text and fits models that explicitly use
+that contract. `embeddinggemma-retrieval-v1` applies EmbeddingGemma's asymmetric
+query/document prompts. Titen unit-normalizes both profiles. Select
+`TITEN_EMBED_MIN_COSINE` from a locked exact-model evaluation; no universal or
+pre-inspected threshold is bundled.
 
 The ADR-0004 implementation will add a separate opt-in tuple such as
 `TITEN_EXTRACT_BASE_URL`, `TITEN_EXTRACT_MODEL`, and
@@ -177,10 +185,11 @@ failure is `503 NOT_READY`, never a silent fallback.
 
 ### Explicit semantic reindex
 
-Migration 13 binds the claim-vector projection to provider, model, revision,
-dimensions, L2 metric, preprocessing `text-v1`, and index schema
-`claims-scope-v1`. A missing legacy fingerprint or any change fails readiness.
-Titen never rewrites this metadata or deletes vectors automatically.
+Migration 13 binds the claim-vector projection to provider, model, immutable
+revision, dimensions, cosine metric, the named role/normalization profile plus
+its calibrated floor, and index schema `claims-scope-v1`. A missing legacy
+fingerprint or any change fails readiness. Titen never rewrites this metadata or
+deletes vectors automatically.
 
 Migration 14 records only safe embedder/vector-store failure timestamps in
 semantic metadata. That local evidence fails `/readyz` without probing either
@@ -238,6 +247,9 @@ podman run -d --name titen --network host -v titen-data:/var/lib/titen \
   -e TITEN_EMBED_BASE_URL=http://127.0.0.1:11434/v1 \
   -e TITEN_EMBED_MODEL=embeddinggemma \
   -e TITEN_EMBED_DIMS=768 \
+  -e TITEN_EMBED_REVISION=<immutable-provider-revision> \
+  -e TITEN_EMBED_PROFILE=embeddinggemma-retrieval-v1 \
+  -e TITEN_EMBED_MIN_COSINE="$CALIBRATED_COSINE_FLOOR" \
   -e TITEN_VEC_DB_PATH=/var/lib/titen/vectors.db \
   titen:latest serve --db /var/lib/titen/titen.db --host 127.0.0.1 --port 8787
 
@@ -286,12 +298,14 @@ handler instead. Add a Cron Trigger to `wrangler.jsonc`:
 
 ### Verified behavior
 
-A containerized run against `embeddinggemma` (768 dimensions) served through
+A historical containerized run against `embeddinggemma` (768 dimensions) served through
 Ollama retrieved a claim that shared no keywords with the query, ranked it above
 a lexically similar decoy in the same order as the model's own cosine similarity,
 and preserved all memory across a container restart. Measured: index drain
 134.9 ms, context compile p50 104.8 ms, embedding 106.4 ms. Graceful shutdown
-completes in about 130 ms.
+completes in about 130 ms. That pre-profile smoke is deployment evidence, not a
+safe current threshold; a current semantic deployment must pass the explicit
+profile/floor contract and its own hard-negative query smoke.
 
 ## Rootless Quadlet
 

--- a/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -73,6 +73,18 @@ evidence.
   one-head/one-winner assertions. Instrumentation is ready; the checkpoint
   recurrence remains unclassified, while only emulator transport instability
   is separately tracked in #157.
+- [ ] Add one shared embedding-policy helper for role-specific text transforms,
+  validation, and unit normalization; require explicit revision/profile/cosine
+  floor in Bun and Cloudflare configuration, with EmbeddingGemma bound to its
+  official query/document profile.
+- [ ] Gate vector hits by the configured absolute cosine floor before hydration
+  and relative ranking; fingerprint the exact profile/threshold in existing
+  semantic metadata and prove mismatch requires the documented explicit
+  projection reset/requeue rather than a new schema or provider abstraction.
+- [ ] Add dual-runtime hard-negative/empty-pack, role parity, sub-threshold
+  non-hydration, scope/provenance, malformed/zero-vector, configuration, and
+  reindex regressions; integrate the immutable calibration evidence branch and
+  run a second untouched holdout before publishing any bundled threshold.
 - [x] Rewrite and human-review README.md, verify `titen.dev`, run `seng-jelas`
   strictly, and prove the packaged README contains only stable external links.
 - [x] Run focused checks after each integration, then the complete local manual
@@ -124,6 +136,7 @@ to its merged evidence or to the concrete decision recorded here.
 | #140 | Keep the default package dependency-free, publish one explicit `sqlite-vec@0.1.9` install command, and exercise both missing-dependency failure and vector-ready success from the clean packed consumer. |
 | #141 | Make omitted project scope select only unscoped claims; add explicit `cross_project` mode guarded by `context:compile:all`, report `project_mode` and the capability-backed broad reason, and make every distributed agent skill resolve a repository project before compile. |
 | #102 recurrence | Keep the atomic UPSERT and handoff fence; retain safe diagnostics for each unexpected D1 contention response, keep the issue open until isolated repeated evidence classifies the recurrence, and add no product retry without a reproducible database failure. |
+| #144, #155 | Use one explicit fingerprinted role-aware embedding policy and absolute cosine gate before the existing relative ranker; require operator calibration and never ship the inspected threshold as a universal default. |
 
 ## Acceptance evidence mapping
 
@@ -193,6 +206,15 @@ to its merged evidence or to the concrete decision recorded here.
   status/error diagnostics for each unexpected response and one durable head;
   the unclassified #102 recurrence remains distinct from #157 emulator
   transport failures.
+- AC-SWP-050: shared policy unit tests plus Bun HTTP, Workers AI, injected-
+  provider, fingerprint-mismatch, explicit-reindex, zero/non-finite-vector, and
+  configuration regressions proving exact query/document transforms and unit
+  normalization on both runtimes.
+- AC-SWP-051: dual-runtime hard-negative fixtures proving sub-threshold IDs are
+  not hydrated or exposed, above-threshold vector recall still works, FTS-only
+  and lexical recall remain unchanged, scope/provenance hold, and public output
+  contains no raw score or calibration setting; immutable calibration reports
+  distinguish inspected evidence from any untouched holdout.
 
 ## Security, migration, deployment, smoke, and rollback
 
@@ -208,6 +230,9 @@ operation or running the documented reindex path with the intended fingerprint.
 Migration 14 adds only two nullable dependency-failure timestamps to the
 singleton semantic metadata row. Delete-only completion or retirement cannot
 clear them; disabling semantic configuration remains the fail-closed rollback.
+Retrieval profile and cosine-floor changes reuse the existing preprocessing
+fingerprint field, add no canonical schema, and require the same explicit
+rebuild/requeue path before readiness can recover.
 
 Before merge, rollback is branch deletion. After merge and before npm publish,
 rollback is a reviewed revert. After npm publish, a bad immutable artifact must

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -611,8 +611,9 @@ separate fields; planned extraction/enrichment remain `disabled` until their
 own implementation and evidence ship.
 
 When semantic retrieval is configured, readiness compares credential-free
-provider identity, model, revision, dimensions, metric, preprocessing version,
-and index-schema version with migration-13 metadata. Partial/invalid
+provider identity, model, immutable revision, dimensions, cosine metric, named
+role-aware preprocessing/unit normalization plus calibrated floor, and
+index-schema version with migration-13 metadata. Partial/invalid
 configuration, unavailable or aliased local vector storage, an untracked legacy
 index, missing historical requeue work, an empty projection after canonical-only
 restore, fingerprint mismatch, or a migration-14 locally recorded embedder/
@@ -620,6 +621,11 @@ vector-store indexing failure returns `503 NOT_READY`, marks the affected
 capability `configured_error`, and supplies one fixed
 `checks.semantic_index` diagnostic. The response does not expose the
 fingerprint, endpoint, database path, or provider error.
+
+The cosine floor is an operator-supplied calibration policy, not a public API
+field or universal Titen default. Sub-threshold vector IDs never reach canonical
+hydration; authorized lexical candidates and successful empty packs retain their
+normal behavior.
 
 Readiness performs bounded local configuration/path/schema/metadata checks only. It
 makes no embedding-provider or vector-index network call. Before a dependency is

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -373,9 +373,11 @@ Release vectors use release IDs/versions and minimum channel/audience metadata,
 not source claim IDs that a gateway could hydrate directly. Customer-private
 memory is never copied into the release vector corpus.
 
-Embedding provider, model, immutable revision when available, dimensions,
-metric, preprocessing version, and index-schema version form a fingerprint.
-Padding or truncating a mismatched vector is prohibited.
+Embedding provider, model, immutable revision, dimensions, metric, named
+query/document preprocessing plus unit-normalization version, calibrated cosine
+floor, and index-schema version form a fingerprint. Padding or truncating a
+mismatched vector is prohibited. A vector ID below the floor is discarded before
+canonical hydration.
 
 ### Memory Atlas projections
 
@@ -483,8 +485,8 @@ order even when timestamps are identical.
 ### `semantic_index_metadata`
 
 Migration 13 stores one immutable `claims` row containing credential-free
-provider identity, model, revision, dimensions, metric, preprocessing, index
-schema, and creation time. Migration 14 adds nullable
+provider identity, model, revision, dimensions, metric, preprocessing policy
+(profile plus cosine floor), index schema, and creation time. Migration 14 adds nullable
 `embedder_failure_at`/`vector_store_failure_at` fields containing no provider
 output to that singleton row. `/readyz` fails semantic readiness when configured
 values differ, indexable claims lack durable work, legacy completed index work

--- a/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
+++ b/docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md
@@ -63,6 +63,15 @@ status and safe error envelope of every loser, distinguish a product race from
 a Miniflare/runtime transient, and never hide an unexplained non-success behind
 an aggregate count.
 
+Issues #144 and #155 expose one retrieval-quality boundary. Titen currently
+sends the same raw text for index documents and queries, then rescales the best
+available vector candidate to `1` even when its absolute similarity is near
+zero. The EmbeddingGemma challenger proved that its official asymmetric prompts
+materially improve the locked fixture, but the inspected threshold is not a
+portable default. The runtime therefore needs one explicit, fingerprinted
+profile and revision plus an operator-calibrated absolute cosine floor before
+relative ranking; no model-independent threshold may be invented.
+
 Treating every report as a feature request would add speculative machinery;
 closing every report without checking it would hide real defects. The release
 needs an issue-by-issue resolution, current branch integration, accurate public
@@ -118,6 +127,12 @@ documentation, and an install smoke against the immutable npm artifact.
 - Diagnose the reopened D1 checkpoint contention result from complete-suite
   evidence; keep the one-head invariant and make expected concurrent outcomes
   explicit without weakening the canonical integrity assertion.
+- Apply one shared role-aware embedding profile before every query/document
+  provider call, normalize validated vectors to unit length, and fingerprint
+  the exact versioned transform with the immutable model revision.
+- Require an explicit calibrated cosine floor, fingerprint it with the profile,
+  discard sub-threshold semantic hits before hydration/ranking, and keep
+  authorized lexical recall and successful empty packs unchanged.
 - Preserve the user's dirty original checkout and existing stash byte-for-byte.
 
 ## Out of scope
@@ -130,6 +145,8 @@ documentation, and an install smoke against the immutable npm artifact.
   accepted throughput, adopter, quality, or lifecycle requirement.
 - Network provider probes on `/readyz`, automatic reindex after an embedding
   fingerprint change, or implementation of planned extraction/enrichment.
+- A universal vector threshold, an implicit raw-text EmbeddingGemma profile, or
+  publication of the already inspected challenger threshold as a safe default.
 - Publishing the externally blocked ClawHub bundle unless the upstream
   inspector accepts the already validated package during this work.
 - Changing or cleaning the original dirty checkout.
@@ -264,6 +281,19 @@ documentation, and an install smoke against the immutable npm artifact.
   shall be retained in assertion-failure evidence, exact aggregate status
   counts shall remain asserted, exactly one durable head shall remain, and no
   unexplained non-success shall be hidden behind an aggregate count.
+- **AC-SWP-050 — Unwanted behavior:** If semantic retrieval is configured, then
+  Titen shall require an immutable model revision, a supported named/versioned
+  role-aware preprocessing profile, and an explicit finite cosine floor; the
+  shared core shall apply the document/query transforms exactly once, reject
+  zero/non-finite vectors, normalize them to unit length, and fingerprint the
+  profile plus threshold so a change requires explicit reindexing. An
+  EmbeddingGemma model shall not run under the raw profile.
+- **AC-SWP-051 — Unwanted behavior:** If every authorized vector hit is below
+  the configured absolute cosine floor, then Titen shall hydrate none of those
+  hits and shall never turn the best bad neighbor into positive relevance by
+  relative normalization. FTS-only behavior, lexical candidates, authorization,
+  provenance, and the successful empty-pack contract shall remain unchanged,
+  and public responses shall not expose the threshold or raw provider scores.
 
 ## Done conditions
 
@@ -283,3 +313,7 @@ is resolved only after both runtimes prove default unscoped-only retrieval,
 explicit capability-gated broad retrieval, and denial of foreign project,
 subject, principal, membership, and visibility substitutions across REST and
 MCP.
+Issues #144 and #155 are resolved only after both runtime adapters share the
+same role-aware profile and absolute-gate contract, fingerprint changes fail
+readiness until explicit reindex, deterministic hard-negative regressions pass,
+and any published calibrated default has separate untouched-holdout evidence.

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -11,7 +11,11 @@ import { planFtsQuery, retrieveClaimCandidates, retrieveClaimsByIds } from "./re
 import { loadAuthorizedEvidenceIds } from "./evidence";
 import { estimateJsonTokens } from "./tokens";
 import type { RequestContext, Result } from "./http";
-import { validateEmbeddingVectors } from "./vectors";
+import {
+  eligibleVectorMatches,
+  embedForRetrieval,
+  parseEmbeddingPolicy,
+} from "./vectors";
 import {
   FEEDBACK_OUTCOMES,
   LIMITS,
@@ -100,20 +104,22 @@ export async function compileContext(ctx: RequestContext): Promise<Result> {
   let vectorUsed = false;
   if (ctx.app.vectors) {
     try {
-      const queryVec = validateEmbeddingVectors(
-        await ctx.app.vectors.embedder.embed([task]),
-        1,
-        ctx.app.vectors.embedder.dimensions,
-      )[0];
+      const queryVec = (await embedForRetrieval(ctx.app.vectors, "query", [task]))[0];
       if (queryVec) {
-        const hits = await ctx.app.vectors.store.query(queryVec, {
-          topK: LIMITS.candidates,
-          filter: {
-            org_id: principal.orgId,
-            subject_id: subjectId,
-            ...(crossProject ? {} : { project_id: projectId ?? "" }),
-          },
-        });
+        const policy = parseEmbeddingPolicy(
+          ctx.app.vectors.fingerprint.preprocessing,
+        )!;
+        const hits = eligibleVectorMatches(
+          await ctx.app.vectors.store.query(queryVec, {
+            topK: LIMITS.candidates,
+            filter: {
+              org_id: principal.orgId,
+              subject_id: subjectId,
+              ...(crossProject ? {} : { project_id: projectId ?? "" }),
+            },
+          }),
+          policy.minimumCosine,
+        );
         const similarity = new Map(hits.map((hit) => [hit.id, hit.score]));
 
         const known = new Set(candidates.map((candidate) => candidate.id));

--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -3,8 +3,8 @@ import { unavailable, validationError } from "./errors";
 import type { RequestContext, Result } from "./http";
 import {
   completeSemanticIndexWork,
+  embedForRetrieval,
   recordSemanticDependencyFailure,
-  validateEmbeddingVectors,
 } from "./vectors";
 
 /**
@@ -109,12 +109,10 @@ export async function drainIndex(ctx: RequestContext): Promise<Result> {
     // One embedding request for the batch, then one index write.
     let vectors;
     try {
-      vectors = validateEmbeddingVectors(
-        await ctx.app.vectors.embedder.embed(
-          eligible.map((entry) => entry.statement),
-        ),
-        eligible.length,
-        ctx.app.vectors.embedder.dimensions,
+      vectors = await embedForRetrieval(
+        ctx.app.vectors,
+        "document",
+        eligible.map((entry) => entry.statement),
       );
     } catch {
       await recordSemanticDependencyFailure(

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -2,8 +2,8 @@ import type { Db } from "./db";
 import { processWebhooks } from "./webhooks";
 import {
   completeSemanticIndexWork,
+  embedForRetrieval,
   recordSemanticDependencyFailure,
-  validateEmbeddingVectors,
   type VectorCapability,
 } from "./vectors";
 import type { WebhookSecurity } from "./webhook-security";
@@ -199,10 +199,10 @@ export async function indexPendingForOrg(
   if (eligible.length > 0) {
     let embeddings: Float32Array[];
     try {
-      embeddings = validateEmbeddingVectors(
-        await vectors.embedder.embed(eligible.map((entry) => entry.statement)),
-        eligible.length,
-        vectors.embedder.dimensions,
+      embeddings = await embedForRetrieval(
+        vectors,
+        "document",
+        eligible.map((entry) => entry.statement),
       );
     } catch (error) {
       await recordSemanticDependencyFailure(

--- a/src/core/vectors.ts
+++ b/src/core/vectors.ts
@@ -42,6 +42,70 @@ export interface EmbeddingProvider {
   model: string;
 }
 
+export const EMBEDDING_PROFILES = [
+  "raw-unit-v1",
+  "embeddinggemma-retrieval-v1",
+] as const;
+export type EmbeddingProfile = (typeof EMBEDDING_PROFILES)[number];
+export type EmbeddingRole = "document" | "query";
+
+export interface EmbeddingPolicy {
+  profile: EmbeddingProfile;
+  minimumCosine: number;
+}
+
+export function embeddingPolicyFingerprint(
+  profile: EmbeddingProfile,
+  minimumCosine: number,
+): string {
+  if (
+    !EMBEDDING_PROFILES.includes(profile) ||
+    !Number.isFinite(minimumCosine) ||
+    minimumCosine < -1 ||
+    minimumCosine > 1
+  )
+    throw new Error("Invalid embedding policy.");
+  return `${profile};min_cosine=${minimumCosine}`;
+}
+
+export function parseEmbeddingPolicy(value: string): EmbeddingPolicy | undefined {
+  const separator = value.lastIndexOf(";min_cosine=");
+  if (separator < 1) return undefined;
+  const profile = value.slice(0, separator) as EmbeddingProfile;
+  const rawMinimum = value.slice(separator + 12);
+  const minimumCosine = Number(rawMinimum);
+  if (
+    !EMBEDDING_PROFILES.includes(profile) ||
+    rawMinimum !== String(minimumCosine) ||
+    !Number.isFinite(minimumCosine) ||
+    minimumCosine < -1 ||
+    minimumCosine > 1
+  )
+    return undefined;
+  return { profile, minimumCosine };
+}
+
+export function embeddingInput(
+  profile: EmbeddingProfile,
+  role: EmbeddingRole,
+  content: string,
+): string {
+  if (profile === "raw-unit-v1") return content;
+  return role === "document"
+    ? `title: none | text: ${content}`
+    : `task: search result | query: ${content}`;
+}
+
+export function embeddingProfileMatchesModel(
+  profile: EmbeddingProfile,
+  model: string,
+): boolean {
+  const embeddingGemma = model.toLowerCase().includes("embeddinggemma");
+  return embeddingGemma
+    ? profile === "embeddinggemma-retrieval-v1"
+    : profile === "raw-unit-v1";
+}
+
 function invalidEmbeddingResponse(): never {
   throw new Error("Invalid embedding response.");
 }
@@ -63,6 +127,69 @@ export function validateEmbeddingVectors(
       if (!Number.isFinite(value)) invalidEmbeddingResponse();
   }
   return response;
+}
+
+/** Apply the fingerprinted role transform and normalize every vector once. */
+export async function embedForRetrieval(
+  capability: VectorCapability,
+  role: EmbeddingRole,
+  texts: string[],
+): Promise<Float32Array[]> {
+  const policy = parseEmbeddingPolicy(capability.fingerprint.preprocessing);
+  if (!policy) throw new Error("Invalid embedding policy.");
+  const vectors = validateEmbeddingVectors(
+    await capability.embedder.embed(
+      texts.map((text) => embeddingInput(policy.profile, role, text)),
+    ),
+    texts.length,
+    capability.embedder.dimensions,
+  );
+  return vectors.map((vector) => {
+    let squared = 0;
+    for (const value of vector) squared += value * value;
+    const norm = Math.sqrt(squared);
+    if (!Number.isFinite(norm) || norm === 0) invalidEmbeddingResponse();
+    const normalized = new Float32Array(vector.length);
+    for (let index = 0; index < vector.length; index += 1) {
+      normalized[index] = vector[index]! / norm;
+      if (!Number.isFinite(normalized[index])) invalidEmbeddingResponse();
+    }
+    return normalized;
+  });
+}
+
+/** Validate absolute cosine evidence before any ID can reach canonical SQL. */
+export function eligibleVectorMatches(
+  matches: unknown,
+  minimumCosine: number,
+): VectorMatch[] {
+  if (
+    !Array.isArray(matches) ||
+    !Number.isFinite(minimumCosine) ||
+    minimumCosine < -1 ||
+    minimumCosine > 1
+  )
+    throw new Error("Invalid vector response.");
+  const ids = new Set<string>();
+  const eligible: VectorMatch[] = [];
+  for (const match of matches) {
+    if (
+      !match ||
+      typeof match !== "object" ||
+      typeof (match as VectorMatch).id !== "string" ||
+      !(match as VectorMatch).id ||
+      ids.has((match as VectorMatch).id) ||
+      typeof (match as VectorMatch).score !== "number" ||
+      !Number.isFinite((match as VectorMatch).score) ||
+      (match as VectorMatch).score < -1 ||
+      (match as VectorMatch).score > 1
+    )
+      throw new Error("Invalid vector response.");
+    ids.add((match as VectorMatch).id);
+    if ((match as VectorMatch).score >= minimumCosine)
+      eligible.push(match as VectorMatch);
+  }
+  return eligible;
 }
 
 /** Validate untrusted provider output before it can reach a vector backend. */
@@ -315,9 +442,15 @@ export async function prepareSemanticReadiness(
   if (initialization.readiness.vector !== "enabled")
     return initialization.readiness;
   const fingerprint = initialization.vectors?.fingerprint;
+  const policy = fingerprint
+    ? parseEmbeddingPolicy(fingerprint.preprocessing)
+    : undefined;
   if (
     !fingerprint ||
+    !policy ||
     !validFingerprint(fingerprint) ||
+    fingerprint.metric !== "cosine" ||
+    !embeddingProfileMatchesModel(policy.profile, fingerprint.model) ||
     fingerprint.model !== initialization.vectors?.embedder.model ||
     fingerprint.dimensions !== initialization.vectors.embedder.dimensions
   )

--- a/src/core/vectors.ts
+++ b/src/core/vectors.ts
@@ -100,7 +100,10 @@ export function embeddingProfileMatchesModel(
   profile: EmbeddingProfile,
   model: string,
 ): boolean {
-  const embeddingGemma = model.toLowerCase().includes("embeddinggemma");
+  const embeddingGemma = model
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, "")
+    .includes("embeddinggemma");
   return embeddingGemma
     ? profile === "embeddinggemma-retrieval-v1"
     : profile === "raw-unit-v1";

--- a/src/runtime/bun/cli.ts
+++ b/src/runtime/bun/cli.ts
@@ -160,6 +160,8 @@ switch (command) {
         embedModel: process.env.TITEN_EMBED_MODEL,
         embedDims: process.env.TITEN_EMBED_DIMS,
         embedRevision: process.env.TITEN_EMBED_REVISION,
+        embedProfile: process.env.TITEN_EMBED_PROFILE,
+        embedMinCosine: process.env.TITEN_EMBED_MIN_COSINE,
         embedApiKey: process.env.TITEN_EMBED_API_KEY,
         maintenanceIntervalMs:
           process.env.TITEN_MAINTENANCE_INTERVAL_MS === undefined

--- a/src/runtime/bun/server.ts
+++ b/src/runtime/bun/server.ts
@@ -29,6 +29,8 @@ export interface ServeOptions {
   embedModel?: string;
   embedDims?: number | string;
   embedRevision?: string;
+  embedProfile?: string;
+  embedMinCosine?: number | string;
   embedApiKey?: string;
   webhookSecurity?: WebhookSecurity;
   secretCipher?: SecretCipher;
@@ -72,6 +74,8 @@ export async function serve(options: ServeOptions) {
         embedModel: options.embedModel,
         embedDims: options.embedDims,
         embedRevision: options.embedRevision,
+        embedProfile: options.embedProfile,
+        embedMinCosine: options.embedMinCosine,
         embedApiKey: options.embedApiKey,
       });
   const semanticReadiness = migrationsReady

--- a/src/runtime/bun/vectors.ts
+++ b/src/runtime/bun/vectors.ts
@@ -6,10 +6,15 @@ import { basename, dirname, join, resolve } from "node:path";
 import type {
   EmbeddingProvider,
   EmbeddingFingerprint,
+  EmbeddingProfile,
   VectorInitialization,
   VectorStore,
 } from "../../core/vectors";
-import { validateEmbeddingResponse } from "../../core/vectors";
+import {
+  embeddingPolicyFingerprint,
+  embeddingProfileMatchesModel,
+  validateEmbeddingResponse,
+} from "../../core/vectors";
 
 function normalizedFilePath(path: string): string {
   const absolute = resolve(path);
@@ -43,10 +48,9 @@ function aliasesFile(first: string, second: string): boolean {
  * the extension, database, or expected schema is unavailable; configured
  * semantic readiness then fails closed while canonical SQL remains intact.
  *
- * ponytail: cosine-style scoring derived from L2 distance as 1/(1+d). The
- * ceiling is that the score is monotonic but not a calibrated similarity, which
- * is enough for ranking and not enough to compare across queries. Upgrade path:
- * store normalized vectors and use a cosine distance metric directly.
+ * The shared embedding policy stores unit vectors. vec0 searches them by exact
+ * L2 distance; 1-(distance^2/2) converts that distance back to cosine so Bun and
+ * Vectorize apply the same calibrated absolute gate.
  */
 export function createSqliteVecStore(
   dbPath: string,
@@ -160,7 +164,10 @@ export function createSqliteVecStore(
           id: string;
           distance: number;
         }[];
-      return rows.map((row) => ({ id: row.id, score: 1 / (1 + row.distance) }));
+      return rows.map((row) => ({
+        id: row.id,
+        score: Math.max(-1, Math.min(1, 1 - (row.distance * row.distance) / 2)),
+      }));
     },
     async remove(ids) {
       if (ids.length === 0) return;
@@ -214,6 +221,8 @@ export function tryCreateVectors(config: {
   embedModel?: string;
   embedDims?: number | string;
   embedRevision?: string;
+  embedProfile?: string;
+  embedMinCosine?: number | string;
   embedApiKey?: string;
 }): VectorInitialization {
   const requested = [
@@ -221,12 +230,16 @@ export function tryCreateVectors(config: {
     config.embedModel,
     config.embedDims,
     config.embedRevision,
+    config.embedProfile,
+    config.embedMinCosine,
     config.embedApiKey,
   ].some((value) => value !== undefined);
   if (!requested)
     return { readiness: { embedding: "disabled", vector: "disabled" } };
 
   const dimensions = Number(config.embedDims);
+  const minimumCosine = Number(config.embedMinCosine);
+  const profile = config.embedProfile?.trim() as EmbeddingProfile | undefined;
   let baseUrl: URL;
   try {
     baseUrl = new URL(config.embedBaseUrl ?? "");
@@ -242,6 +255,13 @@ export function tryCreateVectors(config: {
   if (
     !config.embedModel?.trim() ||
     config.embedModel.trim().length > 200 ||
+    !config.embedRevision?.trim() ||
+    config.embedRevision.trim().length > 200 ||
+    !profile ||
+    !embeddingProfileMatchesModel(profile, config.embedModel.trim()) ||
+    !Number.isFinite(minimumCosine) ||
+    minimumCosine < -1 ||
+    minimumCosine > 1 ||
     !Number.isInteger(dimensions) ||
     dimensions < 1 ||
     dimensions > 65_536 ||
@@ -251,8 +271,6 @@ export function tryCreateVectors(config: {
     baseUrl.search ||
     baseUrl.hash ||
     baseUrl.href.length > 2_048 ||
-    (config.embedRevision !== undefined &&
-      (!config.embedRevision.trim() || config.embedRevision.trim().length > 200)) ||
     (config.vecDbPath !== undefined && !config.vecDbPath.trim())
   )
     return {
@@ -289,10 +307,10 @@ export function tryCreateVectors(config: {
   const fingerprint: EmbeddingFingerprint = {
     provider: `openai-compatible:${createHash("sha256").update(endpoint).digest("hex")}`,
     model: config.embedModel.trim(),
-    revision: config.embedRevision?.trim() ?? "unspecified",
+    revision: config.embedRevision.trim(),
     dimensions,
-    metric: "l2",
-    preprocessing: "text-v1",
+    metric: "cosine",
+    preprocessing: embeddingPolicyFingerprint(profile, minimumCosine),
     index_schema: "claims-scope-v1",
   };
   return {

--- a/src/runtime/bun/vectors.ts
+++ b/src/runtime/bun/vectors.ts
@@ -238,7 +238,8 @@ export function tryCreateVectors(config: {
     return { readiness: { embedding: "disabled", vector: "disabled" } };
 
   const dimensions = Number(config.embedDims);
-  const minimumCosine = Number(config.embedMinCosine);
+  const rawMinimumCosine = String(config.embedMinCosine ?? "").trim();
+  const minimumCosine = Number(rawMinimumCosine);
   const profile = config.embedProfile?.trim() as EmbeddingProfile | undefined;
   let baseUrl: URL;
   try {
@@ -259,6 +260,7 @@ export function tryCreateVectors(config: {
     config.embedRevision.trim().length > 200 ||
     !profile ||
     !embeddingProfileMatchesModel(profile, config.embedModel.trim()) ||
+    !rawMinimumCosine ||
     !Number.isFinite(minimumCosine) ||
     minimumCosine < -1 ||
     minimumCosine > 1 ||

--- a/src/runtime/cloudflare/vectors.ts
+++ b/src/runtime/cloudflare/vectors.ts
@@ -81,7 +81,8 @@ export function tryCreateVectorize(env: {
   const dimensions = Number(env.TITEN_EMBED_DIMS ?? "768");
   const revision = env.TITEN_EMBED_REVISION?.trim();
   const profile = env.TITEN_EMBED_PROFILE?.trim() as EmbeddingProfile | undefined;
-  const minimumCosine = Number(env.TITEN_EMBED_MIN_COSINE);
+  const rawMinimumCosine = env.TITEN_EMBED_MIN_COSINE?.trim() ?? "";
+  const minimumCosine = Number(rawMinimumCosine);
   const aiReady = Boolean(env.AI && typeof env.AI.run === "function");
   const vectorReady = Boolean(
     env.VECTORIZE &&
@@ -96,6 +97,7 @@ export function tryCreateVectorize(env: {
     revision.length > 200 ||
     !profile ||
     !embeddingProfileMatchesModel(profile, model.trim()) ||
+    !rawMinimumCosine ||
     !Number.isFinite(minimumCosine) ||
     minimumCosine < -1 ||
     minimumCosine > 1 ||

--- a/src/runtime/cloudflare/vectors.ts
+++ b/src/runtime/cloudflare/vectors.ts
@@ -1,8 +1,13 @@
 import { validateEmbeddingResponse } from "../../core/vectors";
 import type {
   EmbeddingProvider,
+  EmbeddingProfile,
   VectorInitialization,
   VectorStore,
+} from "../../core/vectors";
+import {
+  embeddingPolicyFingerprint,
+  embeddingProfileMatchesModel,
 } from "../../core/vectors";
 
 /** Minimal Vectorize binding interface (no @cloudflare/workers-types needed). */
@@ -57,6 +62,8 @@ export function tryCreateVectorize(env: {
   TITEN_EMBED_MODEL?: string;
   TITEN_EMBED_DIMS?: string;
   TITEN_EMBED_REVISION?: string;
+  TITEN_EMBED_PROFILE?: string;
+  TITEN_EMBED_MIN_COSINE?: string;
 }): VectorInitialization {
   const requested = [
     env.VECTORIZE,
@@ -64,12 +71,17 @@ export function tryCreateVectorize(env: {
     env.TITEN_EMBED_MODEL,
     env.TITEN_EMBED_DIMS,
     env.TITEN_EMBED_REVISION,
+    env.TITEN_EMBED_PROFILE,
+    env.TITEN_EMBED_MIN_COSINE,
   ].some((value) => value !== undefined);
   if (!requested)
     return { readiness: { embedding: "disabled", vector: "disabled" } };
 
   const model = env.TITEN_EMBED_MODEL ?? "@cf/baai/bge-base-en-v1.5";
   const dimensions = Number(env.TITEN_EMBED_DIMS ?? "768");
+  const revision = env.TITEN_EMBED_REVISION?.trim();
+  const profile = env.TITEN_EMBED_PROFILE?.trim() as EmbeddingProfile | undefined;
+  const minimumCosine = Number(env.TITEN_EMBED_MIN_COSINE);
   const aiReady = Boolean(env.AI && typeof env.AI.run === "function");
   const vectorReady = Boolean(
     env.VECTORIZE &&
@@ -80,11 +92,16 @@ export function tryCreateVectorize(env: {
   if (
     !model.trim() ||
     model.trim().length > 200 ||
+    !revision ||
+    revision.length > 200 ||
+    !profile ||
+    !embeddingProfileMatchesModel(profile, model.trim()) ||
+    !Number.isFinite(minimumCosine) ||
+    minimumCosine < -1 ||
+    minimumCosine > 1 ||
     !Number.isInteger(dimensions) ||
     dimensions < 1 ||
-    dimensions > 65_536 ||
-    (env.TITEN_EMBED_REVISION !== undefined &&
-      (!env.TITEN_EMBED_REVISION.trim() || env.TITEN_EMBED_REVISION.trim().length > 200))
+    dimensions > 65_536
   )
     return {
       readiness: {
@@ -109,10 +126,10 @@ export function tryCreateVectorize(env: {
       fingerprint: {
         provider: "workers-ai",
         model: model.trim(),
-        revision: env.TITEN_EMBED_REVISION?.trim() ?? "unspecified",
+        revision,
         dimensions,
         metric: "cosine",
-        preprocessing: "text-v1",
+        preprocessing: embeddingPolicyFingerprint(profile, minimumCosine),
         index_schema: "claims-scope-v1",
       },
     },

--- a/src/runtime/cloudflare/worker.ts
+++ b/src/runtime/cloudflare/worker.ts
@@ -18,6 +18,8 @@ export interface Env {
   TITEN_EMBED_MODEL?: string;
   TITEN_EMBED_DIMS?: string;
   TITEN_EMBED_REVISION?: string;
+  TITEN_EMBED_PROFILE?: string;
+  TITEN_EMBED_MIN_COSINE?: string;
   /** Secret JSON keyring; keep in a Worker secret, never vars or D1. */
   TITEN_SECRET_KEYS?: string;
   /** Test-only fixed resolution; production has no generic address-pinned fetch. */

--- a/tests/contract/cloudflare-d1.test.ts
+++ b/tests/contract/cloudflare-d1.test.ts
@@ -148,7 +148,7 @@ test("partial Worker semantic configuration fails readiness without leaking it",
     const body = await response.json() as any;
     assert.equal(body.meta.capabilities.embedding, "configured_error");
     assert.equal(body.meta.capabilities.vector, "configured_error");
-    assert.equal(body.meta.checks.semantic_index, "vector_initialization_failed");
+    assert.equal(body.meta.checks.semantic_index, "embedding_configuration_invalid");
     assert.doesNotMatch(JSON.stringify(body), /must-not-leak/);
   } finally {
     await partial.dispose();

--- a/tests/contract/harness.ts
+++ b/tests/contract/harness.ts
@@ -2,7 +2,10 @@ import { createApiKey, organizationStatement } from "../../src/core/auth";
 import { newId } from "../../src/core/ids";
 import type { Db, Param } from "../../src/core/db";
 import type { Trust } from "../../src/core/validate";
-import type { VectorCapability } from "../../src/core/vectors";
+import {
+  embeddingPolicyFingerprint,
+  type VectorCapability,
+} from "../../src/core/vectors";
 import { createSecretCipher } from "../../src/core/secrets";
 import type { WebhookSecurity } from "../../src/core/webhook-security";
 
@@ -206,7 +209,7 @@ export function fakeVectors(): VectorCapability & {
       revision: "v1",
       dimensions: 4,
       metric: "cosine",
-      preprocessing: "text-v1",
+      preprocessing: embeddingPolicyFingerprint("raw-unit-v1", 0.1),
       index_schema: "claims-scope-v1",
     },
     embedder: {

--- a/tests/contract/vectors.test.ts
+++ b/tests/contract/vectors.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "../../src/core/app";
+import type { Db } from "../../src/core/db";
 import { migrate } from "../../src/core/migrations";
 import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
 import { createVectorizeStore } from "../../src/runtime/cloudflare/vectors";
@@ -292,6 +293,81 @@ test("a semantic hit lifts a lexically weak claim up the ranking", async () => {
     lexicalOrder,
     "with no similarity the ranking must match lexical-only",
   );
+});
+
+test("the absolute cosine floor rejects a best bad neighbor before hydration", async () => {
+  const subject = "user_absolute_gate_144";
+  const observation = await withVectors().call("POST", "/v1/observations", {
+    key,
+    body: {
+      subject_id: subject,
+      kind: "tool_result",
+      content: "The unrelated archive stores violet telescope calibration notes.",
+      source: { type: "test", ref: "absolute-gate-144" },
+      trust: "verified",
+    },
+  });
+  assert.equal(observation.status, 201);
+  const consolidation = await withVectors().call("POST", "/v1/consolidations", {
+    key,
+    body: {
+      subject_id: subject,
+      claims: [{
+        kind: "semantic_fact",
+        statement: "Violet telescope calibration belongs in the archive.",
+        sources: [{
+          observation_id: observation.body.data.observation_id,
+          relation: "supports",
+        }],
+      }],
+    },
+  });
+  assert.equal(consolidation.status, 201);
+  const claimId = consolidation.body.data.claims[0].claim_id as string;
+  vectors.setScore(claimId, 0.099, {
+    org_id: orgId,
+    subject_id: subject,
+    project_id: "",
+  });
+
+  let vectorHydrations = 0;
+  const trackedDb: Db = {
+    all: (sql, params) => {
+      if (sql.includes("WHERE c.id IN")) vectorHydrations += 1;
+      return db.all(sql, params);
+    },
+    batch: (statements) => db.batch(statements),
+    exec: (sql) => db.exec(sql),
+  };
+  const client = clientVia(
+    createApp({ db: trackedDb, revision: "test", runtime: "bun-sqlite", vectors }),
+    origin,
+  );
+  const compile = () => client.call("POST", "/v1/context/compile", {
+    key,
+    body: { subject_id: subject, task: "...\u200d...", max_tokens: 900 },
+  });
+
+  const rejected = await compile();
+  assert.equal(rejected.status, 200);
+  assert.deepEqual(rejected.body.data.items, []);
+  assert.equal(rejected.body.meta.candidates, 0);
+  assert.equal(rejected.body.meta.degraded.vector, "used");
+  assert.equal(vectorHydrations, 0, "sub-threshold ids must not reach canonical SQL");
+  assert.doesNotMatch(
+    JSON.stringify(rejected.body),
+    /min_cosine|raw-unit-v1|0\.099/,
+  );
+
+  vectors.setScore(claimId, 0.1, {
+    org_id: orgId,
+    subject_id: subject,
+    project_id: "",
+  });
+  const accepted = await compile();
+  assert.equal(accepted.status, 200);
+  assert.equal(accepted.body.data.items[0].claim_id, claimId);
+  assert.equal(vectorHydrations, 1, "an eligible vector id is hydrated once");
 });
 
 test("narrow-band vector similarity is normalized before ranking", () => {

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -7,9 +7,16 @@ import { createApp } from "../../src/core/app";
 import { runMaintenance } from "../../src/core/maintenance";
 import { migrate } from "../../src/core/migrations";
 import {
+  eligibleVectorMatches,
+  embedForRetrieval,
+  embeddingInput,
+  embeddingPolicyFingerprint,
+  embeddingProfileMatchesModel,
+  parseEmbeddingPolicy,
   validateEmbeddingResponse,
   validateEmbeddingVectors,
   type EmbeddingProvider,
+  type VectorCapability,
   type VectorStore,
 } from "../../src/core/vectors";
 import { createHttpEmbedder } from "../../src/runtime/bun/vectors";
@@ -105,6 +112,171 @@ test("shared embedding validator accepts both provider shapes in input order", (
       dimensions,
     ),
     [new Float32Array(dense()), new Float32Array(dense())],
+  );
+});
+
+test("embedding policies are canonical, role-aware, and model-specific", () => {
+  const fingerprint = embeddingPolicyFingerprint(
+    "embeddinggemma-retrieval-v1",
+    0.737307171,
+  );
+  assert.equal(
+    fingerprint,
+    "embeddinggemma-retrieval-v1;min_cosine=0.737307171",
+  );
+  assert.deepEqual(parseEmbeddingPolicy(fingerprint), {
+    profile: "embeddinggemma-retrieval-v1",
+    minimumCosine: 0.737307171,
+  });
+  assert.equal(
+    embeddingInput("embeddinggemma-retrieval-v1", "query", "release gate"),
+    "task: search result | query: release gate",
+  );
+  assert.equal(
+    embeddingInput("embeddinggemma-retrieval-v1", "document", "release gate"),
+    "title: none | text: release gate",
+  );
+  assert.equal(embeddingInput("raw-unit-v1", "query", "release gate"), "release gate");
+  assert.deepEqual(
+    parseEmbeddingPolicy(embeddingPolicyFingerprint("raw-unit-v1", 0)),
+    { profile: "raw-unit-v1", minimumCosine: 0 },
+  );
+  assert.equal(
+    embeddingProfileMatchesModel(
+      "embeddinggemma-retrieval-v1",
+      "google/embeddinggemma-300m",
+    ),
+    true,
+  );
+  assert.equal(
+    embeddingProfileMatchesModel("raw-unit-v1", "tuf/embeddinggemma"),
+    false,
+  );
+  assert.equal(parseEmbeddingPolicy("raw-unit-v1;min_cosine=0.10"), undefined);
+});
+
+test("both runtime adapters receive identical role prompts and return unit vectors", async () => {
+  const seen: string[][] = [];
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(request: Request) {
+      const body = await request.json() as { input: string[] };
+      seen.push(body.input);
+      return Response.json({
+        data: body.input.map(() => ({ embedding: [3, 4, 0, 0] })),
+      });
+    },
+  });
+  const providers = [
+    createHttpEmbedder({
+      baseUrl: `http://127.0.0.1:${server.port}/v1`,
+      model: "tuf/embeddinggemma",
+      dimensions,
+    }),
+    createWorkersAiEmbedder(
+      {
+        async run(_model, input) {
+          seen.push(input.text);
+          return { data: input.text.map(() => [3, 4, 0, 0]) };
+        },
+      },
+      "tuf/embeddinggemma",
+      dimensions,
+    ),
+  ];
+  const store: VectorStore = {
+    async upsert() {},
+    async query() { return []; },
+    async remove() {},
+  };
+
+  try {
+    for (const embedder of providers) {
+      const capability: VectorCapability = {
+        store,
+        embedder,
+        fingerprint: {
+          provider: "test",
+          model: embedder.model,
+          revision: "immutable-test-revision",
+          dimensions,
+          metric: "cosine",
+          preprocessing: embeddingPolicyFingerprint(
+            "embeddinggemma-retrieval-v1",
+            0.7,
+          ),
+          index_schema: "claims-scope-v1",
+        },
+      };
+      const [query] = await embedForRetrieval(capability, "query", ["release gate"]);
+      const [document] = await embedForRetrieval(capability, "document", ["release gate"]);
+      assert.deepEqual([...query!], [0.6000000238418579, 0.800000011920929, 0, 0]);
+      assert.deepEqual([...document!], [...query!]);
+    }
+    assert.deepEqual(seen, [
+      ["task: search result | query: release gate"],
+      ["title: none | text: release gate"],
+      ["task: search result | query: release gate"],
+      ["title: none | text: release gate"],
+    ]);
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("shared retrieval boundary rejects zero vectors and invalid vector matches", async () => {
+  const capability: VectorCapability = {
+    store: {
+      async upsert() {},
+      async query() { return []; },
+      async remove() {},
+    },
+    embedder: {
+      dimensions: 2,
+      model: "test-model",
+      async embed() { return [new Float32Array([0, 0])]; },
+    },
+    fingerprint: {
+      provider: "test",
+      model: "test-model",
+      revision: "immutable-test-revision",
+      dimensions: 2,
+      metric: "cosine",
+      preprocessing: embeddingPolicyFingerprint("raw-unit-v1", 0.5),
+      index_schema: "claims-scope-v1",
+    },
+  };
+  await assert.rejects(
+    () => embedForRetrieval(capability, "query", ["query"]),
+    /^Error: Invalid embedding response\.$/,
+  );
+  assert.deepEqual(
+    eligibleVectorMatches(
+      [
+        { id: "below", score: 0.499 },
+        { id: "equal", score: 0.5 },
+        { id: "above", score: 1 },
+      ],
+      0.5,
+    ),
+    [
+      { id: "equal", score: 0.5 },
+      { id: "above", score: 1 },
+    ],
+  );
+  for (const matches of [
+    [{ id: "duplicate", score: 0.9 }, { id: "duplicate", score: 0.8 }],
+    [{ id: "outside-cosine", score: 1.01 }],
+    [{ id: "not-finite", score: Number.NaN }],
+  ])
+    assert.throws(
+      () => eligibleVectorMatches(matches, 0.5),
+      /^Error: Invalid vector response\.$/,
+    );
+  assert.throws(
+    () => eligibleVectorMatches([], -1.01),
+    /^Error: Invalid vector response\.$/,
   );
 });
 
@@ -238,7 +410,7 @@ for (const adapter of consumers)
           revision: "test",
           dimensions,
           metric: "cosine",
-          preprocessing: "none",
+          preprocessing: embeddingPolicyFingerprint("raw-unit-v1", 0.1),
           index_schema: "claims-v1",
         },
       };

--- a/tests/integration/embedding-validation.test.ts
+++ b/tests/integration/embedding-validation.test.ts
@@ -144,7 +144,7 @@ test("embedding policies are canonical, role-aware, and model-specific", () => {
   assert.equal(
     embeddingProfileMatchesModel(
       "embeddinggemma-retrieval-v1",
-      "google/embeddinggemma-300m",
+      "google/embedding-gemma-300m",
     ),
     true,
   );

--- a/tests/integration/semantic-configuration.test.ts
+++ b/tests/integration/semantic-configuration.test.ts
@@ -8,9 +8,20 @@ import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
 import { migrate } from "../../src/core/migrations";
 import { serve } from "../../src/runtime/bun/server";
 import { tryCreateVectorize } from "../../src/runtime/cloudflare/vectors";
+import { embeddingPolicyFingerprint } from "../../src/core/vectors";
 import { fakeVectors, TEST_SECRET_CIPHER } from "../contract/harness";
 
 const directory = mkdtempSync(join(tmpdir(), "titen-semantic-config-"));
+const rawPolicy = {
+  embedRevision: "revision-1",
+  embedProfile: "raw-unit-v1",
+  embedMinCosine: 0.1,
+} as const;
+const workerRawPolicy = {
+  TITEN_EMBED_REVISION: "revision-1",
+  TITEN_EMBED_PROFILE: "raw-unit-v1",
+  TITEN_EMBED_MIN_COSINE: "0.1",
+} as const;
 afterAll(() => rmSync(directory, { recursive: true, force: true }));
 
 test("Bun distinguishes absent, partial, unavailable, and healthy semantic configuration", () => {
@@ -32,6 +43,7 @@ test("Bun distinguishes absent, partial, unavailable, and healthy semantic confi
       embedBaseUrl: "http://127.0.0.1:11434/v1",
       embedModel: "model",
       embedDims: 4,
+      ...rawPolicy,
     }).readiness,
     {
       embedding: "enabled",
@@ -44,7 +56,7 @@ test("Bun distinguishes absent, partial, unavailable, and healthy semantic confi
     embedBaseUrl: "http://127.0.0.1:11434/v1",
     embedModel: "model",
     embedDims: 4,
-    embedRevision: "revision-1",
+    ...rawPolicy,
   });
   assert.deepEqual(healthy.readiness, { embedding: "enabled", vector: "enabled" });
   assert.equal(healthy.vectors?.indexEmpty, true);
@@ -53,8 +65,8 @@ test("Bun distinguishes absent, partial, unavailable, and healthy semantic confi
     model: "model",
     revision: "revision-1",
     dimensions: 4,
-    metric: "l2",
-    preprocessing: "text-v1",
+    metric: "cosine",
+    preprocessing: embeddingPolicyFingerprint("raw-unit-v1", 0.1),
     index_schema: "claims-scope-v1",
   });
   assert.match(
@@ -67,7 +79,7 @@ test("Bun distinguishes absent, partial, unavailable, and healthy semantic confi
     embedBaseUrl: "http://127.0.0.1:11435/v1",
     embedModel: "model",
     embedDims: 4,
-    embedRevision: "revision-1",
+    ...rawPolicy,
   });
   assert.notEqual(
     otherEndpoint.vectors?.fingerprint.provider,
@@ -78,7 +90,7 @@ test("Bun distinguishes absent, partial, unavailable, and healthy semantic confi
     embedBaseUrl: "http://127.0.0.1:11434/v1",
     embedModel: "model",
     embedDims: 4,
-    embedRevision: "revision-1",
+    ...rawPolicy,
   });
   assert.equal(reopened.vectors?.indexEmpty, true);
   const incompatible = tryCreateVectors({
@@ -86,6 +98,7 @@ test("Bun distinguishes absent, partial, unavailable, and healthy semantic confi
     embedBaseUrl: "http://127.0.0.1:11434/v1",
     embedModel: "model",
     embedDims: 8,
+    ...rawPolicy,
   });
   assert.equal(incompatible.readiness.vector, "configured_error");
   assert.equal(incompatible.readiness.diagnostic, "vector_initialization_failed");
@@ -106,6 +119,7 @@ test("Bun refuses canonical database aliases before vector schema mutation", () 
       embedBaseUrl: "http://127.0.0.1:11434/v1",
       embedModel: "model",
       embedDims: 4,
+      ...rawPolicy,
     });
     assert.deepEqual(result.readiness, {
       embedding: "enabled",
@@ -151,6 +165,7 @@ test("Bun rejects plain and wrong-module vec_claims lookalikes", () => {
       embedBaseUrl: "http://127.0.0.1:11434/v1",
       embedModel: "model",
       embedDims: 4,
+      ...rawPolicy,
     });
     assert.equal(result.readiness.vector, "configured_error");
     assert.equal(result.readiness.diagnostic, "vector_initialization_failed");
@@ -176,13 +191,18 @@ test("Cloudflare validates binding completeness without calling either binding",
     embedding: "disabled",
     vector: "disabled",
   });
-  assert.deepEqual(tryCreateVectorize({ AI: ai }).readiness, {
+  assert.deepEqual(tryCreateVectorize({ AI: ai, ...workerRawPolicy }).readiness, {
     embedding: "enabled",
     vector: "configured_error",
     diagnostic: "vector_initialization_failed",
   });
   assert.equal(
-    tryCreateVectorize({ AI: ai, VECTORIZE: vectorize, TITEN_EMBED_DIMS: "nope" })
+    tryCreateVectorize({
+      AI: ai,
+      VECTORIZE: vectorize,
+      TITEN_EMBED_DIMS: "nope",
+      ...workerRawPolicy,
+    })
       .readiness.diagnostic,
     "embedding_configuration_invalid",
   );
@@ -191,11 +211,66 @@ test("Cloudflare validates binding completeness without calling either binding",
     VECTORIZE: vectorize,
     TITEN_EMBED_MODEL: "@cf/example/model",
     TITEN_EMBED_DIMS: "4",
-    TITEN_EMBED_REVISION: "revision-1",
+    ...workerRawPolicy,
   });
   assert.equal(healthy.readiness.vector, "enabled");
   assert.equal(healthy.vectors?.fingerprint.provider, "workers-ai");
+  assert.equal(
+    healthy.vectors?.fingerprint.preprocessing,
+    embeddingPolicyFingerprint("raw-unit-v1", 0.1),
+  );
   assert.equal(calls, 0, "configuration and readiness must not call remote bindings");
+});
+
+test("both runtimes require the EmbeddingGemma retrieval profile", () => {
+  const vecDbPath = join(directory, "embeddinggemma-profile.db");
+  const bunBase = {
+    vecDbPath,
+    embedBaseUrl: "http://127.0.0.1:11434/v1",
+    embedModel: "tuf/embeddinggemma",
+    embedDims: 4,
+    embedRevision: "immutable-test-revision",
+    embedMinCosine: 0.7,
+  } as const;
+  assert.equal(
+    tryCreateVectors({ ...bunBase, embedProfile: "raw-unit-v1" }).readiness
+      .diagnostic,
+    "embedding_configuration_invalid",
+  );
+  assert.equal(
+    tryCreateVectors({
+      ...bunBase,
+      embedProfile: "embeddinggemma-retrieval-v1",
+    }).readiness.vector,
+    "enabled",
+  );
+
+  const AI = { run: async () => ({ data: [] }) };
+  const VECTORIZE = {
+    upsert: async () => {},
+    query: async () => ({ matches: [] }),
+    deleteByIds: async () => {},
+  };
+  const workerBase = {
+    AI,
+    VECTORIZE,
+    TITEN_EMBED_MODEL: "tuf/embeddinggemma",
+    TITEN_EMBED_DIMS: "4",
+    TITEN_EMBED_REVISION: "immutable-test-revision",
+    TITEN_EMBED_MIN_COSINE: "0.7",
+  } as const;
+  assert.equal(
+    tryCreateVectorize({ ...workerBase, TITEN_EMBED_PROFILE: "raw-unit-v1" })
+      .readiness.diagnostic,
+    "embedding_configuration_invalid",
+  );
+  assert.equal(
+    tryCreateVectorize({
+      ...workerBase,
+      TITEN_EMBED_PROFILE: "embeddinggemma-retrieval-v1",
+    }).readiness.vector,
+    "enabled",
+  );
 });
 
 test("Bun serves health but fails readiness for a partial semantic tuple", async () => {

--- a/tests/integration/semantic-configuration.test.ts
+++ b/tests/integration/semantic-configuration.test.ts
@@ -241,6 +241,14 @@ test("both runtimes require the EmbeddingGemma retrieval profile", () => {
     tryCreateVectors({
       ...bunBase,
       embedProfile: "embeddinggemma-retrieval-v1",
+      embedMinCosine: "   ",
+    }).readiness.diagnostic,
+    "embedding_configuration_invalid",
+  );
+  assert.equal(
+    tryCreateVectors({
+      ...bunBase,
+      embedProfile: "embeddinggemma-retrieval-v1",
     }).readiness.vector,
     "enabled",
   );
@@ -262,6 +270,14 @@ test("both runtimes require the EmbeddingGemma retrieval profile", () => {
   assert.equal(
     tryCreateVectorize({ ...workerBase, TITEN_EMBED_PROFILE: "raw-unit-v1" })
       .readiness.diagnostic,
+    "embedding_configuration_invalid",
+  );
+  assert.equal(
+    tryCreateVectorize({
+      ...workerBase,
+      TITEN_EMBED_PROFILE: "embeddinggemma-retrieval-v1",
+      TITEN_EMBED_MIN_COSINE: "   ",
+    }).readiness.diagnostic,
     "embedding_configuration_invalid",
   );
   assert.equal(

--- a/tests/integration/sqlite-vec.test.ts
+++ b/tests/integration/sqlite-vec.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "../../src/core/app";
 import { migrate } from "../../src/core/migrations";
+import { embeddingPolicyFingerprint } from "../../src/core/vectors";
 import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
 import { createSqliteVecStore, createHttpEmbedder } from "../../src/runtime/bun/vectors";
 import { clientVia, provisionWith } from "../contract/harness";
@@ -184,8 +185,8 @@ test("the real store drives compilation through the shared core", async () => {
       model: "stub",
       revision: "v1",
       dimensions: DIMENSIONS,
-      metric: "l2",
-      preprocessing: "text-v1",
+      metric: "cosine",
+      preprocessing: embeddingPolicyFingerprint("raw-unit-v1", 0.1),
       index_schema: "claims-scope-v1",
     },
     embedder: createHttpEmbedder({


### PR DESCRIPTION
## Summary

- require an immutable embedding revision, named role-aware profile, and explicit calibrated cosine floor
- apply the official asymmetric EmbeddingGemma query/document inputs once in shared core and unit-normalize all vectors
- discard sub-threshold vector IDs before canonical SQL hydration while preserving lexical recall and successful empty packs
- fingerprint the policy in existing semantic metadata; no schema or dependency added

Refs #144
Refs #155

## Workflow

- Spec: `docs/specs/active/2026-07-31-open-issue-sweep-and-npm-release.md` (AC-SWP-050, AC-SWP-051)
- Plan: `docs/plans/active/2026-07-31-open-issue-sweep-and-npm-release.md`
- Release impact: patch
- Migration: none; profile/floor changes require the documented explicit projection reset and requeue
- Rollback: disable semantic configuration for intentional FTS-only operation or revert before npm publication

## Manual verification

- 82 focused embedding/configuration/vector tests passed
- 152 integration tests passed
- 117 Bun contract/vector/SDK tests passed
- Worker dry-run build passed
- route docs, workflow docs, and `git diff --check` passed

GitHub Actions remain disabled by project policy; all gates are manual-local so the repository incurs no hosted automation cost.