### PR TITLE
test: stabilize the D1 release gate

### DIFF
--- a/docs/plans/active/2026-07-31-d1-release-gate-runtime.md
+++ b/docs/plans/active/2026-07-31-d1-release-gate-runtime.md
@@ -1,0 +1,50 @@
+---
+work_id: d1-release-gate-runtime
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-07-31
+updated: 2026-07-31
+review_after: 2026-08-14
+owner: CADIS
+spec: docs/specs/active/2026-07-31-d1-release-gate-runtime.md
+---
+# Plan
+
+- [x] Reproduce the locked-runtime failure in five predeclared serial runs and
+  retain each complete log and digest.
+- [x] Run the same five-run experiment with only the matched 2026-07-30
+  Miniflare/workerd and Wrangler versions changed.
+- [ ] Pin the two existing development tools, update the reviewed supply-chain
+  exclusions, remove the parser retry, and add exact checkpoint response
+  diagnostics.
+- [ ] Run focused diagnostics, frozen install, supply-chain check, Worker build,
+  five complete D1 passes, teardown inspection, workflow checks, package smoke,
+  production audit, secret scan, and the full local repository gate.
+- [ ] Rebase onto current `origin/main`, review the exact diff, merge through a
+  pull request, and repeat the release-critical checks from clean source.
+- [ ] Run a real Cloudflare D1 smoke, record issue/PR evidence, and close this
+  pair only when every criterion is proven.
+
+## Evidence mapping
+
+- AC-D1G-001: five old-runtime logs, five candidate-runtime logs, and five final
+  clean-branch 94/94 transcripts with no rerun.
+- AC-D1G-002: removed retry diff plus a focused synthetic unexpected-response
+  diagnostic check and unchanged failure assertions.
+- AC-D1G-003: unique `mkdtempSync` source audit, `dispose()` paths, and empty
+  owned-workerd inspection after the five-run lane.
+- AC-D1G-004: exact manifest/lock versions, frozen install, supply-chain policy,
+  and `pnpm build:worker` output.
+- AC-D1G-005: production Worker revision plus real D1 health, readiness, and
+  authenticated write/read smoke without logging credentials.
+
+## Security, deployment, smoke, and rollback
+
+No production schema or API behavior changes. Diagnostics retain only response
+status and the existing safe error envelope. Deployment is not required for the
+dependency pin itself, but the release remains blocked until a real D1 smoke
+passes. Before merge, rollback is branch deletion; after merge it is a reviewed
+revert to the prior pins, which cannot be used as release approval because the
+old gate failed two of five controlled runs.

--- a/docs/plans/active/2026-07-31-d1-release-gate-runtime.md
+++ b/docs/plans/active/2026-07-31-d1-release-gate-runtime.md
@@ -1,7 +1,7 @@
 ---
 work_id: d1-release-gate-runtime
 status: active
-stage: plan
+stage: implement
 outcome: pending
 complexity: complex
 created: 2026-07-31
@@ -16,9 +16,10 @@ spec: docs/specs/active/2026-07-31-d1-release-gate-runtime.md
   retain each complete log and digest.
 - [x] Run the same five-run experiment with only the matched 2026-07-30
   Miniflare/workerd and Wrangler versions changed.
-- [ ] Pin the two existing development tools, update the reviewed supply-chain
-  exclusions, remove the parser retry, and add exact checkpoint response
-  diagnostics.
+- [x] Pin the two existing development tools, update the reviewed supply-chain
+  exclusions, remove the parser retry, bundle the D1 test entrypoint for Node's
+  built-in runner, bound only its long semantic-readiness case at 60 seconds,
+  and add exact checkpoint response diagnostics.
 - [ ] Run focused diagnostics, frozen install, supply-chain check, Worker build,
   five complete D1 passes, teardown inspection, workflow checks, package smoke,
   production audit, secret scan, and the full local repository gate.
@@ -31,19 +32,21 @@ spec: docs/specs/active/2026-07-31-d1-release-gate-runtime.md
 
 - AC-D1G-001: five old-runtime logs, five candidate-runtime logs, and five final
   clean-branch 94/94 transcripts with no rerun.
