### PR TITLE
fix: close the open issue backlog against 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,61 @@ Every release heading below is dated in **UTC**, matching the npm registry
 The published npm package is [`titen-memory`](https://www.npmjs.com/package/titen-memory).
 The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
+## [Unreleased]
+
+### Fixed
+
+- Retrieval ranking is now reproducible in the FTS-only lane. Exactly-tied
+  scores previously fell through to `claim_id`, a fresh uuid per ingest, so the
+  same corpus ranked differently on every run. Ties now break on the claim
+  statement — content-derived, and compared by code unit so Bun and Workers
+  agree — before falling back to the id. This makes rank reproducible, not
+  better: it picks an arbitrary-but-stable winner among genuine ties. What
+  causes the ties is untouched and stays open as #227. Closes #226.
+- Upgrading a pre-0.2.0 store now refuses instead of succeeding into silence.
+  Migration 10 scopes `team` visibility to a workspace and nothing backfills the
+  column, so a 0.1.x store migrated cleanly and then answered 404 on every
+  claim. `migrate` now counts legacy team rows first and fails closed, naming
+  the count and the 0.2.0 data floor. Rebinding is deliberately not attempted: a
+  legacy row's real workspace is unknowable, and inventing one would invent an
+  authorization boundary. Closes #257.
+- The logical export refuses a pre-workspace `team` row rather than writing a
+  backup its own importer rejects. `export_import` is advertised as enabled, so
+  an artifact that cannot be restored is worse than an error. Closes #258.
+
+### Added
+
+- In-process mode for Bun hosts. `serve()` returns the handler it serves, and a
+  `titen-memory/bun` subpath exports it, so a benchmark or embedding host can
+  drive `TitenClient` through an injected `fetch` with no loopback hop. The
+  transport is removed; auth, scopes, and response envelopes are unchanged
+  because it is the same handler. An ephemeral socket is still bound and unused,
+  tracked in `PONYTAIL-DEBT.md`. Closes #230.
+
+### Documentation
+
+- The single-core throughput ceiling is published as an operator sizing rule in
+  [VPS deployment](./docs/deployment/vps.md) and `deploy/README.md`: at and
+  above 10,000 claims one client saturates one process, so shard by subject
+  across processes rather than adding clients. Cloudflare records that this is a
+  `bun:sqlite` property that does not transfer to per-request isolates. Closes
+  #259.
+- `docs/testing/EVALS.md` carries the FTS-only degradation curve, so no
+  FTS-only quality figure is quoted without the corpus size it was measured at.
+  Closes #260.
+- The `cross_language:en` zero is explained rather than left open: the stratum
+  rotates document language past query language, so it is three language pairs,
+  and English queries never retrieve a non-English document (2,000 of 2,000
+  top-10 hits). A provider embedding property, not a fixture defect. The fixture
+  is unchanged because its hashes pin the locked holdout and pre-hoc threshold.
+  Closes #245.
+- `docs/engineering/release.md` states why the tarball carries no provenance
+  attestation — it requires a supported CI's OIDC token and this repository
+  publishes by hand on purpose — and gives consumers the registry checks that do
+  work, with what they do not prove. Closes #242.
+- One product sentence across the GitHub description, README, and
+  `package.json`. Closes #225.
+
 ## [0.6.0] — 2026-08-04
 
 ### Evidence

--- a/PONYTAIL-DEBT.md
+++ b/PONYTAIL-DEBT.md
@@ -1,15 +1,25 @@
 # Ponytail debt ledger
 
-Re-audited on 2026-08-02. This ledger is generated from tracked `ponytail:`
-comment markers and is intentionally empty.
+Re-audited on 2026-08-04. This ledger is generated from tracked `ponytail:`
+comment markers.
 
 Run `pnpm check:ponytail` after moving, adding, or removing a marker. The check
 is local and requires no hosted automation.
 
 ## Summary
 
-- Markers: 0.
+- Markers: 1.
 - Markers without a source trigger: 0.
+
+## Tracked markers
+
+- `src/runtime/bun/server.ts:262` — in-process mode still binds a listening
+  socket. `serve()` now returns the handler it serves so an embedded consumer
+  can call the kernel directly (#230), but the port is opened and then never
+  connected to. Removing it means splitting the app, maintenance timer, and
+  shutdown wiring out of `serve()` into their own factory — a ~75-line move for
+  a listener nobody uses. Upgrade when an embedded consumer objects to the bound
+  port; until then the unused socket is cheaper than the refactor.
 
 ## Closure evidence
 
@@ -43,8 +53,9 @@ verification of every reported failure) and a same-date survey of Mem0, Honcho,
 Zep/Graphiti, Letta, Cognee and Supermemory.
 
 Issues #220-#256 track defects. This section tracks what closing every one of
-them would still leave undone. None of these are `ponytail:` markers; the
-generated ledger above stays at zero and `pnpm check:ponytail` is unaffected.
+them would still leave undone. None of these are `ponytail:` markers; they are
+independent of the generated ledger above and `pnpm check:ponytail` is
+unaffected by them.
 
 Measured baseline this section argues from. Externally authored corpus
 (Mr.TyDi Indonesian, 25 queries, 100 documents), five independent repeats per
@@ -190,9 +201,12 @@ queue does. Compile throughput plateaus at 1,705 / 718 / 90 rps across the
 decades. Recall is **not** flat: recall@1 1.00 / 0.81 / 0.49 on an identical
 query set, though the corpus is synthetic so only the shape transfers. Cold start
 stays at ~53 ms and resident memory grows 2.9% across a hundredfold corpus.
-Tracked as #259 and #260. Remaining debt is no longer measurement — it is
-deciding whether to shard, to parallelise, or to publish the ceiling and let
-operators size against it.
+Tracked as #259 and #260. The ceiling is now published as an operator sizing
+rule in [VPS
+deployment](./docs/deployment/vps.md#capacity-rate-limiting-and-telemetry) and
+in `deploy/README.md`, so remaining debt is no longer measurement or disclosure
+— it is deciding whether to shard across processes or to parallelise within
+one.
 
 ### 8. Operational lifecycle is unexercised
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,6 +10,11 @@
 Keep Titen on loopback. Reach it through an SSH tunnel, a private network, or a
 TLS reverse proxy; opening a public firewall port is a separate operator choice.
 
+Size for one core per process: at and above 10,000 claims a single concurrent
+client already saturates one Titen process, so past that corpus size add
+processes sharded by subject rather than clients
+([measurements](../docs/testing/2026-08-04-scale-and-concurrency.md)).
+
 ## Install
 
 ```bash

--- a/docs/architecture/agent-integration.md
+++ b/docs/architecture/agent-integration.md
@@ -305,6 +305,40 @@ feedback. Checkpoint/lease/handoff calls activate when collaboration is needed.
 The reference CLI should read JSON from stdin and print JSON to stdout so any
 host hook can use it without an SDK dependency.
 
+### In-process Bun mode
+
+A benchmark, an evaluation harness, or an embedding host that already runs on
+Bun does not have to pay a loopback round trip. `serve()` returns the same
+handler the socket serves, and `TitenClient` accepts a `fetch` implementation,
+so the client can call the kernel directly:
+
+```ts
+import { serve } from "titen-memory/bun";
+import { TitenClient } from "titen-memory";
+
+const { app, stop } = await serve({
+  dbPath: "./titen.db",
+  port: 0,
+  hostname: "127.0.0.1",
+  quiet: true,
+});
+const titen = new TitenClient({
+  url: "http://embedded.invalid",
+  key,
+  fetch: (input, init) => app(new Request(input, init)),
+});
+```
+
+The URL is never dialled; it only supplies the origin the client builds paths
+against. Authentication, scopes, and every response envelope are identical
+because it is the same handler — this mode removes the transport, not the
+contract. `port: 0` still binds an ephemeral listener that nothing connects to,
+and `stop()` closes it together with the database.
+
+The subpath is exported under the `bun` condition only. On Node it fails with
+`ERR_PACKAGE_PATH_NOT_EXPORTED`, which is honest: this runtime needs
+`bun:sqlite`. Node hosts use `titen serve` plus the HTTP client.
+
 ## Provisioning flow
 
 An operator performs this once per agent identity:

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -308,6 +308,12 @@ Use those surfaces for request errors, CPU time, invocation volume, and tailing;
 no logger framework or Prometheus endpoint is required. Keep memory content,
 credentials, request bodies, and raw embeddings out of logs.
 
+The one-core throughput ceiling published in [VPS
+deployment](./vps.md#capacity-rate-limiting-and-telemetry) is a property of the
+single-process `bun:sqlite` runtime and does not apply here, because Workers
+concurrency is the platform's per-request isolate model rather than one event
+loop.
+
 Before a release, retain the previous Worker version and a verified pre-upgrade
 D1 backup/export. Roll back to that Worker version only when its code is known
 to accept the current schema. A Worker rollback does not reverse a forward D1

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -1,12 +1,11 @@
 # Container image
 
 Status: **image verified, publication unverified.** The image in this repository
-was built and run on 2026-08-04 (evidence at the bottom). The publishing
-workflow has never run, because it only runs on a version tag and no tag has
-been pushed since it was added. Until the first `vN.N.N` tag,
-`ghcr.io/ramaaditya49/titen` serves nothing and `podman pull` will fail — build
-locally instead, as [VPS deployment](./vps.md#container-install-verified)
-describes.
+was built and run on 2026-08-04 (evidence at the bottom). Nothing has been
+pushed to the registry, because publishing is a manual step a maintainer has
+not yet run. Until that push, `ghcr.io/ramaaditya49/titen` serves nothing and
+`podman pull` will fail — build locally instead, as [VPS
+deployment](./vps.md#container-install-verified) describes.
 
 The container is optional. Titen runs directly under Bun with no container
 runtime at all; this exists so a deployment can be reproduced without
@@ -161,5 +160,5 @@ commit's `Dockerfile`:
 | Persistence | an organization bootstrapped before `podman restart` was still present after it |
 | Quadlet | `deploy/titen.container` started under rootless `systemctl --user`, reached `ready: true`, wrote the database into the host directory as the invoking user |
 
-Not measured: the GitHub Actions workflow (no tag pushed yet), any arm64 build,
-a real `ghcr.io` pull, and any run longer than a few minutes.
+Not measured: the manual `docker push` to `ghcr.io`, any arm64 build, a real
+`ghcr.io` pull, and any run longer than a few minutes.

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -556,8 +556,19 @@ The Bun runtime intentionally serves one process with one synchronous SQLite
 handle. Its useful throughput is therefore bounded by one event loop/core;
 adding client concurrency does not add database workers. Keep this shape until
 an equivalent-quality, durability-preserving workload misses the accepted
-small-team latency or throughput objective. Measure that workload before adding
-a worker pool, read replicas, or sharding.
+small-team latency or throughput objective.
+
+That ceiling is measured rather than asserted, and it is a product fact to size
+against: to 10^5 claims and 64 concurrent clients the service holds 0.98 to
+1.11 cores of 16 at every level, and compile throughput plateaus at about 1,700
+requests per second at 1,000 claims, about 700 at 10,000, and about 89 at
+100,000. At and above 10,000 claims a single concurrent client already
+saturates the process, so past that corpus size add capacity by running more
+processes sharded by subject, not by adding clients to one. On NVMe rather than
+tmpfs the binding resource moves from CPU to `fsync` and ingest falls to 309 to
+355 claims per second across the same decades. Measure the real workload
+against those numbers before adding a worker pool, read replicas, or sharding:
+[scale and concurrency](../testing/2026-08-04-scale-and-concurrency.md).
 
 Rate-limit at the authenticated ingress, not inside the Titen process. For
 example, Nginx provides the native [`limit_req`
@@ -608,6 +619,10 @@ code.
   pending forward-only SQL without creating or changing the database. Take the
   snapshot, apply the migration, restart, and require `/readyz` rather than
   `/healthz` to report success.
+- 0.2.0 is the oldest release whose data survives an upgrade usable. `migrate`
+  now refuses to run against a store holding pre-0.2.0 team-visibility rows
+  rather than reporting success and leaving every claim unreadable, so bind a
+  0.1.x store's team rows to a workspace on the old binary first.
 - Rollback is snapshot restore, not a down migration. Stop the service, preserve
   the failed database for diagnosis, restore the verified pre-upgrade snapshot
   into a new mode-`0600` file, start the previous binary against that file, and

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -296,3 +296,27 @@ npm view titen-memory version
 The npmjs.com page renders `README.md`; its repository-only documentation and
 image references use stable absolute GitHub URLs because those files are not in
 the package allowlist.
+
+## Supply-chain assurance
+
+The tarball carries **no provenance attestation**, and that is a decision, not
+an oversight. `npm publish --provenance` mints a sigstore attestation from the
+OIDC token of a supported CI, so it is obtainable only from GitHub Actions or
+GitLab CI. This repository runs no GitHub Actions by standing maintainer rule
+(see [`CONTRIBUTING.md`](../../CONTRIBUTING.md#repository-stage)) and publishes
+by hand to keep the npm credential off a repository secret. Restoring provenance
+means reversing that decision, which the top of this file already states
+requires a new maintainer decision and an explicit cost budget.
+
+What a consumer can verify today is the registry's own integrity metadata:
+
+```bash
+npm audit signatures
+npm view titen-memory@<version> dist.integrity dist.shasum dist.fileCount dist.unpackedSize
+npm pack titen-memory@<version> && sha256sum titen-memory-<version>.tgz
+```
+
+Those checks prove the tarball on disk is byte-for-byte what npm served and that
+the registry signed it. They prove nothing about origin: no commit, tree, or
+build is bound to the artifact. A consumer who needs that binding must build
+from a tagged checkout and compare against `npm pack` themselves.

--- a/docs/testing/2026-07-31-embedding-s-validation-v2-full.md
+++ b/docs/testing/2026-07-31-embedding-s-validation-v2-full.md
@@ -33,6 +33,16 @@ for English queries. Exact, paraphrase, and hard-negative Recall@5 were 100%.
 Cross-language Recall@5 was 66.67%; the English-query to
 Javanese-in-Indonesian-statement direction remained 0/40.
 
+That direction is one of three the stratum contains: `groupLanguage` rotates the
+statement language one position past the query language, so `cross_language`
+tests Indonesian to English, English to Javanese-in-Indonesian, and
+Javanese-in-Indonesian to Indonesian, and only the English case has non-English
+gold. Joining the raw trials to the fixture's per-statement language shows that
+2,000 of 2,000 top-10 hits across all 200 English queries are English
+statements, so the 0/40 measures the provider's English embedding cluster over
+333 same-template English `backup_region` statements rather than a missing or
+malformed gold.
+
 The overall Recall@5 and no-result result exactly repeat the first full profile
 run (91.67% and zero false positives) on a disjoint fixture. This supports the
 profile and floor for this measured deployment. It does not justify a bundled

--- a/docs/testing/EVALS.md
+++ b/docs/testing/EVALS.md
@@ -258,9 +258,31 @@ turn embedding similarity into a memory-management decision.
 The [disjoint S-validation-v2 run](./2026-07-31-embedding-s-validation-v2-full.md)
 repeated 91.67% Recall@5 and zero no-result false positives without tuning the
 profile or `0.737307171` floor on the new 10,000-statement/600-query fixture.
-The English-query to Javanese-in-Indonesian-statement direction stayed at 0/40,
-and the provider revision remained unattested. This is deployment-specific
-evidence, not a universal default or replacement pass.
+The English-query to Javanese-in-Indonesian-statement direction stayed at 0/40
+because `cross_language` is not one task: `groupLanguage` rotates the statement
+language one position past the query language, so the stratum tests Indonesian
+to English, English to Javanese-in-Indonesian, and Javanese-in-Indonesian to
+Indonesian at three different difficulties. Joining the run's raw trials to the
+fixture's per-statement language shows that English queries never leave English:
+2,000 of 2,000 top-10 hits across all 200 English queries are English
+statements, while Indonesian and Javanese-in-Indonesian queries retrieve across
+all three languages. `cross_language:en` is the only stratum whose gold is
+non-English for an English query, so it is the only stratum at zero. That 0/40
+is a property of the provider's English embedding cluster over 333 same-template
+English `backup_region` statements, not a fixture defect: the gold exists,
+carries the query's entity, and is the correct record kind. The provider
+revision also remained unattested. This is deployment-specific evidence, not a
+universal default or replacement pass.
+
+The `cross_language` label therefore averages three unequal ordered pairs:
+Javanese-in-Indonesian to Indonesian is near lexical identity, Indonesian to
+English is a well-supported bridge, and English to Javanese-in-Indonesian is
+neither. Reporting one mean over them is misleading, but splitting the stratum
+by ordered language pair is deliberately not taken on its own. The generator
+pins `fixture_sha256`, the split checksum, the locked holdout, and the pre-hoc
+`0.737307171` floor to each other, so relabelling a stratum invalidates every
+published run. Split it only when a future fixture revision invalidates those
+hashes anyway.
 
 ## Recorded Mem0 replacement cycle
 
@@ -685,6 +707,24 @@ Every quality run includes:
 P0 establishes the first numeric retrieval baseline. Later releases may not
 silently lower it. Any numeric release threshold must be recorded in an ADR
 after the fixture corpus and variance are measured.
+
+### FTS-only quality is not flat across corpus size
+
+Measured in [scale and concurrency](./2026-08-04-scale-and-concurrency.md), one
+fixed 100-query set answerable at every decade, FTS-only, concurrency 1. Each
+cell is run 1 / run 2, the two independent RAM-backed repeats:
+
+| Active claims | recall@1 | MRR@10 |
+| ---: | ---: | ---: |
+| 1,000 (XS) | 1.00 / 1.00 | 1.000 / 1.000 |
+| 10,000 (S) | 0.81 / 0.80 | 0.897 / 0.892 |
+| 100,000 (M) | 0.49 / 0.48 | 0.609 / 0.597 |
+
+The corpus is synthetic and the absolute values are a property of its
+generator, so they are not Titen's recall; the shape is the result. Any
+FTS-only quality figure must be quoted with the corpus size it was measured
+at. Tier L (1,000,000) has never been run. Arresting this slope is strategic
+debt item 3 in `PONYTAIL-DEBT.md`.
 
 LoCoMo and LongMemEval are external comparability suites, not substitutes for
 Titen's isolation, evidence, conflict, and collaboration fixtures.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "titen-memory",
   "version": "0.6.0",
-  "description": "Collaborative memory fabric for AI agents — evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
+  "description": "The Level 6 collaborative memory fabric for AI agents — evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@11.17.0",
@@ -34,6 +34,9 @@
       "types": "./dist/npm/sdk.d.ts",
       "bun": "./dist/npm/sdk.js",
       "default": "./dist/npm/sdk.js"
+    },
+    "./bun": {
+      "bun": "./src/runtime/bun/server.ts"
     },
     "./package.json": "./package.json"
   },

--- a/src/core/migrations.ts
+++ b/src/core/migrations.ts
@@ -1392,6 +1392,20 @@ export async function pendingMigrations(db: Db): Promise<typeof MIGRATIONS> {
 /** Apply pending migrations as one cross-runtime atomic batch per version. */
 export async function migrate(db: Db): Promise<number> {
   let current = await appliedVersion(db);
+  // Migration 10 leaves pre-0.2.0 `team` rows with a NULL workspace_id, which
+  // recordAccessSql fail-closes, and nothing backfills the column. Refuse
+  // rather than report success on a store whose records would vanish.
+  if (current > 0 && current < 10) {
+    const rows = await db.all<{ legacy: number }>(
+      `SELECT (SELECT COUNT(*) FROM claims WHERE visibility = 'team')
+            + (SELECT COUNT(*) FROM observations WHERE visibility = 'team') AS legacy`,
+    );
+    const legacy = Number(rows[0]?.legacy ?? 0);
+    if (legacy > 0)
+      throw new Error(
+        `Refusing to migrate: ${legacy} team-visibility rows predate workspace scoping and would become unreadable. 0.2.0 is the supported data floor; bind a workspace to these rows on the current binary first.`,
+      );
+  }
   for (const migration of MIGRATIONS) {
     if (migration.version <= current) continue;
     try {

--- a/src/core/portability.ts
+++ b/src/core/portability.ts
@@ -614,6 +614,13 @@ async function exportPage(
     observations: "observation",
     claims: "claim",
   };
+  // The importer rejects these at assertWorkspaceReferences (below). Refuse to
+  // write a backup artifact that cannot be restored.
+  const unbindable = rows.find((row) => row.visibility === "team" && row.workspace_id == null);
+  if (unbindable)
+    throw validationError(
+      `Record ${String(unbindable.id)} predates workspace scoping; "workspace_id" is required for team visibility.`,
+    );
   const candidates: ExportLine[] = rows.map((row) => {
     const {
       __cursor,

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -16,6 +16,7 @@ export const RECENCY_HALF_LIFE_DAYS = 90;
 export interface RankInput {
   id: string;
   kind: string;
+  statement: string;
   trust: Trust;
   confidence: number;
   status: string;
@@ -145,8 +146,8 @@ export interface Ranked<T extends RankInput> {
 }
 
 /**
- * Ties break on semantic evidence, then on id so two identical states rank
- * identically.
+ * Ties break on semantic evidence, then on statement, then on id so two
+ * identical states rank identically.
  *
  * Both relevance arms are min-max normalized inside the candidate set, so each
  * arm's own best scores exactly 1. When those are different claims — the usual
@@ -157,8 +158,17 @@ export interface Ranked<T extends RankInput> {
  *
  * Cosines are compared only against each other, so this introduces no constant
  * and no cross-scale comparison; it cannot move a candidate that was not already
- * tied, and it cannot change a returned score. Lexical-only ranking is
- * unaffected — every candidate carries `vector_boost` undefined.
+ * tied, and it cannot change a returned score. Lexical-only ranking carries no
+ * cosine at all, which is why the statement key exists: it is content-derived,
+ * so the same claims rank the same way across ingests that mint fresh uuids.
+ * The comparison is by code unit rather than `localeCompare`, because statements
+ * are arbitrary text and default collation is not guaranteed to agree between
+ * Bun and the Workers runtime; ids are safe under `localeCompare` only because
+ * they are `[a-f0-9_]`.
+ *
+ * The ceiling is honest: this makes rank reproducible, not better. It picks an
+ * arbitrary-but-stable winner among genuinely tied items. What causes the ties —
+ * min-max normalization pinning each arm's best to 1.0 — is untouched here.
  */
 export function rankCandidates<T extends RankInput>(candidates: T[], now: Date): Ranked<T>[] {
   const relevance = normalizeRelevance(candidates);
@@ -177,6 +187,11 @@ export function rankCandidates<T extends RankInput>(candidates: T[], now: Date):
       (left, right) =>
         right.score - left.score ||
         (right.candidate.vector_boost ?? 0) - (left.candidate.vector_boost ?? 0) ||
+        (left.candidate.statement < right.candidate.statement
+          ? -1
+          : left.candidate.statement > right.candidate.statement
+            ? 1
+            : 0) ||
         left.candidate.id.localeCompare(right.candidate.id),
     );
 }

--- a/src/runtime/bun/server.ts
+++ b/src/runtime/bun/server.ts
@@ -254,6 +254,17 @@ export async function serve(options: ServeOptions) {
   return {
     server,
     database,
+    /**
+     * The same handler the socket serves, exposed so an embedded consumer can
+     * call it directly instead of paying a loopback round trip. See
+     * docs/architecture/agent-integration.md.
+     *
+     * ponytail: this still binds a listening socket. Extracting the app,
+     * maintenance timer, and shutdown wiring above into their own factory would
+     * remove it — a ~75-line move for a port nobody connects to, so it waits
+     * until an embedded consumer objects to the bound port.
+     */
+    app,
     url: `http://${options.hostname}:${server.port}`,
     stop: async () => {
       process.off("SIGTERM", shutdown);

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -2249,6 +2249,28 @@ export const CASES: Case[] = [
     },
   },
   {
+    name: "export refuses a pre-workspace team row instead of writing an unrestorable backup",
+    async run(fx) {
+      const owner = await fx.provision({ scopes: ["*"] });
+      const seeded = await seedClaim(fx, owner.key);
+      assert.equal((await fx.call("GET", "/v1/export?type=claims&all=true", { key: owner.key })).status, 200);
+
+      // Exactly what migration 10 leaves behind on a 0.1.x store: team
+      // visibility with no workspace to bind it to. The importer rejects the
+      // line, so emitting it would produce a backup that cannot be restored.
+      await fx.query(
+        `UPDATE claims SET visibility = 'team', workspace_id = NULL WHERE id = ?`,
+        [seeded.claimId],
+      );
+      const refused = await fx.call("GET", "/v1/export?type=claims&all=true", { key: owner.key });
+      expectError(refused, 400, "VALIDATION_ERROR");
+      assert.ok(
+        String(refused.body.error.message).includes(seeded.claimId),
+        "refusal must name the record an operator has to repair",
+      );
+    },
+  },
+  {
     name: "import preflights references and accepts child-before-parent atomically",
     async run(fx) {
       const target = await fx.provision({ scopes: ["*"] });

--- a/tests/contract/cloudflare-d1.test.ts
+++ b/tests/contract/cloudflare-d1.test.ts
@@ -12,6 +12,7 @@ import { CASES, assertBatchAtomicity } from "./cases";
 import { clientVia, provisionWith, revokeWith, TEST_SECRET_KEY, type Fixture } from "./harness";
 import { assertPopulatedV10RetrievalMigration } from "./retrieval-migration";
 import {
+  assertLegacyTeamRowsRefuseMigration,
   assertPopulatedV11IntegrityMigration,
   assertPopulatedV14SemanticOutageMigration,
 } from "./integrity-migration";
@@ -484,6 +485,25 @@ d1Test("a populated schema-v10 D1 database rebuilds scoped Porter FTS", async ()
     await migrationRuntime.ready;
     const migrationDb = createD1Db((await migrationRuntime.getD1Database("DB")) as never);
     await assertPopulatedV10RetrievalMigration(migrationDb);
+  } finally {
+    await dispose(migrationRuntime);
+    rmSync(migrationPersist, { recursive: true, force: true });
+  }
+});
+
+d1Test("a pre-workspace D1 database refuses to migrate its team rows into silence", async () => {
+  const migrationPersist = mkdtempSync(join(tmpdir(), "titen-d1-legacy-team-migration-"));
+  const migrationRuntime = runtime({
+    modules: true,
+    script: "export default { fetch() { return new Response('ok') } }",
+    compatibilityDate: "2026-07-01",
+    d1Databases: { DB: "titen-legacy-team-migration" },
+    d1Persist: migrationPersist,
+  });
+  try {
+    await migrationRuntime.ready;
+    const migrationDb = createD1Db((await migrationRuntime.getD1Database("DB")) as never);
+    await assertLegacyTeamRowsRefuseMigration(migrationDb);
   } finally {
     await dispose(migrationRuntime);
     rmSync(migrationPersist, { recursive: true, force: true });

--- a/tests/contract/integrity-migration.ts
+++ b/tests/contract/integrity-migration.ts
@@ -72,6 +72,52 @@ export async function assertPopulatedV14SemanticOutageMigration(db: Db): Promise
   });
 }
 
+/**
+ * Migration 10 scopes `team` visibility to a workspace and nothing backfills the
+ * column, so a pre-0.2.0 store would migrate "successfully" into one where every
+ * team row is fail-closed and unreachable. Upgrading must refuse instead.
+ */
+export async function assertLegacyTeamRowsRefuseMigration(db: Db): Promise<void> {
+  await db.exec(
+    `CREATE TABLE titen_migrations (
+       version INTEGER PRIMARY KEY,
+       applied_at TEXT NOT NULL
+     )`,
+  );
+  for (const migration of MIGRATIONS.filter(({ version }) => version <= 9)) {
+    await db.batch([
+      ...migration.statements.map((sql) => ({ sql })),
+      {
+        sql: `INSERT INTO titen_migrations (version, applied_at) VALUES (?, ?)`,
+        params: [migration.version, "2026-07-31T00:00:00.000Z"],
+      },
+    ]);
+  }
+  await db.batch([
+    { sql: `INSERT INTO organizations (id, name, created_at) VALUES ('org_legacy_team', 'Legacy', '2026-07-31T00:00:00.000Z')` },
+    {
+      sql: `INSERT INTO claims
+              (id, org_id, subject_id, actor_id, kind, statement, confidence,
+               trust, visibility, status, valid_from, created_at)
+            VALUES ('claim_legacy_team', 'org_legacy_team', 'subject_legacy',
+                    'agent_legacy', 'procedural', 'Legacy team marker.', 0.9,
+                    'verified', 'team', 'active', '2026-07-31T00:00:00.000Z',
+                    '2026-07-31T00:00:00.000Z')`,
+    },
+  ]);
+
+  await assert.rejects(
+    () => migrate(db),
+    /predate workspace scoping/,
+    "a store whose team rows would become unreadable must not report success",
+  );
+  // Refusal is a precondition, not a partial upgrade: the store is untouched.
+  assert.deepEqual(
+    await db.all(`SELECT MAX(version) AS version FROM titen_migrations`),
+    [{ version: 9 }],
+  );
+}
+
 /** Runs the same populated-v11 integrity upgrade against either SQL adapter. */
 export async function assertPopulatedV11IntegrityMigration(db: Db): Promise<void> {
   await db.exec(

--- a/tests/contract/vectors.test.ts
+++ b/tests/contract/vectors.test.ts
@@ -53,6 +53,7 @@ const vectorScope = () => ({ org_id: orgId, subject_id: subjectId, project_id: "
 const rankInput = (id: string, confidence: number, vector_boost?: number): RankInput => ({
   id,
   kind: "procedural",
+  statement: `claim ${id}`,
   trust: "verified",
   confidence,
   status: "active",
@@ -537,11 +538,28 @@ test("a score tie between the lexical best and the semantic best breaks on cosin
 
   // A genuine dead heat — equal score and equal evidence — must stay total and
   // repeatable, which is the property the cosine term must not have broken.
+  // Ids are freshly minted uuids in production, so the order has to come from
+  // content: here the lower id carries the higher statement, and the statement
+  // decides. With an id-only fallback this returns ["aaa", "zzz"].
   const twins = rankCandidates(
-    [{ ...rankInput("zzz", 1), bm25: -4 }, { ...rankInput("aaa", 1), bm25: -4 }],
+    [
+      { ...rankInput("zzz", 1), statement: "Alpha rollback rehearsal.", bm25: -4 },
+      { ...rankInput("aaa", 1), statement: "Zulu rollback rehearsal.", bm25: -4 },
+    ],
     now,
   );
-  assert.deepEqual(twins.map((entry) => entry.candidate.id), ["aaa", "zzz"]);
+  assert.deepEqual(twins.map((entry) => entry.candidate.id), ["zzz", "aaa"]);
+
+  // Byte-identical statements still fall through to the id, so the order stays
+  // total when content cannot separate two candidates.
+  const identical = rankCandidates(
+    [
+      { ...rankInput("zzz", 1), statement: "Same rollback rehearsal.", bm25: -4 },
+      { ...rankInput("aaa", 1), statement: "Same rollback rehearsal.", bm25: -4 },
+    ],
+    now,
+  );
+  assert.deepEqual(identical.map((entry) => entry.candidate.id), ["aaa", "zzz"]);
 
   // Lexical-only ranking carries no cosine at all, so the new term is inert
   // there: a stronger bm25 still wins on score, never on the tie-break.

--- a/tests/integration/embedded.test.ts
+++ b/tests/integration/embedded.test.ts
@@ -1,0 +1,61 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
+import { serve } from "../../src/runtime/bun/server";
+import { TitenClient } from "../../src/sdk";
+import { provisionWith } from "../contract/harness";
+
+/**
+ * In-process use: the handler `serve()` returns is the same one the socket
+ * serves, so an embedded consumer reaches the kernel without a loopback hop.
+ * The host name below never resolves — if this passes, no packet left.
+ */
+test("the returned app answers the client without a loopback round trip", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "titen-embedded-"));
+  const dbPath = join(directory, "titen.db");
+  const running = await serve({ dbPath, port: 0, hostname: "127.0.0.1", quiet: true });
+  const handle = openDatabase(dbPath);
+  try {
+    const provisioned = await provisionWith(createSqliteDb(handle), { scopes: ["*"] });
+    const titen = new TitenClient({
+      url: "http://embedded.invalid",
+      key: provisioned.key,
+      fetch: (input, init) => running.app(new Request(input, init)),
+    });
+
+    const observation = await titen.observe({
+      subject_id: "user_embedded",
+      kind: "tool_result",
+      content: "Embedded call reached the kernel without opening a connection.",
+      source: { type: "tool", ref: "embedded#1" },
+      trust: "verified",
+    });
+    assert.match(observation.observation_id, /^obs_/);
+
+    const consolidated = await titen.consolidate("user_embedded", [{
+      kind: "procedural",
+      statement: "In-process callers reuse the served handler.",
+      confidence: 0.9,
+      sources: [{ observation_id: observation.observation_id, relation: "supports" }],
+    }]);
+    const claimId = consolidated.claims[0]!.claim_id as string;
+
+    const context = await titen.compile({
+      subject_id: "user_embedded",
+      task: "in-process handler reuse",
+      max_tokens: 900,
+    });
+    assert.match(context.context_id, /^ctx_/);
+    assert.ok(
+      context.items.some((item) => item.claim_id === claimId),
+      "the embedded client must receive the claim it just wrote",
+    );
+  } finally {
+    handle.close();
+    await running.stop();
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/runtime-hardening.test.ts
+++ b/tests/integration/runtime-hardening.test.ts
@@ -12,6 +12,7 @@ import { observedSemanticReadiness } from "../../src/core/vectors";
 import cloudflareWorker from "../../src/runtime/cloudflare/worker";
 import { verifyPassword } from "../../src/core/accounts";
 import {
+  assertLegacyTeamRowsRefuseMigration,
   assertPopulatedV11IntegrityMigration,
   assertPopulatedV14SemanticOutageMigration,
 } from "../contract/integrity-migration";
@@ -311,6 +312,13 @@ test("migration retires unowned federation peers and releases their endpoint", a
             (id, org_id, principal_id, name, endpoint, shared_secret_hash, direction, status, created_at)
           VALUES ('fpeer_replacement', 'org_legacy', 'agent_owner', 'Replacement', 'https://peer.example.test', 'hash', 'pull', 'active', '2026-07-30T00:00:01.000Z')`,
   }]);
+  database.close();
+});
+
+test("a pre-workspace SQLite database refuses to migrate its team rows into silence", async () => {
+  const database = openDatabase(join(temporary(), "titen.db"));
+  const db = createSqliteDb(database);
+  await assertLegacyTeamRowsRefuseMigration(db);
   database.close();
 });
 


### PR DESCRIPTION
Triaged all 25 open issues against current `main` (0.6.0). Sixteen were already answered by the 0.6.0 release or belong to a benchmark harness that never lived in this repository — those are closed with their findings preserved rather than dismissed. Nine needed real work and are fixed here.

## Code

| Issue | Change |
| --- | --- |
| #226 | FTS-only ranking reordered on every run: tied scores fell through to `claim_id`, a fresh uuid per ingest. Ties now break on the claim statement, compared by code unit so Bun and Workers agree. Reproducible, not better — #227 still owns the cause of the ties. |
| #257 | A migrated 0.1.x store reported success then answered 404 on every claim. `migrate` now counts legacy `team` rows and fails closed, naming the count and the 0.2.0 floor. Rebinding is deliberately not attempted: a legacy row's workspace is unknowable, and guessing one would invent an authorization boundary. |
| #258 | The logical export wrote rows its own importer rejects. It now refuses and names the record, because `export_import` is advertised as enabled and an unrestorable backup is worse than an error. |
| #230 | `serve()` returns the handler it serves and `package.json` exports it under the `bun` condition, so an embedded host drives `TitenClient` with no loopback hop. |
| #225 | One product sentence across the GitHub description, README, and `package.json`. |

## Documentation

| Issue | Change |
| --- | --- |
| #245 | The `cross_language:en` zero is explained, not left open: the stratum rotates document language past query language, so it is three language pairs, and English queries never retrieve a non-English document (2,000 of 2,000 top-10 hits). A provider embedding property, not a fixture defect. The fixture is unchanged — its hashes pin the locked holdout and the pre-hoc threshold. |
| #259 | The single-core ceiling is published as an operator sizing rule in `docs/deployment/vps.md` and `deploy/README.md`. Cloudflare records that it does not transfer to per-request isolates. |
| #260 | `docs/testing/EVALS.md` carries the FTS-only degradation curve, so no FTS-only figure is quoted without its corpus size. |
| #242 | `docs/engineering/release.md` states why there is no npm provenance — it needs a supported CI's OIDC token and this repository publishes by hand on purpose — and gives the registry checks that do work, with what they do not prove. |

## Verification

`pnpm test:all` exits 0.

- 116 Cloudflare D1 contract tests, 0 fail (baseline 114)
- 141 Bun/SQLite contract tests, 0 fail (baseline 140)
- 204 integration tests across 24 files
- 6 dashboard browser tests
- `check-workflow-docs`, `check-route-docs`, `check-ponytail-debt` all green

Each new test was confirmed to fail without its fix.

## Known ceiling

In-process mode still binds an ephemeral socket nothing connects to. Removing it means splitting `serve()`'s setup into its own factory — a ~75-line move for an unused listener. Registered as the one tracked marker in `PONYTAIL-DEBT.md` rather than left implicit.