### PR TITLE
fix: stop webhooks losing same-millisecond events; record what the field measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ### Fixed
 
+- Webhooks no longer silently drop events written in their own registration
+  millisecond. Eligibility compared `w.created_at < e.created_at`, a strict
+  comparison on a millisecond wall-clock string, so on a fast host the
+  registration and the next write shared a millisecond and those events were
+  never queued, never delivered, and never retried. Delivery now pages on the
+  `event_order.seq` watermark that `/v1/events` and federation already use:
+  migration 22 adds `webhooks.created_seq`, backfilled to the current head so an
+  upgrade delivers only future events rather than replaying history. Both
+  eligibility sites are converted — `processWebhooks` and the background
+  `deliverPending` selector — because the second one would otherwise leave an
+  organization unwoken until another event arrived. Measured on a 16-core host:
+  the contract file went from 8 of 12 runs failing to 12 of 12 passing.
+  Closes #265.
+
 - Retrieval ranking is now reproducible in the FTS-only lane. Exactly-tied
   scores previously fell through to `claim_id`, a fresh uuid per ingest, so the
   same corpus ranked differently on every run. Ties now break on the claim
@@ -46,6 +60,17 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
   backup its own importer rejects. `export_import` is advertised as enabled, so
   an artifact that cannot be restored is worse than an error. Closes #258.
 
+### Measured, not built
+
+- The reranking stage recorded as strategic debt was measured before being
+  written, and the measurement says do not write it. The oracle ceiling over
+  Titen's own top-10 is +10.2 points (recall@1 0.880 to 0.982), but every cheap
+  reranking signal tested captured at most 0.6 of those points at p=0.61, and
+  two were significantly *worse* than no reranking at all. MemPalace, which
+  ships one, scored lower with it than without it in both embedding
+  configurations. The gain is real and lexical signals cannot reach it.
+  Closes #269.
+
 ### Added
 
 - In-process mode for Bun hosts. `serve()` returns the handler it serves, and a
@@ -56,6 +81,15 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
   tracked in `PONYTAIL-DEBT.md`. Closes #230.
 
 ### Documentation
+
+- Measured the memory-agent field on an externally authored corpus
+  (LongMemEval-S, MIT) and recorded where Titen actually stands:
+  [landscape note](./docs/research/2026-08-04-memory-agent-landscape.md).
+  `docs/testing/EVALS.md` now marks recall@5/@10 as saturated on that corpus so
+  only recall@1 and MRR@10 are quoted as discriminating, and `blueprint.md` no
+  longer plans a LoCoMo run — LoCoMo is CC BY-NC 4.0 and a launch is commercial
+  use, which an SPDX check misses because GitHub reports it as `NOASSERTION`.
+  Closes #267, #270, #271.
 
 - The single-core throughput ceiling is published as an operator sizing rule in
   [VPS deployment](./docs/deployment/vps.md) and `deploy/README.md`: at and

--- a/blueprint.md
+++ b/blueprint.md
@@ -1128,7 +1128,25 @@ Mulai dengan fixture Indonesia + Jawa + English yang merepresentasikan:
 - paraphrase lintas bahasa;
 - “no relevant memory”.
 