-- AC-D1G-002: removed retry diff plus a focused synthetic unexpected-response
-  diagnostic check and unchanged failure assertions.
+- AC-D1G-002: captured pre-fix 501 body, removed retry diff, focused 20/20
+  concurrent passes, rejected direct-Request experiment, and unchanged failure
+  assertions.
 - AC-D1G-003: unique `mkdtempSync` source audit, `dispose()` paths, and empty
   owned-workerd inspection after the five-run lane.
 - AC-D1G-004: exact manifest/lock versions, frozen install, supply-chain policy,
-  and `pnpm build:worker` output.
+  `pnpm build:worker` output, and Node-built-in D1 runner transcript.
 - AC-D1G-005: production Worker revision plus real D1 health, readiness, and
   authenticated write/read smoke without logging credentials.
 
 ## Security, deployment, smoke, and rollback
 
 No production schema or API behavior changes. Diagnostics retain only response
-status and the existing safe error envelope. Deployment is not required for the
+status, at most 200 characters of a non-JSON body, and the existing safe error
+envelope. Deployment is not required for the
 dependency pin itself, but the release remains blocked until a real D1 smoke
 passes. Before merge, rollback is branch deletion; after merge it is a reviewed
 revert to the prior pins, which cannot be used as release approval because the

--- a/docs/specs/active/2026-07-31-d1-release-gate-runtime.md
+++ b/docs/specs/active/2026-07-31-d1-release-gate-runtime.md
@@ -1,0 +1,77 @@
+---
+work_id: d1-release-gate-runtime
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-07-31
+updated: 2026-07-31
+review_after: 2026-08-14
+owner: CADIS
+---
+# D1 release gate runtime
+
+## Problem
+
+The locked `miniflare@4.20260722.1` D1 contract lane failed two of five
+predeclared serial runs on a quiet host. One run lost an expected checkpoint
+success and another received plain `ERROR` where Miniflare expected JSON. The
+same 94-case suite passed five of five serial runs after updating only the
+matched Miniflare/workerd and Wrangler versions dated 2026-07-30.
+
+The test currently retries one Miniflare parser failure during provisioning.
+That can hide a red release gate and conflicts with the repository rule that a
+failed canonical-integrity run is retained rather than averaged away.
+
+## Scope
+
+- Pin the existing Miniflare and Wrangler development dependencies to their
+  matching 2026-07-30 releases without adding a package.
+- Remove the provisioning retry and retain safe per-response diagnostics for
+  concurrent checkpoint failures.
+- Keep every Miniflare database in a unique temporary directory and prove each
+  owned runtime is disposed after the complete lane.
+- Require five predeclared complete serial passes and a real Cloudflare D1
+  smoke before the npm release can proceed.
+
+## Out of scope
+
+- Product retries, relaxed concurrency assertions, or treating emulator errors
+  as successful requests.
+- GitHub Actions, a new test framework, or a cross-platform lock service.
+- Automatic derivation/reflection implementation or unrelated open issues.
+
+## Constraints and risks
+
+- D1 and SQL remain canonical; the change may alter only the local gate runtime
+  and diagnostics.
+- Supply-chain age policy must still pass with explicit reviewed exclusions for
+  the two new tool versions.
+- A five-run local pass does not replace a real Cloudflare D1 smoke.
+- Rollback is restoring the prior dependency pins; it also restores the
+  reproduced unreliable gate and therefore cannot approve a release.
+
+## Acceptance criteria
+
+- **AC-D1G-001 — Event-driven:** When the complete Cloudflare/D1 contract runs
+  with the reviewed runtime pins, Titen shall pass all 94 cases in five
+  predeclared consecutive serial runs without retrying a failed run.
+- **AC-D1G-002 — Unwanted behavior:** If provisioning or a concurrent request
+  returns an unexpected status or parser failure, then the gate shall fail the
+  current run and retain the safe status, error code, message, and request ID
+  available at that boundary.
+- **AC-D1G-003 — Ubiquitous:** Every Miniflare database shall use a unique
+  temporary persistence directory, every owned Miniflare runtime shall be
+  disposed, and no owned workerd process shall remain after the lane exits.
+- **AC-D1G-004 — Event-driven:** When dependencies are installed from the
+  frozen lockfile, supply-chain policy and the Worker dry-run build shall pass
+  with `miniflare@4.20260730.0` and `wrangler@4.116.0`.
+- **AC-D1G-005 — State-driven:** While the npm candidate lacks a passing real
+  Cloudflare D1 smoke, Titen shall not publish the release.
+
+## Done conditions
+
+All criteria have reproducible evidence, the full repository gate and package
+verifier pass, issue #157 records the old/new comparison, superseded PR #147 is
+closed without merging its stale release claims, and this pair moves to
+`docs/specs/done/` and `docs/plans/done/`.

