### PR TITLE
fix: stop the full-fit context contract from rotting on the calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+### Fixed
+
+- The full-fit context contract no longer pins an absolute as-of date, so it
+  stops passing or failing on the calendar. Shipped code is unchanged: the
+  fixture asked for context as of a date that had moved into the past, and
+  `valid_from <= at` correctly excluded the claims it had just written.
+
 ## [0.5.7] — 2026-08-02
 
 ### Documentation

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -685,7 +685,6 @@ export const CASES: Case[] = [
           subject_id: subject,
           task: "final pack metric marker",
           max_tokens: 4_000,
-          at: "2026-08-02T00:00:00.000Z",
         },
       });
       expectOk(compiled);
@@ -712,7 +711,6 @@ export const CASES: Case[] = [
           subject_id: subject,
           task: "final pack metric marker",
           max_tokens: 500,
-          at: "2026-08-02T00:00:00.000Z",
         },
       });
       expectOk(pressured);


### PR DESCRIPTION
## Problem

Closes #218. `POST /v1/context/compile` deterministically returned an empty pack in
the contract case *"a full-fit public context preserves rank and ideal final-pack
metrics"* — reported reproducing 5/5 on fresh containers against published
`titen-memory@0.5.7`.

The published runtime is not defective. The case seeds five claims at write time,
which the server stamps `valid_from = now` (`src/core/claims.ts:200`), then compiles
with a hard-coded `at: "2026-08-02T00:00:00.000Z"`. Both literals were authored on
2026-08-01 (`88935ba`, `8b20773`) — one day in the future then, two days in the past
now. The documented temporal predicate `AND c.valid_from <= ?`
(`src/core/retrieval.ts:140,186`; specified in `docs/reference/api.md:360-362`)
therefore excluded every claim the case had just written.

## Solution

Delete the two literals so compile defaults to the server instant, which is by
construction later than the seeds in the same process. Net diff: −2 lines, no
additions, nothing under `src/`.

Rejected alternatives: bumping to another fixed future date re-arms the same trap on
a timer; pinning `valid_from`/`valid_to` on all five seeds is equally rot-proof but
costs five fixture lines to buy window coverage the sibling *"historical context and
candidate bounds are explicit and fail closed"* case already owns. Clock injection in
the harness would be a new mechanism serving one test that no longer needs it.

## Impact

- Runtime(s): none — test fixture only, verified on both Bun/SQLite and Cloudflare/D1
- Security or data migration: none
- API compatibility: compatible; no observable behavior changes
- Release impact: **none**. `package.json#files` does not include `tests/`, so a
  successor to 0.5.7 would be byte-identical in runtime behavior.

## Changelog and README

- Changelog: updated under `Unreleased`, stating plainly that shipped code is unchanged
- README: not needed — no public usage change
- Detailed docs: not needed — `docs/reference/api.md` already specifies the `at` anchor
  behavior this case violated

## Workflow

- Classification: simple
- Spec: inline (this pull request and #218)
- Plan: inline
- Terminal outcome: completed

## Verification

Root cause was established empirically, not by reading, and independently challenged
on a second runtime before the edit.

Isolated mechanism probe, identical seed and task, only `at` varied (Bun/SQLite and
again on real workerd + local D1 via miniflare):

| `at` | candidates | items |
| --- | --- | --- |
| `2026-08-02` (the literal) | 0 | 0 |
| omitted (server now) | 5 | 5 |
| `2026-08-04` | 5 | 5 |

`candidates 0` proves exclusion happens inside the candidate query, upstream of
ranking, packing, and metrics. FTS, budget accounting, diversity packing, lifecycle
status, and authorization were each excluded by measurement.

After the fix:

```
pnpm test:api                 exit 0 — cloudflare-d1 110/110, bun 135/135
bun test tests/contract/bun-sqlite.test.ts -t 'full-fit'                  1 pass / 0 fail
node --test --test-name-pattern='full-fit' dist/test/cloudflare-d1.test.mjs  1 pass / 0 fail
20x fresh-process repetitions, Bun/SQLite lane      20/20 pass, 0 empty-pack failures
20x fresh-process repetitions, Cloudflare/D1 lane   20/20 pass, 0 empty-pack failures
pnpm check:workflow           workflow docs OK (76 artifacts), ponytail debt OK
```

Pack states remain distinguishable and truthful, confirmed by name on both lanes:
partial-fit (the `max_tokens: 500` compile in this same case — `budget_exhausted:
true` with omissions), all-too-large (*"a tiny budget drops whole items instead of
truncating them"*), genuinely empty (*"no eligible memory returns a successful empty
pack"* — `budget_exhausted: false`, `used_tokens: 0`), out-of-window (*"historical
context…"* — `items.length === 0` at `at: "2026-03-01"`), and semantic abstention
(bun enrichment contract). All green.

Remaining as-of literals after this change are lines 747 and 761, both inside the
historical case that pins `valid_from: "2026-01-01"` / `valid_to: "2026-02-01"`
alongside them — every absolute as-of left in the suite is paired with an absolute
validity window.

## Checklist

- [x] Change is scoped to one logical concern.
- [x] Branch was rebased onto current `origin/main` before final review.
- [x] Pull request title is a valid Conventional Commit squash subject.
- [x] The change followed `spec -> plan -> implement -> done`.
- [x] Complex work has paired EARS spec/plan artifacts under `done/` — n/a, simple.
- [x] Every acceptance ID has reproducible evidence and no plan item is left unchecked.
- [x] Non-trivial behavior has a regression or contract test — the repaired case is it.
- [x] Cross-scope authorization was considered — unchanged; authorization was excluded
      as a cause by measurement.
- [x] Documentation matches observable behavior.
- [x] Release impact is classified; this pull request does not bump the package or tag.
- [x] Notable user-facing work updates `CHANGELOG.md` under `Unreleased`.
- [x] `README.md` and `docs/README.md` are aligned — no public usage change.
- [x] No credentials or private memory data are included.
- [x] Rollback/compatibility impact is documented when relevant — none; test-only.