-Ukur Recall@5, MRR, precision, abstention/no-result quality, token cost extraction, dan latency. Setelah itu jalankan subset reproducible LoCoMo/LongMemEval melalui harness resmi. Jangan membandingkan angka marketing antar repo yang memakai model, prompt, dan dataset split berbeda.
+Ukur recall@1, MRR@10, precision, abstention/no-result quality, token cost extraction, dan latency. Setelah itu jalankan corpus eksternal yang reproducible melalui harness sendiri. Jangan membandingkan angka marketing antar repo yang memakai model, prompt, dan dataset split berbeda.
+
+Corpus eksternal yang dipakai sebagai bukti rilis:
+
+- **LongMemEval-S ([MIT](https://github.com/xiaowu0162/LongMemEval/blob/main/LICENSE)) — corpus eksternal utama.** Inilah yang benar-benar dijalankan pada 2026-08-04, 500 instance, dan hasilnya tercatat di [`docs/testing/EVALS.md`](./docs/testing/EVALS.md). Pada corpus ini recall@1 dan MRR@10 adalah metrik primer; recall@5 dan recall@10 sudah jenuh dan harus ditandai jenuh setiap kali dikutip.
+- **Mr.TyDi ([Apache-2.0](https://github.com/castorini/mr.tydi)) — lane pendukung non-English.**
+
+**LoCoMo tidak dipakai.** `snap-research/locomo/LICENSE.txt` baris 1 berbunyi
+`Attribution-NonCommercial 4.0 International`, dan menghasilkan angka benchmark
+untuk mendukung peluncuran produk komersial adalah penggunaan komersial. LoCoMo
+juga corpus yang disengketakan antar vendor, sehingga angka apa pun yang kita
+publikasikan darinya mewarisi sengketa itu.
+
+Aturan umum, karena jebakannya tidak terlihat oleh pemeriksaan rutin: **baca
+file LICENSE setiap corpus sebelum corpus itu masuk ke rencana bukti.**
+`gh api repos/snap-research/locomo --jq .license.spdx_id` mengembalikan
+`NOASSERTION`, jadi gate berbasis SPDX meloloskannya; pembatasan CC BY-NC hanya
+terlihat saat file-nya dibaca. `NOASSERTION` berarti **tidak diketahui**, bukan
+permisif.
 
 ## 21. Estimasi biaya Cloudflare
 
@@ -1185,7 +1203,7 @@ Gate: jangan lanjut jika BGE-M3 binding, `sqlite-vec` pada Bun, atau bounded ove
 ### P3 — quality and operations
 
 - bilingual eval harness;
-- LoCoMo/LongMemEval reproducible run;
+- LongMemEval-S reproducible run, dengan Mr.TyDi sebagai lane non-English;
 - rate limiting/deletion workflows jika deployment publik membutuhkannya;
 - backup/restore drill automation;
 - optional OCI image;

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -182,6 +182,11 @@ and unsafe IPv6 addresses, re-resolves before every attempt, pins TLS to one
 approved address, and never follows redirects. Cloudflare returns `503` for
 webhook registration/delivery because Worker `fetch` cannot prove this pinning.
 
+Registration records the current event sequence as the webhook's watermark, and
+delivery is owed for every event committed after it. Eligibility never depends
+on comparing wall-clock timestamps, so events written in the same millisecond as
+the registration are delivered rather than dropped.
+
 Canonical writes enqueue durable delivery rows before outbound I/O. Claims are
 atomic leases that recover after expiry. `X-Titen-Delivery` is stable across
 retries; `X-Titen-Attempt` changes per network attempt. Delivery is

--- a/docs/research/2026-08-04-memory-agent-landscape.md
+++ b/docs/research/2026-08-04-memory-agent-landscape.md
@@ -1,0 +1,258 @@
+# Agent-memory landscape, 2026-08-04
+
+**Survey date: 2026-08-04. Re-verified: 2026-08-05.**
+**Expires 2026-11-04.** After that date this document is evidence of what was
+true in August 2026 and nothing more — do not cite it in launch material without
+re-running the checks below. That expiry is not boilerplate: between April and
+August 2026 one competitor stopped shipping a self-hostable server, another was
+created from nothing and passed 58,000 stars, and an independent audit landed
+that changes how every published number in this field should be read. A
+competitor list without a date is worse than no list.
+
+This note exists so a launch can cite something. Every claim below carries a URL
+or a command that reproduces it. Where a check contradicted what we believed
+going in, the contradiction is recorded rather than smoothed over — including
+where it goes against Titen.
+
+## How to re-verify
+
+Repository facts:
+
+```bash
+gh api repos/getzep/zep        --jq '{description, license: .license.spdx_id}'
+gh api repos/MemPalace/mempalace --jq '{license: .license.spdx_id, created_at, stars: .stargazers_count}'
+gh api repos/plastic-labs/honcho --jq '.license.spdx_id'
+gh api repos/letta-ai/letta-app-server-deployment --jq '.license'
+curl -s https://pypi.org/pypi/mempalace/json | jq -r '.info.version, .info.requires_dist[]'
+```
+
+License facts — **read the file, not the SPDX field**:
+
+```bash
+gh api repos/snap-research/locomo --jq .license.spdx_id            # NOASSERTION
+gh api repos/snap-research/locomo/contents/LICENSE.txt \
+  -H "Accept: application/vnd.github.raw" | head -1                # CC BY-NC 4.0
+```
+
+`NOASSERTION` means **unknown, not permissive**. An SPDX-based license gate
+passes LoCoMo; the restriction is only visible in the file. See
+[`docs/testing/EVALS.md`](../testing/EVALS.md#third-party-references-and-licenses).
+
+Our own measurements: `~/titen-bench-20260804/results/*.json` on `rama-tuf`, one
+shared scorer, failures kept in the denominator.
+
+## Zep is no longer self-hostable
+
+This is the single most likely thing to be wrong in an old internal list.
+
+- `getzep/zep`'s description is now **"Zep | Examples, Integrations, & More"**.
+- Its README states: *"Zep Community Edition is no longer supported. Its code has
+  been moved to the [`legacy/`](legacy/) folder."* The repository's own component
+  table lists `legacy/` as **"Deprecated Zep Community Edition (unsupported)"**.
+- `legacy/` is where the server lives: `Dockerfile.ce`, `docker-compose.ce.yaml`,
+  `zep.yaml`, `go.work`.
+- The repository is still Apache-2.0, and that badge is what misleads. The
+  licence covers examples, integrations, an eval harness, and unsupported legacy
+  code. **It does not cover a maintained self-hostable server, because there
+  isn't one.**
+
+**[Graphiti](https://github.com/getzep/graphiti)** (Apache-2.0, 29,557 stars) is
+the part of that stack still open and still developed. Compare against Graphiti,
+not against "Zep". Graphiti's bitemporal edge model remains ahead of Titen's
+validity windows; see strategic debt item 4 in `PONYTAIL-DEBT.md`.
+
+Do not write "Zep is a self-hostable competitor". It was true; it is not.
+
+## Mem0's headline numbers are platform-only, by their own README
+
+Mem0's README reports **LoCoMo 92.5** and **LongMemEval 94.4**. Immediately
+below the table, verbatim:
+
+> All benchmarks run on the same production-representative model stack.
+> Single-pass retrieval (one call, no agentic loops) at a top_200 retrieval
+> budget. Scores reflect Mem0's managed platform, which includes proprietary
+> optimizations not available in the open-source SDK; open-source users should
+> expect directionally similar gains but not identical numbers.
+
+Two rules follow, and they are not optional:
+
+1. **Always write "Mem0 OSS 2.0.x", never bare "Mem0".** The open-source SDK and
+   the managed platform are different products with different numbers.
+2. **Quote the concession ourselves.** It is in their README. If we omit it and
+   someone else surfaces it, we look like we were hiding it; if we quote it, we
+   are simply reading the documentation.
+
+Note also what a plain `pip install mem0ai==2.0.15` actually gives you: the
+sparse/BM25 half of Mem0 2.0.x hybrid search is **off**, because `fastembed` is
+not a base dependency. Any OSS Mem0 measurement — ours included — is of that
+configuration unless stated otherwise.
+
+## MemPalace is real, large, and was missing from every internal list
+
+[`MemPalace/mempalace`](https://github.com/MemPalace/mempalace):
+
+| Fact | Value |
+| --- | --- |
+| License | MIT |
+| Created | 2026-04-05 |
+| Stars | 58,047 (2026-08-04) → 58,068 (2026-08-05) |
+| PyPI | `mempalace` 3.6.0 |
+| LLM dependency | **none** — no `openai`, no `anthropic` in `requires_dist` |
+
+Its runtime dependency set is `chromadb`, `huggingface-hub`, `numpy`,
+`python-dateutil`, `pyyaml`, `tokenizers`. No API key, no model provider, no
+server process, one `pip install`.
+
+That is the same pitch as Titen's low-operational-floor claim, from a project
+four months old with more stars than Mem0 had at the same age. Treat it as the
+direct competitor on that axis. It measures well too — see below, where its
+plain vector mode beat its own reranked mode and beat our FTS-only lane.
+
+The star delta over one day is left in the table deliberately: it is the
+cheapest available evidence that this field's numbers decay.
+
+## The independent audit: MemDelta
+
+**[arXiv:2606.29914v1](https://arxiv.org/abs/2606.29914)**, *MemDelta: Controlled
+Baselines and Hidden Confounds in Agent Memory Evaluation*, Kuan Wang,
+submitted 2026-06-29 (cs.CL, cs.LG).
+
+This is the most important citation in the space and it should be ours before it
+is anyone else's. From the abstract, verbatim:
+
+> on 2 of 6 question types (n = 88), Mem0 matches cloud RAG (72.7% vs. 73.9%,
+> p = 1.0) at 50x the cost, suggesting narrow rather than general gains
+
+and:
+
+> swapping only the embedding model in an identical pipeline shifts accuracy by
+> +6.2pp at n = 500 (p = 0.004), and Mem0 beats MiniLM-RAG by +11pp but loses to
+> cloud-RAG by 1.2pp, so one variable flips the conclusion
+
+The paper's introduction states the conclusion plainly: *"The apparent '+11pp
+memory gain' was not a property of the memory architecture. It was an embedding
+confound."* Its §4.4 write-path table puts verbatim RAG at ~60 s ingest, 0 LLM
+calls, ~$0.01, against Mem0 at ~120 min, 1,000+ LLM calls, ~$0.50+.
+
+Precision matters when citing this: the 72.7 / 73.9 comparison is over **2 of 6
+question types, n = 88** — not all of LongMemEval-S. Overstating it is the same
+error the paper is about.
+
+### Our run reproduces the direction, and it is not flattering to Titen either
+
+2026-08-04, `rama-tuf`, LongMemEval-S, the same 60 instances for every lane
+(10 per question type, deterministically stratified), one shared scorer, zero
+failures anywhere. Session retrieval against `answer_session_ids`.
+
+| Lane, matched n=60 | recall@1 | MRR@10 | LLM calls | embed calls | ingest |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Titen 0.6.0, FTS+vector | 0.883 | 0.934 | 0 | 595 | 57.7 s |
+| MemPalace 3.6.0, vector | 0.867 | 0.921 | 0 | — | 6,065.8 s |
+| verbatim-RAG control | 0.850 | 0.899 | 0 | 122 | 173.9 s |
+| **Mem0 OSS 2.0.15** | **0.833** | 0.888 | **2,981** | 5,883 | **288,020.8 s** |
+| Titen 0.6.0, FTS-only | 0.817 | 0.862 | 0 | 0 | 47.5 s |
+
+Paired sign tests on recall@1 over those 60 instances:
+
+| Comparison | W/L/T | two-sided p |
+| --- | ---: | ---: |
+| Titen FTS+vector vs Mem0 OSS | 5/2/53 | 0.453 |
+| verbatim-RAG control vs Mem0 OSS | 4/3/53 | 1.000 |
+| Titen FTS-only vs Mem0 OSS | 3/4/53 | 1.000 |
+| Titen FTS+vector vs verbatim-RAG control | 3/1/56 | 0.625 |
+
+**Read this honestly.** No lane separates from Mem0 on accuracy — not one
+p-value is close to significant. Titen's zero-provider FTS-only lane scores
+**below** Mem0 on this subsample (0.817 against 0.833), and Titen's best lane
+needs an embedding provider to get above it. On accuracy, the correct claim is
+*parity, unmeasurable difference*, and nothing stronger.
+
+The **cost axis** is where the separation is real and it is enormous. Mem0 spent
+2,981 LLM calls and 288,021 s of summed worker ingest time — 80 hours across 60
+workers, 1.6 h wall-clock — to land *between* Titen's two lanes and below a
+~100-line verbatim-RAG control that spent 122 embedding calls and 174 seconds.
+Extraction bought no measurable retrieval advantage at roughly 1,600x the ingest
+cost of the control. That is MemDelta's finding, reproduced on a different
+subsample with a different scorer.
+
+Two caveats that must travel with this table:
+
+- n=60 is small; every p-value above reflects that. The 500-instance run exists
+  only for the lanes that could afford it, and Titen's FTS+vector lane is not
+  one of them (#266).
+- recall@5 and recall@10 are **saturated** on this corpus. Only k=1 and MRR@10
+  discriminate. See
+  [`EVALS.md`](../testing/EVALS.md#recall10-is-saturated-on-longmemeval-s-k1-and-mrr10-are-the-primary-metrics).
+
+### Correction to earlier internal summaries
+
+`PONYTAIL-DEBT.md` and issue #271 both state that Titen scored **0.883 against
+Mem0's 0.833 with zero LLM calls**, implying the zero-provider lane won. Checked
+against the artifacts: 0.883 is the **FTS+vector** lane, which uses 595
+embedding calls. The zero-provider FTS-only lane scored **0.817**, below Mem0.
+The debt ledger's sign test ("2 wins, 5 losses, 53 ties, p = 0.45") also does not
+match the artifact, which gives **3W/4L/53T, p = 1.0** for FTS-only versus Mem0
+and 5W/2L/53T, p = 0.453 for FTS+vector. Recomputing every lane from its raw
+`.ranked.json` reproduces the stored scores exactly, so the artifacts are
+trustworthy and the summaries drifted. Do not requote the ledger's version.
+
+## Not viable to benchmark, and why
+
+Recorded so these are not re-litigated. Each one was checked, not assumed.
+
+| System | Why not | Verification |
+| --- | --- | --- |
+| **Letta** | No retrieval surface to benchmark. The Agent SDK's documented API is agent-centric — `createAgent`, `createSession`, `send` — with no `search(query)` returning ranked memories. Self-hosting now routes through [`letta-app-server-deployment`](https://github.com/letta-ai/letta-app-server-deployment), which ships a Dockerfile, `docker-compose.yml`, `fly.toml` and `railway.json` and **no licence file at all**. | `gh api repos/letta-ai/letta-app-server-deployment --jq .license` → `null`; `/license` → 404. The main `letta-ai/letta` repo is Apache-2.0 but its README calls itself "the legacy Letta server". |
+| **Honcho** | AGPL-3.0, including the network clause. A valid licence, but it imposes obligations incompatible with how we would need to run a comparison lane in a commercial context. | `gh api repos/plastic-labs/honcho --jq .license.spdx_id` → `AGPL-3.0` |
+| **Supermemory** | No engine source. The repository (MIT, 28,779 stars) ships SDKs, plugins, browser/Raycast extensions, an MCP app, docs, and `@supermemory/memory-graph` — a *"graph visualization component"*. The engine itself arrives as a prebuilt binary via `curl https://supermemory.ai/install \| bash`. Their README is candid: *"We are a research lab building the engine, plugins and tools around it."* | Inspect `packages/` and `apps/`; read `packages/memory-graph/package.json`. |
+| **LangMem** | Effectively frozen. Last PyPI release **0.0.30 on 2025-10-27**; every repository commit since at least 2026-06-23 is a Dependabot bump; 59 open issues; not archived, but no feature work in ~9 months. | `curl -s https://pypi.org/pypi/langmem/json \| jq '.info.version'`; `gh api repos/langchain-ai/langmem/commits` |
+| **OpenAI Assistants** | Shut down **2026-08-26** — three weeks after this survey. Benchmarking it would produce a number that expires before it could be published. | [OpenAI deprecations](https://developers.openai.com/api/docs/deprecations) |
+
+Two corrections to the assumptions this survey started from:
+
+- LangMem was believed to be stale because *"its last release predates the
+  LangChain 1.x line"*. **That is false.** LangChain 1.0.0 shipped 2025-10-17 and
+  LangMem 0.0.30 shipped 2025-10-27, ten days later. The freeze is real, but the
+  reason is the nine-month release gap and the all-Dependabot commit log, not the
+  ordering against LangChain 1.x. LangMem 0.0.30 does still pin
+  `langchain>=0.3.15`, i.e. it was built against the 0.3 line and never moved.
+- The claim that LangMem's *"read and write paths disagree"* **was not
+  verified** and is not asserted here. If it is needed for positioning, someone
+  must reproduce it first.
+
+## What this supports, and what it does not
+
+Supported by the evidence above:
+
+- Titen's operational floor — no LLM, no embedding provider, no external service
+  — is a genuinely differentiated position, but **MemPalace occupies the same
+  ground** with a larger community and a Python-native install.
+- Extraction-based memory has not demonstrated a retrieval advantage over
+  embedding raw sessions, in an independent audit or in our own run. That is a
+  claim about the category, not about Titen.
+- Coordination primitives (leases, handoffs, checkpoints) inside the memory's
+  authorization boundary remain unmatched by everything surveyed. This is the
+  only axis where Titen leads rather than matches.
+
+**Not** supported, and not to be claimed:
+
+- that Titen beats Mem0, MemPalace, or a verbatim-RAG baseline on retrieval
+  accuracy — no comparison reached significance, and the zero-provider lane lost
+  to Mem0 on the matched subsample;
+- any LongMemEval-S recall@5 or recall@10 figure without the saturation caveat;
+- that Zep is a beaten competitor. It exited the self-hosted category on its own;
+  we did not displace it.
+
+## Sources
+
+- [getzep/zep](https://github.com/getzep/zep) · [getzep/graphiti](https://github.com/getzep/graphiti)
+- [mem0ai/mem0](https://github.com/mem0ai/mem0)
+- [MemPalace/mempalace](https://github.com/MemPalace/mempalace) · [`mempalace` on PyPI](https://pypi.org/project/mempalace/)
+- [MemDelta, arXiv:2606.29914](https://arxiv.org/abs/2606.29914)
+- [letta-ai/letta](https://github.com/letta-ai/letta) · [letta-app-server-deployment](https://github.com/letta-ai/letta-app-server-deployment)
+- [plastic-labs/honcho](https://github.com/plastic-labs/honcho)
+- [supermemoryai/supermemory](https://github.com/supermemoryai/supermemory)
+- [langchain-ai/langmem](https://github.com/langchain-ai/langmem)
+- [OpenAI API deprecations](https://developers.openai.com/api/docs/deprecations)
+- [LongMemEval](https://github.com/xiaowu0162/LongMemEval) (MIT) · [LoCoMo](https://github.com/snap-research/locomo) (CC BY-NC, not used)
+- Prior internal note: [`competitive-landscape.md`](./competitive-landscape.md), 2026-07-26 — superseded on Zep and Mem0 by this document.

--- a/docs/testing/EVALS.md
+++ b/docs/testing/EVALS.md
@@ -726,8 +726,64 @@ FTS-only quality figure must be quoted with the corpus size it was measured
 at. Tier L (1,000,000) has never been run. Arresting this slope is strategic
 debt item 3 in `PONYTAIL-DEBT.md`.
 
-LoCoMo and LongMemEval are external comparability suites, not substitutes for
-Titen's isolation, evidence, conflict, and collaboration fixtures.
+LongMemEval-S is an external comparability suite, not a substitute for Titen's
+isolation, evidence, conflict, and collaboration fixtures. LoCoMo is not used at
+all — see [third-party references and licenses](#third-party-references-and-licenses).
+
+### recall@10 is saturated on LongMemEval-S; k=1 and MRR@10 are the primary metrics
+
+Measured 2026-08-04 on `rama-tuf`, LongMemEval-S, all 500 instances, one shared
+scorer, failures kept in the denominator, zero failures in every lane. Artifacts
+are `~/titen-bench-20260804/results/*-500.json`; the overall and per-question-type
+figures below are read from the `by_type` block the scorer emits, and recomputing
+each lane from its raw `.ranked.json` reproduces the stored scores exactly.
+
+| Lane, n=500 | recall@1 | recall@5 | recall@10 | MRR@10 |
+| --- | ---: | ---: | ---: | ---: |
+| Titen FTS-only | 0.880 | 0.960 | 0.982 | 0.9147 |
+| verbatim-RAG control, router embeddings | 0.854 | 0.974 | 0.990 | 0.9067 |
+| MemPalace 3.6.0, MiniLM, user-only | 0.804 | 0.964 | 0.982 | 0.8717 |
+| verbatim-RAG control, fastembed | 0.772 | 0.932 | 0.972 | 0.8427 |
+| MemPalace 3.6.0, MiniLM, full-text | 0.746 | 0.924 | 0.968 | 0.8249 |
+
+The spread between the best and worst serious lane collapses as k grows:
+**13.4 points at k=1, 5.0 at k=5, 2.2 at k=10**, against 9.0 points on MRR@10.
+k=1 discriminates roughly **six times** as strongly as k=10, and every lane sits
+within 3.2 points of the ceiling at k=10, so a lane-vs-lane difference there is
+noise. Two question types have no headroom left at all:
+`single-session-assistant` (n=56) is recall@1 **1.000** in both control arms and
+in Titen FTS-only, and `knowledge-update` (n=78) is recall@5 1.000 in four of the
+five lanes.
+
+Therefore, on this corpus:
+
+- **recall@1 and MRR@10 are the primary metrics.** A ranking improvement that
+  does not move them has not been measured.
+- **recall@5 and recall@10 must be marked saturated wherever they are quoted**,
+  in this repository and in any external material. Publishing a bare recall@10
+  table implies a discrimination that is not there.
+
+One caveat against over-reading the saturation: it is a property of the serious
+lanes, not of the metric. The MCP reference server lane scores recall@10 0.482,
+so k=10 still separates a working retriever from a broken one — it just cannot
+rank the working ones.
+
+The `single-session-assistant` ceiling is *not* explained by the questions
+restating the gold session verbatim, which was the initial hypothesis. Measured:
+a median of only **0.44** of each question's content words appear in the gold
+session's opening 1,200 characters, and a bare word-overlap ranker scores
+recall@1 **0.464** on that type against 1.000 for the real lanes. The type is
+easy for any competent retriever, lexical or dense; it is not a string match.
+
+**Better fix, future work: enlarge the haystack rather than change the metric.**
+Each instance currently carries its own small haystack — median **50** sessions
+(min 39, max 66) — while the corpus holds **19,829 distinct sessions** across
+25,112 (instance, session) pairs. Scoring against one shared haystack instead of
+~50 candidates per instance is roughly a **400x** larger candidate pool and is
+also closer to how a real store looks. This connects directly to the FTS-only
+degradation curve above: recall@1 falls 1.00 -> 0.49 from 10^3 to 10^5 claims, so
+at realistic corpus sizes the saturation disappears on its own and ranking, not
+candidate generation, becomes the binding constraint. Tracked as #267.
 
 ## Release gates
 
@@ -781,6 +837,12 @@ Every published result includes:
   throughput, quality floor, and raw trials.
 - Never compare a local self-hosted run directly with a managed network service
   as though their infrastructure were equivalent.
+- Never quote recall@5 or recall@10 from LongMemEval-S without marking it
+  saturated; report recall@1 and MRR@10 as the primary metrics on that corpus.
+- Never let a corpus into an evidence plan without reading its `LICENSE` file.
+  An SPDX lookup is not sufficient: `gh api repos/snap-research/locomo --jq
+  .license.spdx_id` returns `NOASSERTION`, which means **unknown, not
+  permissive**, while the file itself is CC BY-NC.
 
 ## Third-party references and licenses
 
@@ -789,9 +851,14 @@ their code or datasets. Referencing a project does not imply affiliation or
 endorsement.
 
 - The LoCoMo repository declares
-  [CC BY-NC 4.0](https://github.com/snap-research/locomo/blob/main/LICENSE.txt).
+  [CC BY-NC 4.0](https://github.com/snap-research/locomo/blob/main/LICENSE.txt);
+  line 1 of `LICENSE.txt` is `Attribution-NonCommercial 4.0 International`.
   Do not vendor or redistribute its dataset in Titen's Apache-2.0 release, and
-  do not assume commercial benchmark use is permitted.
+  do not assume commercial benchmark use is permitted. **Titen does not run
+  LoCoMo at all**: producing benchmark numbers to support a commercial launch is
+  commercial use. GitHub reports its SPDX id as `NOASSERTION`, so a license gate
+  that reads SPDX alone will wave it through — the restriction is only visible in
+  the file. `blueprint.md` §20.5 records the same decision.
 - The LongMemEval repository declares
   [MIT](https://github.com/xiaowu0162/LongMemEval/blob/main/LICENSE). Confirm the
   separately hosted dataset terms before redistribution.
@@ -805,8 +872,12 @@ committed into this repository.
 
 ## Primary references
 
-- [LoCoMo dataset and code](https://github.com/snap-research/locomo)
-- [LongMemEval project](https://xiaowu0162.github.io/long-mem-eval/)
+- [LongMemEval project](https://xiaowu0162.github.io/long-mem-eval/) — primary
+  external corpus, MIT
+- [Mr.TyDi](https://github.com/castorini/mr.tydi) — supporting non-English lane,
+  Apache-2.0
+- [LoCoMo dataset and code](https://github.com/snap-research/locomo) — cited for
+  its license only; not run, CC BY-NC
 - [Mem0 memory benchmark harness](https://github.com/mem0ai/memory-benchmarks)
 - [Anthropic: effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
 - [VectorDBBench methodology and metrics](https://github.com/zilliztech/VectorDBBench)

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -392,10 +392,11 @@ async function deliverPending(
           AND (d.lease_expires_at IS NULL OR d.lease_expires_at <= ?)
        UNION ALL
        SELECT w.org_id, e.created_at AS due_at
-         FROM webhooks w JOIN events e ON e.org_id = w.org_id
+         FROM webhooks w
+         JOIN event_order eo ON eo.seq > w.created_seq
+         JOIN events e ON e.id = eo.event_id AND e.org_id = w.org_id
         WHERE w.status = 'active' AND w.principal_id IS NOT NULL
           AND ${eventAccessSql("e", "w.principal_id")}
-          AND w.created_at < e.created_at
           AND ((',' || w.events || ',') LIKE '%,*,%' OR (',' || w.events || ',') LIKE '%,' || e.kind || ',%')
           AND NOT EXISTS (
             SELECT 1 FROM webhook_deliveries d

--- a/src/core/migrations.ts
+++ b/src/core/migrations.ts
@@ -1347,6 +1347,19 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
        )`,
     ],
   },
+  {
+    version: 22,
+    statements: [
+      // Webhook eligibility compared millisecond wall-clock strings, so an
+      // event written in a webhook's own registration millisecond was never
+      // queued. event_order.seq is the monotonic watermark /v1/events and
+      // federation already page on; webhooks now use the same one.
+      `ALTER TABLE webhooks ADD COLUMN created_seq INTEGER`,
+      // Existing subscriptions start at the current head. Backfilling to 0
+      // would replay the entire event history into every webhook on upgrade.
+      `UPDATE webhooks SET created_seq = (SELECT COALESCE(MAX(seq), 0) FROM event_order)`,
+    ],
+  },
 ];
 
 export const SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]!.version;

--- a/src/core/webhooks.ts
+++ b/src/core/webhooks.ts
@@ -61,9 +61,12 @@ export async function registerWebhook(ctx: RequestContext): Promise<Result> {
 
   await ctx.app.db.batch([
     {
+      // created_seq is the delivery watermark: everything already committed is
+      // excluded, everything after it is owed, with no dependence on how many
+      // writes share the registration millisecond.
       sql: `INSERT INTO webhooks
-              (id, org_id, principal_id, url, secret_hash, secret, events, status, failure_count, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'active', 0, ?)`,
+              (id, org_id, principal_id, url, secret_hash, secret, events, status, failure_count, created_at, created_seq)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'active', 0, ?, (SELECT COALESCE(MAX(seq), 0) FROM event_order))`,
       params: [
         id,
         principal.orgId,
@@ -242,15 +245,15 @@ export async function listDeliveries(ctx: RequestContext): Promise<Result> {
 async function queueEvent(
   db: Db,
   orgId: string,
-  event: { id: string; kind: string; created_at: string },
+  event: { id: string; kind: string; seq: number },
   now: Date = new Date(),
   principalId?: string,
 ): Promise<void> {
   const hooks = await db.all<{ id: string; events: string; principal_id: string }>(
     `SELECT id, events, principal_id FROM webhooks
        WHERE org_id = ? AND status = 'active' AND principal_id IS NOT NULL
-         AND created_at < ? AND (? IS NULL OR principal_id = ?)`,
-    [orgId, event.created_at, principalId ?? null, principalId ?? null],
+         AND created_seq < ? AND (? IS NULL OR principal_id = ?)`,
+    [orgId, event.seq, principalId ?? null, principalId ?? null],
   );
   const statements: Stmt[] = [];
   for (const hook of hooks) {
@@ -440,21 +443,21 @@ export async function processWebhooks(options: {
   cipher: RequestContext["app"]["secretCipher"];
   principalId?: string;
 }): Promise<{ events: number; attempted: number; delivered: number; cursor: string | null }> {
-  const events = await options.db.all<{ id: string; kind: string; created_at: string }>(
-    `SELECT e.id, e.kind, e.created_at FROM events e
+  const events = await options.db.all<{ id: string; kind: string; seq: number }>(
+    `SELECT e.id, e.kind, eo.seq FROM event_order eo JOIN events e ON e.id = eo.event_id
       WHERE e.org_id = ? AND EXISTS (
         SELECT 1 FROM webhooks w
          WHERE w.org_id = e.org_id AND w.status = 'active'
            AND w.principal_id IS NOT NULL
            AND (? IS NULL OR w.principal_id = ?)
            AND ${eventAccessSql("e", "w.principal_id")}
-           AND w.created_at < e.created_at
+           AND eo.seq > w.created_seq
            AND ((',' || w.events || ',') LIKE '%,*,%' OR (',' || w.events || ',') LIKE '%,' || e.kind || ',%')
            AND NOT EXISTS (
              SELECT 1 FROM webhook_deliveries d
               WHERE d.webhook_id = w.id AND d.event_id = e.id
            )
-      ) ORDER BY e.created_at, e.id LIMIT ?`,
+      ) ORDER BY eo.seq LIMIT ?`,
     [options.orgId, options.principalId ?? null, options.principalId ?? null, options.limit],
   );
   // The durable delivery uniqueness rule advances later pages across passes.

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -4342,15 +4342,16 @@ export const CASES: Case[] = [
     },
   },
   {
-    name: "a webhook never receives an event recorded in its own registration millisecond",
+    name: "webhook delivery follows the registration sequence, not the registration millisecond",
     async run(fx) {
       const owner = await fx.provision({ scopes: ["*"] });
       await seedClaim(fx, owner.key, {
         observation: { content: "Evidence recorded before the webhook existed." },
         claim: { statement: "Pre-registration evidence stays out of the queue." },
       });
-      const [latest] = await fx.query<{ created_at: string }>(
-        `SELECT created_at FROM events WHERE org_id = ? ORDER BY created_at DESC, id DESC LIMIT 1`,
+      const [latest] = await fx.query<{ created_at: string; seq: number }>(
+        `SELECT e.created_at, eo.seq FROM event_order eo JOIN events e ON e.id = eo.event_id
+          WHERE e.org_id = ? ORDER BY eo.seq DESC LIMIT 1`,
         [owner.orgId],
       );
       const hook = await fx.call("POST", "/v1/webhooks", {
@@ -4363,19 +4364,61 @@ export const CASES: Case[] = [
       });
       expectOk(hook, 201);
       const hookId = hook.body.data.webhook_id;
+      // Registration records the committed head as its watermark, so eligibility
+      // never depends on the resolution of a wall clock.
+      const [registered] = await fx.query<{ created_seq: number }>(
+        `SELECT created_seq FROM webhooks WHERE id = ?`,
+        [hookId],
+      );
+      assert.equal(
+        Number(registered!.created_seq),
+        Number(latest!.seq),
+        "registration must record the current event sequence",
+      );
+
+      await seedClaim(fx, owner.key, {
+        observation: { content: "Evidence recorded after the webhook existed." },
+        claim: { statement: "Post-registration evidence is owed to the queue." },
+      });
       // ISO-8601 timestamps are millisecond-precision, so a fast host can register
-      // a webhook inside the millisecond an earlier event already occupies.
+      // a webhook and write its next events inside one millisecond. Collapse the
+      // webhook and every event onto a single timestamp: the wall clock can no
+      // longer separate them, and only the sequence can.
       await fx.query(`UPDATE webhooks SET created_at = ? WHERE id = ?`, [latest!.created_at, hookId]);
+      await fx.query(`UPDATE events SET created_at = ? WHERE org_id = ?`, [
+        latest!.created_at,
+        owner.orgId,
+      ]);
+
+      const before = await fx.query<{ id: string }>(
+        `SELECT e.id FROM event_order eo JOIN events e ON e.id = eo.event_id
+          WHERE e.org_id = ? AND eo.seq <= ? ORDER BY eo.seq`,
+        [owner.orgId, latest!.seq],
+      );
+      const after = await fx.query<{ id: string }>(
+        `SELECT e.id FROM event_order eo JOIN events e ON e.id = eo.event_id
+          WHERE e.org_id = ? AND eo.seq > ? ORDER BY eo.seq`,
+        [owner.orgId, latest!.seq],
+      );
+      assert.ok(before.length > 0 && after.length > 0, "both sides of the watermark must be seeded");
 
       expectOk(await fx.call("POST", "/v1/webhooks/deliver", { key: owner.key, body: {} }));
       const deliveries = await fx.call("GET", `/v1/webhooks/${hookId}/deliveries?limit=200`, {
         key: owner.key,
       });
       expectOk(deliveries);
-      assert.deepEqual(
+      const queued = new Set<string>(
         deliveries.body.data.deliveries.map((delivery: any) => delivery.event_id),
+      );
+      assert.deepEqual(
+        before.filter(({ id }) => queued.has(id)).map(({ id }) => id),
         [],
-        "a webhook must never receive an event that predates its own registration",
+        "a webhook must never receive an event that precedes its registration sequence",
+      );
+      assert.deepEqual(
+        after.filter(({ id }) => !queued.has(id)).map(({ id }) => id),
+        [],
+        "a webhook must receive every event after its registration sequence, same millisecond included",
       );
     },
   },


### PR DESCRIPTION
## The fix (#265)

Webhook delivery eligibility compared `w.created_at < e.created_at` — a **strict comparison on a millisecond wall-clock string**. On a fast host a registration and the next write share a millisecond, so those events were never queued, never delivered, never retried. Silent loss, no diagnostic, worst on the fast hosts most likely to run it in production.

The repository already had the right primitive and two other consumers used it (`src/core/events.ts`, `src/core/federation.ts`, both `eo.seq > ?`), with a passing contract case for exactly this hazard — for federation. Webhooks were the one consumer still on the clock.

- **Migration 22** adds `webhooks.created_seq`, backfilled to the **current head** rather than 0, so an upgrade delivers only future events instead of replaying the entire history into every subscription.
- **Both** eligibility sites converted. The second — `deliverPending` in `maintenance.ts` — selects which orgs have due work; leaving it would have fixed the path the test caught while an org whose only outstanding work was a same-millisecond event stayed unwoken. `grep -rn "created_at < e.created_at" src/` now returns nothing.
- The contract case that pinned the old exclusion as *intended* behaviour is **restated, not deleted**, and now asserts the missing half: every event after the registration sequence is delivered, same millisecond included. Reverting only the predicates makes it fail.

| Host | Before | After |
| --- | --- | --- |
| rama-tuf (16-core) | 8/12 fail | **12/12 pass** |
| this laptop | 12/12 pass | 12/12 pass |

`pnpm test:all` exits 0 including the **116-test D1 lane**, so migration 22 is verified on both runtimes.

## The decision not to build (#269)

The reranking stage in `PONYTAIL-DEBT.md` was measured before being written, and the measurement says don't.

Oracle ceiling over titen's own top-10: **+10.2 points** (0.880 → 0.982). Every cheap signal tested:

| Signal | recall@1 | Δ | p |
| --- | ---: | ---: | ---: |
| MemPalace's own recipe | 0.886 | +0.006 | 0.607 |
| RRF(base, BM25) | 0.880 | 0.000 | 1.000 |
| session BM25 | 0.866 | −0.014 | 0.311 |
| IDF-weighted coverage | 0.848 | −0.032 | **0.029** |
| question-word coverage | 0.844 | −0.036 | **0.008** |

Best capture is 5.9% of the ceiling at p=0.61. Two signals are significantly *worse* than no reranking. MemPalace, which ships one, scored **lower with it than without it in both embedding arms** — 16 of 21 rank changes were downgrades, 9 starting from rank 1.

The 10 points are real; lexical signals cannot reach them. One honest gap: score-margin couldn't be tested because the ranked artifacts store only ordered IDs, no scores.

## Documentation (#267 #270 #271)

recall@5/@10 marked saturated on LongMemEval-S so only recall@1 and MRR@10 are quoted; `blueprint.md` drops its planned LoCoMo run (**CC BY-NC 4.0** — a launch is commercial use, and GitHub reports `NOASSERTION` so an SPDX gate passes it); new dated landscape note under `docs/research/`.

## Not closed

#266 and #268 — their 500-instance runs were still executing. Not closing on a promise.