### PR TITLE
fix: pin undici past the five open advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: 7.29.0
+
 importers:
 
   .:
@@ -1584,8 +1587,8 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2908,7 +2911,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -3217,7 +3220,7 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,12 @@
 packages:
   - "."
 
+# miniflare pins undici at exactly 7.28.0, so no upstream bump clears
+# GHSA-4cwx-7wf7-3272 and its four siblings. 7.29.0 is the advised patch and the
+# last 7.x. Drop this once miniflare ships a dependency past it.
+overrides:
+  undici: "7.29.0"
+
 allowBuilds:
   esbuild: true
   workerd: true


### PR DESCRIPTION
All five open Dependabot alerts are the same package: `undici@7.28.0`, reached only through `miniflare` and `wrangler` — both devDependencies. It never enters a consumer install (`files` ships no `node_modules`), but it does run on a maintainer machine during the D1 gate and the worker build, so it is worth clearing rather than dismissing.

## Why an override rather than an upgrade

No upstream bump clears it:

- `miniflare` pins `undici: "7.28.0"` — an exact version, not a range.
- The newest `miniflare` on the registry is `4.20260730.0`, which is the version already in use here.
- The only `wrangler` ahead of ours (`4.118.0`) depends on `miniflare@5.20260730.0-alpha`.

Jumping the test toolchain to a miniflare 5 alpha to satisfy a devDependency advisory is a worse trade than pinning the transitive dep. So this is a pnpm override to `7.29.0` — the version the advisories themselves name as the fix, and the last 7.x, making it a single patch bump against a pinned dependency rather than a major jump to 8.x.

The override lives in `pnpm-workspace.yaml`, not `package.json`. pnpm 11 no longer reads a `pnpm.overrides` field and ignores it with only a warning — worth knowing, because putting it in the obvious place looks like it works and does not.

It carries a comment naming the removal condition, so it gets dropped when miniflare ships a dependency past it instead of outliving its reason.

## Covered

| Advisory | Severity |
| --- | --- |
| GHSA-4cwx-7wf7-3272 | high |
| GHSA-8xcm-r25x-g524 | moderate |
| GHSA-v3r7-h72x-cjcm | moderate |
| GHSA-jr45-8vmc-qm54 | moderate |
| GHSA-m8rv-5g2x-5cg5 | moderate |

## Verification

`pnpm why undici` resolves to `7.29.0`.

`pnpm test:all` exits 0 with the bump in place — 116 Cloudflare D1 contract tests, 141 Bun/SQLite contract tests, 204 integration, 6 dashboard, all doc and ledger checks green. Identical to the totals before the bump, which is the point: miniflare and workerd drive the D1 lane, so that suite is the real check on whether the override disturbs anything.

`package.json` is unchanged, so the published tarball is unaffected.