### PR TITLE
docs: put the measured results in the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ Agents connect through authenticated REST, Streamable HTTP MCP, the `titen mcp`
 stdio bridge, or the TypeScript SDK. Titen never treats retrieved memory as an
 instruction, and it does not run agent loops.
 
+## Measured against the field
+
+On [LongMemEval-S](https://github.com/xiaowu0162/LongMemEval) (MIT, externally
+authored, 500 instances), our own scorer, failures kept in the denominator,
+protocol pre-registered before each run. Full table and method at
+[titen.dev/benchmark](https://titen.dev/benchmark).
+
+| Lane, n=500 | recall@1 | LLM calls | embedding calls |
+| --- | ---: | ---: | ---: |
+| Titen 0.6.0, FTS + vector | **0.900** | 0 | 4,989 |
+| Titen 0.6.0, FTS-only | 0.880 | **0** | **0** |
+| verbatim-RAG control (~100 lines of cosine) | 0.854 | 0 | 877 |
+| MemPalace 3.6.0 | 0.804 | 0 | — |
+
+The FTS+vector lane beats the dense control on a paired sign test — 35 wins, 12
+losses, 453 ties, **p = 0.0011**. Three things we will not let that number imply:
+
+- **FTS-only is at parity**, not ahead (44/31/425, p = 0.165), and the vector arm
+  is not proven to be the cause of the win (27/17/456, p = 0.174).
+- **Answer accuracy is a flat null.** With one reader pinned across every lane,
+  eight pre-registered comparisons produce nothing significant (best p = 0.41).
+  Retrieval significance does not transfer to answers.
+- **We do not beat Mem0's LLM-free mode.** Mem0 `infer=False` scores 0.8667
+  against our 0.8833 on the shared subsample — 3/4/53, **p = 1.0**. Its default
+  `infer=True` mode spends 2,981 LLM calls to score *lower* (0.8333), so Mem0's
+  own extraction bought nothing measurable here. Any cost claim must name the
+  configuration it measured.
+
+What survives every configuration argument is the dependency floor: **Titen's
+FTS-only lane made zero LLM calls and zero embedding calls.** Mem0 without an LLM
+still needs an embedding provider. `dependencies: {}`, zero external imports in
+`src/core/`, and exactly two outbound calls in the whole codebase, both opt-in.
+
+Where Titen loses is published too: FTS-only recall@1 falls from 1.00 to 0.49
+between 10³ and 10⁵ claims on a synthetic corpus, one process saturates one core
+at 10k claims, there is no reranking stage, and no external suite scores the
+governance and collaboration primitives at all.
+
 ## Project status
 
 **Titen is pre-1.0.** Per [SemVer clause 4](https://semver.org/spec/v2.0.0.html#spec-item-4),

--- a/docs/testing/EVALS.md
+++ b/docs/testing/EVALS.md
@@ -284,6 +284,70 @@ pins `fixture_sha256`, the split checksum, the locked holdout, and the pre-hoc
 published run. Split it only when a future fixture revision invalidates those
 hashes anyway.
 
+## Recorded LongMemEval-S run, 2026-08-04/06
+
+Externally authored corpus (MIT, 500 instances, 246,930 turns), our own scorer,
+failures kept in the denominator, protocol pre-registered before each run.
+Published at [titen.dev/benchmark](https://titen.dev/benchmark).
+
+| Lane, n=500 | recall@1 | MRR@10 | LLM calls | embed calls |
+| --- | ---: | ---: | ---: | ---: |
+| Titen 0.6.0, FTS + vector | **0.900** | **0.9384** | 0 | 4,989 |
+| Titen 0.6.0, FTS-only | 0.880 | 0.9147 | **0** | **0** |
+| verbatim-RAG control, router embeddings | 0.854 | 0.9067 | 0 | 877 |
+| MemPalace 3.6.0, MiniLM | 0.804 | 0.8717 | 0 | — |
+| MCP reference server, substring | 0.050 | 0.1509 | 0 | — |
+
+Paired sign tests on recall@1, same instances:
+
+- FTS+vector vs the dense control: 35/12/453, **p = 0.0011** — significant, and it
+  holds at 34/13, p = 0.0031 against a control given a matched 2,048-token budget.
+- FTS-only vs that control: 44/31/425, p = 0.165 — not significant.
+- FTS+vector vs FTS-only: 27/17/456, p = 0.174 — **the vector arm is not proven to
+  be the cause of the win.**
+
+### Mem0 in both of its modes
+
+Mem0 supports `infer=False`, which skips LLM extraction entirely. Measuring only
+its default overstates its cost, so both were run on the same 60 instances.
+
+| Mem0 OSS 2.0.15 | recall@1 | MRR@10 | LLM calls | summed ingest |
+| --- | ---: | ---: | ---: | ---: |
+| `infer=False` | 0.8667 | 0.9019 | **0** | 14,827 s |
+| `infer=True` (default) | 0.8333 | 0.8882 | 2,981 | 288,021 s |
+
+The LLM-free mode is nominally ahead and the difference is noise (3/1/56,
+p = 0.625), so **Mem0's own extraction bought nothing measurable on this corpus**
+at 19x the summed ingest. Titen FTS+vector against Mem0 `infer=False` is 3/4/53,
+**p = 1.0** — indistinguishable. Zero LLM calls was verified with a raising
+monkey-patch, a negative control, and a closed-port LLM base URL, not assumed.
+
+Standing consequence for any cost claim: **name the configuration measured.**
+"Mem0 burns thousands of LLM calls" is true of its default and false of its
+LLM-free mode.
+
+### Answer accuracy is a null
+
+One reader pinned across every lane (same model, temperature 0, k=5, prompt
+byte-identical by hash). Primary metric is judge-free containment; the LLM judge
+is secondary with its model and prompt published.
+
+Eight pre-registered comparisons against the dense control, **none significant**,
+best p = 0.41. Titen FTS-only is numerically below the control. At n=60, Mem0 OSS
+and MemPalace both score above Titen. Headroom at k=5 is only 1.8 points because
+every competent retriever already holds the gold session, so this run had little
+power by construction — k=5 was fixed before the first call and deliberately not
+retuned afterwards.
+
+**Retrieval significance does not transfer to answers.**
+
+### What does not depend on configuration
+
+Titen's FTS-only lane made zero LLM calls **and zero embedding calls** and scored
+0.880. Mem0 `infer=False` still made 29,582 embedding calls and still requires an
+embedding provider. That is the one difference in this table that no competitor
+setting can erase.
+
 ## Recorded Mem0 replacement cycle
 
 The first versioned side-by-side run against `server-wulan` is documented in


### PR DESCRIPTION
The benchmark numbers were live on titen.dev but existed **nowhere in this repository**. The repo is the source of truth and a reader starting here found nothing.

README gains a *Measured against the field* section; `docs/testing/EVALS.md` gains the full run record.

Both carry the same three qualifications the site does, in the same breath as the headline rather than below the fold:

- **FTS-only is at parity** with the dense control (44/31/425, p = 0.165), and the vector arm is **not proven** to be the cause of the win that does clear significance (27/17/456, p = 0.174).
- **Answer accuracy is a flat null** — eight pre-registered comparisons, none significant, best p = 0.41.
- **We do not beat Mem0's LLM-free mode.** `infer=False` scores 0.8667 against our 0.8833, **p = 1.0**, while its default spends 2,981 LLM calls to score *lower* (0.8333).

Also records the standing rule that produced that last correction: **any cost claim must name the configuration it measured.** We published the unqualified version before a reader caught it.

The dependency floor is stated as the one claim no competitor setting can erase: zero LLM calls **and** zero embedding calls, against Mem0 `infer=False` still needing an embedding provider for its 29,582 calls.

Where Titen loses is in both files too — the 1.00 → 0.49 scale curve, the single-core ceiling, the absent reranker, and that no external suite scores the governance and collaboration primitives at all.

`tests/integration/agent-plugin.test.ts` (which pins README content) passes 6/6.