### PR TITLE
release: 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The **CLI command is `titen`** regardless; see [Package name](#package-name).
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-08-05
+
 ### Fixed
 
 - Webhooks no longer silently drop events written in their own registration
@@ -837,7 +839,9 @@ disabled so the repository has no hosted automation cost; manual publication
 also keeps the npm token out of repository secrets. See
 [`docs/engineering/release.md`](./docs/engineering/release.md).
 
-[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.5.7...HEAD
+[Unreleased]: https://github.com/RamaAditya49/titen/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/RamaAditya49/titen/releases/tag/v0.6.1
+[0.6.0]: https://github.com/RamaAditya49/titen/releases/tag/v0.6.0
 [0.5.7]: https://github.com/RamaAditya49/titen/releases/tag/v0.5.7
 [0.5.6]: https://github.com/RamaAditya49/titen/releases/tag/v0.5.6
 [0.5.5]: https://github.com/RamaAditya49/titen/releases/tag/v0.5.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titen-memory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The Level 6 collaborative memory fabric for AI agents — evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Patch release. Per `docs/engineering/release.md`'s table, nothing here removes a route, changes a response shape, or renames a field.

**Headline:** #265 — webhooks silently dropped events written in their own registration millisecond. Eligibility compared `w.created_at < e.created_at` on a millisecond wall-clock string; migration 22 moves both sites onto the `event_order.seq` watermark `/v1/events` and federation already used. Existing rows backfill to the current head, so an upgrade delivers future events rather than replaying history into every subscription.

Measured: `8/12 runs failing → 12/12 passing` on a 16-core host. `pnpm test:all` exit 0 including the 116-test D1 lane, so migration 22 is verified on both runtimes.

Also in this release: deterministic FTS-only tie-breaks (#226), migration refuses a pre-0.2.0 store rather than succeeding into silence (#257), export refuses rows its own importer rejects (#258), in-process Bun mode (#230), and the measured decision **not** to build a reranker (#269).

Version bumped to 0.6.1, `[Unreleased]` dated to `[0.6.1] — 2026-08-05`, and the compare links corrected — `[Unreleased]` still pointed at `v0.5.7...HEAD` and `[0.6.0]` had no link line at all.

#266 and #268 remain open: benchmark-completeness issues whose runs are still executing. They do not touch the tarball.