### PR TITLE
docs: standardize website release handoff

### DIFF
--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -151,7 +151,8 @@ git tag -a "v$(node -p 'require("./package.json").version')" \
   -m "titen-memory $(node -p 'require("./package.json").version')"
 git push origin "v$(node -p 'require("./package.json").version')"
 gh release create "v$(node -p 'require("./package.json").version')" \
-  --title "…" --notes-file <(scripts/changelog-section.sh)
+  --title "titen-memory $(node -p 'require("./package.json").version')" \
+  --notes-file <(scripts/changelog-section.sh)
 ```
 
 `npm publish` is the right command even though the repo uses pnpm: `pnpm
@@ -165,11 +166,55 @@ the GitHub release body is generated from it by
 [`scripts/changelog-section.sh`](../../scripts/changelog-section.sh) so the two
 can never drift. Do not hand-write a release body.
 
+Keep each released changelog section easy to scan:
+
+1. begin with a one- or two-sentence summary when the release needs context;
+2. put `### Upgrade notes` first when an operator must migrate or reconfigure;
+3. use the applicable Keep a Changelog headings: `Added`, `Changed`,
+   `Deprecated`, `Removed`, `Fixed`, and `Security`;
+4. omit empty headings; and
+5. prefix every incompatible change with **`Breaking:`** and describe the
+   required migration in the same item.
+
+The generator adds the exact install command and links to the install guide,
+the matching titen.dev page, and the versioned npm package. These presentation
+lines are derived from the version; the release content still comes only from
+`CHANGELOG.md`.
+
 Every published version needs a `vN.N.N` tag and a GitHub release. The one
 exception on record is **0.1.0**, published from a staging tree before the
 packaging work was committed — no commit represents it, so it has no tag.
 Do not retrofit one onto a later commit; that would point the tag at code the
 release never contained.
+
+### Website handoff
+
+A stable release is not complete until its static discovery surface is live.
+After npm `latest`, the annotated tag, and the non-draft GitHub Release agree,
+update a clean `titen-web` branch:
+
+```bash
+pnpm release:sync <version>
+pnpm release:sync <version> --check
+pnpm build
+```
+
+`release:sync` reads the public GitHub Release, the package and Codex-plugin
+manifests at that exact tag, and npm `latest`. It writes a reviewable Markdown
+snapshot plus `src/data/release.json`; the website build itself remains offline
+and deterministic. If the plugin version did not change, its previous release
+date and notes link stay unchanged.
+
+Merge and deploy the reviewed `titen-web` change manually, then smoke
+`/version.json`, `/releases/<version>`, the homepage release badge, and both
+`titen.dev` hostnames. Do not announce the release as complete before those
+checks pass. If published notes need a correction, update `CHANGELOG.md`,
+replace the GitHub Release body with regenerated output, then sync and deploy
+the website again.
+
+This handoff does not use GitHub Actions, a webhook, a scheduled job, or a
+runtime GitHub API request. Roll back a bad website deployment to its previous
+Cloudflare Worker version; do not republish an unchanged npm release.
 
 ### Where published links live
 

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -25,4 +25,18 @@ if [ -z "$section" ]; then
   exit 1
 fi
 
+if [[ "$version" == *-* ]]; then
+  release_label="Prerelease"
+  dist_tag="next"
+else
+  release_label="Stable release"
+  dist_tag="latest"
+fi
+
+printf '> **%s** · npm `%s`\n\n' "$release_label" "$dist_tag"
+printf '```bash\nnpm install -g titen-memory@%s\n```\n\n' "$version"
+printf '[Install guide](https://titen.dev/docs/install) · '
+printf '[Release page](https://titen.dev/releases/%s) · ' "$version"
+printf '[npm package](https://www.npmjs.com/package/titen-memory/v/%s)\n\n' "$version"
+printf '%s\n\n' '---'
 printf '%s\n' "$section"


### PR DESCRIPTION
## Problem

GitHub Release notes already come from `CHANGELOG.md`, but the maintainer guide did not define a complete, drift-resistant handoff to the static release channel on titen.dev or a consistent presentation format.

## Solution

- Keep `CHANGELOG.md` as the only hand-written release-notes source.
- Add a compact generated install/link header to `scripts/changelog-section.sh`.
- Define the release-note heading and breaking-migration format.
- Require the manual `titen-web` sync, review, deploy, and production smoke before a stable release is declared complete.
- Keep GitHub Actions, webhooks, cron, databases, and runtime GitHub requests out of the release flow.

## Impact

- Runtime(s): docs and maintainer release tooling only
- Security or data migration: none
- API compatibility: compatible
- Release impact: none

## Changelog and README

- Changelog: not needed; contributor/release process only
- README: not needed; public product usage is unchanged
- Detailed docs: `docs/engineering/release.md`

## Workflow

- Classification: simple
- Spec: GitHub, npm, and titen.dev shall share one canonical release body and a documented manual handoff.
- Plan: format generated notes, document the web handoff, verify current 0.4.0 output and repository workflow checks.
- Terminal outcome: completed

## Verification

- `bash -n scripts/changelog-section.sh`
- Generated `0.4.0` output contains the stable channel, exact install command, titen.dev/npm links, and both changelog sections.
- `node scripts/check-workflow-docs.mjs`
- `node scripts/check-workflow-docs.mjs --self-test`
- `node scripts/check-ponytail-debt.mjs`
- `git diff --check`

## Checklist

- [x] Change is scoped to one logical concern.
- [x] Branch was based on current `origin/main` before final review.
- [x] Pull request title is a valid Conventional Commit squash subject.
- [x] The change followed `spec -> plan -> implement -> done` using the simple inline path.
- [x] Non-trivial behavior has a runnable verification.
- [x] Documentation matches the intended manual workflow.
- [x] Release impact is `none`; no package version or tag changed.
- [x] No credentials or private memory data are included.
- [x] Rollback is reverting this documentation/tooling commit.