--- a/docs/specs/active/2026-07-31-d1-release-gate-runtime.md
+++ b/docs/specs/active/2026-07-31-d1-release-gate-runtime.md
@@ -1,7 +1,7 @@
 ---
 work_id: d1-release-gate-runtime
 status: active
-stage: plan
+stage: implement
 outcome: pending
 complexity: complex
 created: 2026-07-31
@@ -17,7 +17,12 @@ The locked `miniflare@4.20260722.1` D1 contract lane failed two of five
 predeclared serial runs on a quiet host. One run lost an expected checkpoint
 success and another received plain `ERROR` where Miniflare expected JSON. The
 same 94-case suite passed five of five serial runs after updating only the
-matched Miniflare/workerd and Wrangler versions dated 2026-07-30.
+matched Miniflare/workerd and Wrangler versions dated 2026-07-30, while the
+existing provisioning retry was still present. Removing that retry exposed one
+more harness failure in five runs: Miniflare returned HTTP 501 with
+`ERROR: Unrecognized request method.` before Titen handled the request. Passing
+the existing request object directly did not fix the proxy: a complete run then
+hit twelve non-JSON `ERROR` replies from Miniflare's synchronous D1 stub.
 
 The test currently retries one Miniflare parser failure during provisioning.
 That can hide a red release gate and conflicts with the repository rule that a
@@ -27,8 +32,13 @@ failed canonical-integrity run is retained rather than averaged away.
 
 - Pin the existing Miniflare and Wrangler development dependencies to their
   matching 2026-07-30 releases without adding a package.
-- Remove the provisioning retry and retain safe per-response diagnostics for
-  concurrent checkpoint failures.
+- Remove the provisioning retry and retain safe bounded response diagnostics
+  for concurrent checkpoint failures.
+- Bundle only the D1 contract entrypoint with the existing Bun builder and run
+  that bundle under Node's built-in test runner, matching Miniflare's documented
+  host runtime without adding a dependency or changing the Bun/SQLite lane.
+- Give only the multi-phase semantic-readiness case a 60-second ceiling; keep
+  the other 93 cases at the existing 20-second default.
 - Keep every Miniflare database in a unique temporary directory and prove each
   owned runtime is disposed after the complete lane.
 - Require five predeclared complete serial passes and a real Cloudflare D1
@@ -38,6 +48,7 @@ failed canonical-integrity run is retained rather than averaged away.
 
 - Product retries, relaxed concurrency assertions, or treating emulator errors
   as successful requests.
+- Raising the timeout for the complete D1 lane or its race cases.
 - GitHub Actions, a new test framework, or a cross-platform lock service.
 - Automatic derivation/reflection implementation or unrelated open issues.
 
@@ -58,14 +69,15 @@ failed canonical-integrity run is retained rather than averaged away.
   predeclared consecutive serial runs without retrying a failed run.
 - **AC-D1G-002 — Unwanted behavior:** If provisioning or a concurrent request
   returns an unexpected status or parser failure, then the gate shall fail the
-  current run and retain the safe status, error code, message, and request ID
-  available at that boundary.
+  current run and retain the safe status, bounded non-JSON body, error code,
+  message, and request ID available at that boundary.
 - **AC-D1G-003 — Ubiquitous:** Every Miniflare database shall use a unique
   temporary persistence directory, every owned Miniflare runtime shall be
   disposed, and no owned workerd process shall remain after the lane exits.
 - **AC-D1G-004 — Event-driven:** When dependencies are installed from the
   frozen lockfile, supply-chain policy and the Worker dry-run build shall pass
-  with `miniflare@4.20260730.0` and `wrangler@4.116.0`.
+  with `miniflare@4.20260730.0` and `wrangler@4.116.0`, and the D1 lane shall
+  execute under the repository's supported Node 22-or-newer runtime.
 - **AC-D1G-005 — State-driven:** While the npm candidate lacks a passing real
   Cloudflare D1 smoke, Titen shall not publish the release.
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "preview": "astro preview",
     "test": "pnpm build && playwright test",
     "test:browser": "playwright test",
-    "test:api": "pnpm build:worker && bun test --timeout=20000 tests/contract/cloudflare-d1.test.ts && bun test tests/contract/bun-sqlite.test.ts tests/contract/vectors.test.ts tests/sdk",
+    "test:api": "pnpm build:worker && pnpm test:d1 && bun test tests/contract/bun-sqlite.test.ts tests/contract/vectors.test.ts tests/sdk",
+    "test:d1": "bun build tests/contract/cloudflare-d1.test.ts --outfile dist/test/cloudflare-d1.test.mjs --target node --format esm --external miniflare && node --test --test-timeout=20000 dist/test/cloudflare-d1.test.mjs",
     "test:all": "pnpm test:api && pnpm test:integration && pnpm verify:dashboard-live && pnpm test && pnpm check:workflow",
     "build:worker": "WRANGLER_SEND_METRICS=false wrangler deploy --dry-run --outdir dist/worker",
     "build:npm": "bun build src/sdk.ts --outfile dist/npm/sdk.js --target node --format esm",
@@ -85,8 +86,8 @@
     "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@playwright/test": "1.62.0",
     "astro": "7.1.4",
-    "miniflare": "4.20260722.1",
-    "wrangler": "4.115.0",
+    "miniflare": "4.20260730.0",
+    "wrangler": "4.116.0",
     "sqlite-vec": "0.1.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,14 +24,14 @@ importers:
         specifier: 7.1.4
         version: 7.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       miniflare:
-        specifier: 4.20260722.1
-        version: 4.20260722.1
+        specifier: 4.20260730.0
+        version: 4.20260730.0
       sqlite-vec:
         specifier: 0.1.9
         version: 0.1.9
       wrangler:
-        specifier: 4.115.0
-        version: 4.115.0
+        specifier: 4.116.0
+        version: 4.116.0
 
 packages:
 
@@ -205,32 +205,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
-    resolution: {integrity: sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==}
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
+    resolution: {integrity: sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
-    resolution: {integrity: sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==}
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
+    resolution: {integrity: sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260722.1':
-    resolution: {integrity: sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==}
+  '@cloudflare/workerd-linux-64@1.20260730.1':
+    resolution: {integrity: sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260722.1':
-    resolution: {integrity: sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==}
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
+    resolution: {integrity: sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260722.1':
-    resolution: {integrity: sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==}
+  '@cloudflare/workerd-windows-64@1.20260730.1':
+    resolution: {integrity: sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1320,8 +1320,8 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
-  miniflare@4.20260722.1:
-    resolution: {integrity: sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==}
+  miniflare@4.20260730.0:
+    resolution: {integrity: sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1729,17 +1729,17 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  workerd@1.20260722.1:
-    resolution: {integrity: sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==}
+  workerd@1.20260730.1:
+    resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.115.0:
-    resolution: {integrity: sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==}
+  wrangler@4.116.0:
+    resolution: {integrity: sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260722.1
+      '@cloudflare/workers-types': ^5.20260730.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -1927,25 +1927,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260722.1
+      workerd: 1.20260730.1
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260722.1':
+  '@cloudflare/workerd-linux-64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260722.1':
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260722.1':
+  '@cloudflare/workerd-windows-64@1.20260730.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -2896,12 +2896,12 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  miniflare@4.20260722.1:
+  miniflare@4.20260730.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
       undici: 7.28.0
-      workerd: 1.20260722.1
+      workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -3295,24 +3295,24 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  workerd@1.20260722.1:
+  workerd@1.20260730.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260722.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260722.1
-      '@cloudflare/workerd-linux-64': 1.20260722.1
-      '@cloudflare/workerd-linux-arm64': 1.20260722.1
-      '@cloudflare/workerd-windows-64': 1.20260722.1
+      '@cloudflare/workerd-darwin-64': 1.20260730.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260730.1
+      '@cloudflare/workerd-linux-64': 1.20260730.1
+      '@cloudflare/workerd-linux-arm64': 1.20260730.1
+      '@cloudflare/workerd-windows-64': 1.20260730.1
 
-  wrangler@4.115.0:
+  wrangler@4.116.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260722.1
+      miniflare: 4.20260730.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260722.1
+      workerd: 1.20260730.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ allowBuilds:
   workerd: true
 
 minimumReleaseAgeExclude:
-  - miniflare@4.20260722.1
-  - wrangler@4.115.0
+  - miniflare@4.20260730.0
+  - wrangler@4.116.0
 
 onlyBuiltDependencies:
   - esbuild

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -3957,6 +3957,7 @@ export const CASES: Case[] = [
         .map((result, index) => ({
           index,
           status: result.status,
+          body: typeof result.body === "string" ? result.body.slice(0, 200) : undefined,
           code: result.body?.error?.code,
           message: result.body?.error?.message,
           request_id: result.body?.meta?.request_id,

--- a/tests/contract/cloudflare-d1.test.ts
+++ b/tests/contract/cloudflare-d1.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, test } from "bun:test";
+import { after, before, test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -70,29 +70,11 @@ const client = () =>
     return response as unknown as Response;
   }, origin);
 
-/**
- * Miniflare's D1 shim occasionally answers a batch with a non-JSON error
- * string, which its own response parser then throws on. It is a harness fault,
- * not a service fault, so provisioning retries once.
- *
- * ponytail: single retry, no backoff. The ceiling is a second consecutive shim
- * fault failing the case; upgrade path is dropping this once Miniflare's D1
- * parser handles its own error payloads.
- */
-async function provisionRetrying(options?: Parameters<typeof provisionWith>[1]) {
-  try {
-    return await provisionWith(db, options);
-  } catch (error) {
-    if (!/Unexpected identifier|JSON Parse error/.test(String(error))) throw error;
-    return provisionWith(db, options);
-  }
-}
-
 const fixture: Fixture = {
   runtime: "cloudflare-d1",
   call: (method, path, options) => client().call(method, path, options),
   callRaw: (method, path, options) => client().callRaw(method, path, options),
-  provision: (options) => provisionRetrying(options),
+  provision: (options) => provisionWith(db, options),
   revoke: (keyId) => revokeWith(db, keyId),
   query: (sql, params) => db.all(sql, params),
   async restart() {
@@ -101,8 +83,8 @@ const fixture: Fixture = {
   },
 };
 
-beforeAll(start);
-afterAll(async () => {
+before(start);
+after(async () => {
   await starting;
   await mf.dispose();
   rmSync(persist, { recursive: true, force: true });
@@ -112,9 +94,13 @@ test("batch writes are atomic on D1", async () => {
   await assertBatchAtomicity(db);
 });
 
-test("D1 semantic readiness persists and compares its fingerprint locally", async () => {
-  await assertSemanticReadiness(db, "cloudflare-d1");
-});
+test(
+  "D1 semantic readiness persists and compares its fingerprint locally",
+  { timeout: 60_000 },
+  async () => {
+    await assertSemanticReadiness(db, "cloudflare-d1");
+  },
+);
 
 test("auto-migrate off blocks API traffic on a stale D1 schema", async () => {
   const stalePersist = mkdtempSync(join(tmpdir(), "titen-d1-stale-"));
@@ -262,7 +248,5 @@ test("a populated schema-v11 D1 database repairs collaboration integrity", async
 for (const contractCase of CASES) {
   const name = `cloudflare-d1: ${contractCase.name}`;
   const run = async () => contractCase.run(fixture);
-  if (contractCase.name === "committed memory survives a restart without a rebuild step")
-    test(name, run, 20_000);
-  else test(name, run);
+  test(name, run);
 }


### PR DESCRIPTION
## Summary

- pin matched Miniflare/workerd and Wrangler releases
- remove the retry that could hide a red D1 contract run
- run the bundled D1 contract under Node built-in test runner, while retaining Bun for Bun/SQLite contracts
- retain bounded raw response diagnostics for unexpected checkpoint statuses

## Evidence

- pre-fix locked runtime failed 2/5 full runs
- post-fix rebased source passed 5/5 full D1 runs (470/470) with no reruns
- `pnpm test:all`
- `bash scripts/verify-pack.sh`
- `pnpm audit --prod`
- workflow/self-test, diff, credential-pattern, and owned-workerd checks

GitHub Actions remain disabled; all gates were run manually.