### PR TITLE
docs: record the strategy the benchmark evidence actually supports

### DIFF
--- a/docs/plans/active/2026-08-06-substitution-and-write-hygiene.md
+++ b/docs/plans/active/2026-08-06-substitution-and-write-hygiene.md
@@ -1,0 +1,130 @@
+---
+work_id: substitution-and-write-hygiene
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-08-06
+updated: 2026-08-06
+owner: ramaaditya
+spec: docs/specs/active/2026-08-06-substitution-and-write-hygiene.md
+review_after: 2026-08-20
+---
+
+# Plan — substitution first, then the instrument
+
+Six items. Every one is hours or days, deliberately: a single maintainer with no
+CI who publishes by hand cannot carry a months-long item, and the two that
+matter are cheap to try and structurally expensive for an incumbent to copy.
+
+## Dependency spine
+
+S1 unblocks S2 and S5. S2's `memory.json` parser is reused by S4. **S3 must land
+before S4** or the recall-loop metric is self-declared and therefore worthless.
+S6 gates only discovery.
+
+## Sequence
+
+### Week 0 — S6: list in the official MCP registry (hours)
+
+`registry.modelcontextprotocol.io/v0/servers?search=titen` returns count 0 while
+the reference server's README routes every discovery query there. First only
+because it has a propagation delay. This is plumbing, not strategy; 12,700+
+servers are already listed and the standalone effect is approximately zero.
+
+- [ ] Publish to the official MCP registry.
+
+### Week 1 — S1: zero-config local mode (days)
+
+`src/runtime/bun/mcp-stdio.ts:44` throwing without `TITEN_MCP_URL` and
+`TITEN_API_KEY` is the single line between Titen and every play below. Nothing
+is reachable while trying Titen costs more than the incumbent's entire
+lifecycle.
+
+- [ ] `npx titen-memory mcp` with no environment opens or creates
+      `~/.titen/memory.db`, auto-provisions org/workspace/project/owner as real
+      rows, serves MCP over stdio in-process, FTS-only, no outbound call.
+- [ ] The existing served mode and its auth path are untouched — an additional
+      entry point, not a relaxation.
+- [ ] If auto-bootstrap would require special-casing `assertTrustCeiling` or
+      authorization inside `src/core/`, take the longer route and write real
+      records. `src/core/`'s zero-external-import discipline is what keeps the
+      Cloudflare runtime buildable and is not tradeable for a shortcut.
+
+### Week 2 — S2: drop-in for the reference server (days)
+
+The acquisition play. Ship as early as possible, because the kill criterion runs
+60 days after it lands and the point is to learn early whether the pool is real.
+
+- [ ] Serve the nine reference tool names alongside `titen_*`:
+      `create_entities`, `create_relations`, `add_observations`,
+      `delete_entities`, `delete_observations`, `delete_relations`,
+      `read_graph`, `search_nodes`, `open_nodes`.
+- [ ] Route `search_nodes` through Titen retrieval instead of a linear scan.
+- [ ] Import an existing `memory.json` on first run from `MEMORY_FILE_PATH` or
+      the working directory.
+- [ ] Document the swap as a one-line diff in an MCP config. Claim a lossless
+      substitute for a broken default; do not claim to beat the field.
+
+### Week 2, same push — S5: concurrent-writer durability suite (hours)
+
+S1 invites multiple agents onto one local SQLite file, so this cannot lag it.
+Correctness, not accuracy — it sits outside the refuted race.
+
+- [ ] Publish the invariants before running anything: exactly one claim per
+      canonical hash, zero lost observations, no partial write survives a failed
+      batch.
+- [ ] N concurrent writers with identical and overlapping content, on both
+      Bun/SQLite and D1 via the existing `test:d1` path.
+- [ ] Publish Titen's own violations first. Record a system lacking a primitive
+      as "primitive absent", never "fail".
+
+### Week 3 — S3: close the two provenance holes (days)
+
+Produces no visible feature, which makes it the first item cut under pressure.
+**Cutting it invalidates S4.**
+
+- [ ] Require `source.ref` on the HTTP write path. Breaking; ship as a minor
+      bump and say so.
+- [ ] `titen_compile` returns a server-issued context token; observations
+      written under it are stamped `source.type: recalled`, unforgeable by the
+      caller.
+- [ ] Reject or flag `recalled` observations at consolidation so the loop is
+      closed, not merely labelled.
+- [ ] Runnable check that fails if a forged `recalled` write is accepted.
+
+### Weeks 4-5 — S4: `titen audit` (days)
+
+The strategic payload, and the only item that still pays off if S2's pool turns
+out to be noise, because it runs against stores Titen does not own.
+
+- [ ] `npx titen-memory audit <path>` over `memory.json`, a Mem0 export, or a
+      Titen store.
+- [ ] Five counts, each with per-item evidence a skeptic can check by hand:
+      exact-duplicate, near-duplicate (same canonical hash), recall-loop,
+      secret-pattern, stale-since-write.
+- [ ] No network, no LLM, no upload. The report is a local file the user chooses
+      to share.
+- [ ] Publish Titen's own store's numbers — including whatever is embarrassing —
+      in the same commit that ships the tool.
+- [ ] Publish the detection rules before running them on anyone. Counterexamples
+      in the Jepsen shape; never a leaderboard, never a composite score.
+
+## Not in this plan
+
+The refusals in the spec's non-goals, plus the `memory_20250818` backend, which
+does not enter the queue until its trigger fires: S2 landed **and** either ≥10
+external MCP configs appear, or someone files a request for a serverless
+memory-tool backend.
+
+## Honest odds
+
+Shipping S1+S2+S5+S6: high. Kill criterion 1 passing: roughly a third. Three
+external `titen audit` write-ups by 2027-02-01: low, and it is the
+highest-variance, highest-value item — if it lands, Titen becomes the instrument
+rather than a competitor, which is a position nobody takes by shipping features.
+
+Most likely outcome: all six ship, all six work, and almost nobody notices. At
+that point the kill criteria fire and the correct answer is to stop investing
+and keep Titen as a well-built library its author uses. That costs about six
+weeks and leaves a smaller, more honest codebase behind.

--- a/docs/specs/active/2026-08-06-substitution-and-write-hygiene.md
+++ b/docs/specs/active/2026-08-06-substitution-and-write-hygiene.md
@@ -1,0 +1,130 @@
+---
+work_id: substitution-and-write-hygiene
+status: active
+stage: plan
+outcome: pending
+complexity: complex
+created: 2026-08-06
+updated: 2026-08-06
+owner: ramaaditya
+review_after: 2026-08-20
+---
+
+# Stop competing on retrieval; become the substitute and the instrument
+
+## Problem
+
+The 2026-08-04/06 benchmark programme settled what Titen can and cannot claim,
+and the answer removes the strategy the project was implicitly pursuing.
+
+Retrieval accuracy is refuted as a wedge. Titen FTS+vector beats a
+hundred-line dense control (35/12/453, p = 0.0011) but is indistinguishable from
+Mem0's LLM-free mode (3/4/53, p = 1.0), and answer accuracy is a flat null across
+eight pre-registered comparisons. At the top of this table everyone is inside
+everyone else's noise.
+
+The assets assumed to be uncontested are not. A competitor publishes Titen's
+governance differentiators by name in an arXiv paper with a university co-author
+and has ~45x the stars. The 2026 concurrency literature argues against leases,
+and zero issues across mem0, Letta, or Cognee request locking primitives. A
+5,873-star single Go binary tells the zero-dependency story with better
+packaging than a Bun runtime and a `pnpm install`.
+
+Two things survive that subtraction.
+
+**A substitution gap.** `@modelcontextprotocol/server-memory` takes ~441,501
+downloads a month while Anthropic's own README calls it "an educational
+reference implementation, not production-ready software". We measured it at
+recall@1 0.050 against Titen's 0.900 — the only non-noise gap in the entire
+programme. Its whole state is one `memory.json` behind nine named tools, which
+makes replacing it a substitution, not a race. But Titen currently demands
+*more* setup than the thing it outperforms: `src/runtime/bun/mcp-stdio.ts:44`
+throws without `TITEN_MCP_URL` and `TITEN_API_KEY`.
+
+**An unmeasured failure mode.** The most frequently reported pain in agent
+memory is write-side accumulation, not retrieval. The one public audit found
+97.8% of 10,134 entries were junk after 32 days, over half of it the system
+re-extracting its own recalled output. Upgrading the extraction model moved that
+only to 89.6%. No benchmark measures it, and Titen's mandatory-provenance write
+path is shaped to constrain exactly that mechanism — but the claim is currently
+unprovable, because provenance is caller-declared and unverified.
+
+## Non-goals
+
+Recorded so they are refused deliberately rather than drifted into.
+
+- Any further retrieval or answer-accuracy lane. Both are refuted by our own
+  pre-registered measurements.
+- More governance, federation, or org-hierarchy code. 2,210 lines already aim at
+  a procurement process that will not open for a 9-star repo with no audit.
+- More coordination primitives, and leases as a headline anywhere. Keep the
+  code; never lead with it.
+- "Zero dependencies" as the acquisition pitch. It is a supporting fact for the
+  deployment envelope, not a wedge.
+
+## EARS acceptance criteria
+
+- **AC-SUB-001 — Event-driven:** When `npx titen-memory mcp` is invoked with no
+  environment configured, Titen shall create or open a local store, provision a
+  real organization, workspace, project and owner principal as ordinary rows,
+  and serve MCP over stdio without an HTTP hop, an API key, or an outbound
+  network call.
+- **AC-SUB-002 — Unwanted-behaviour:** If auto-provisioning cannot satisfy
+  `assertTrustCeiling` or the authorization predicates honestly, then Titen
+  shall write the real records rather than special-case them, and
+  `src/core/**` shall retain zero external imports.
+- **AC-SUB-003 — Event-driven:** When a caller invokes any of the nine
+  `@modelcontextprotocol/server-memory` tool names, Titen shall serve them
+  against observations and claims, with `search_nodes` routed through Titen
+  retrieval rather than a linear scan.
+- **AC-SUB-004 — Event-driven:** When a `memory.json` is present at
+  `MEMORY_FILE_PATH` or in the working directory on first run, Titen shall
+  import it without data loss.
+- **AC-PROV-001 — Ubiquitous:** Titen shall require `source.ref` on the HTTP
+  write path, matching the obligation the MCP tool spec already states.
+- **AC-PROV-002 — Event-driven:** When an observation is written while carrying
+  a context token issued by `titen_compile`, Titen shall stamp it with a
+  server-assigned `source.type` of `recalled` that the caller cannot forge or
+  override.
+- **AC-PROV-003 — Unwanted-behaviour:** If a caller submits an observation
+  declaring `recalled` provenance it was not issued, then Titen shall reject the
+  write, and a runnable check shall fail if such a write is accepted.
+- **AC-AUDIT-001 — Event-driven:** When `titen audit <path>` is run against a
+  `memory.json`, a Mem0 export, or a Titen store, Titen shall report
+  exact-duplicate, near-duplicate, recall-loop, secret-pattern, and stale rates,
+  each with per-item evidence, without any network call or upload.
+- **AC-AUDIT-002 — Unwanted-behaviour:** If a store lacks the signal a metric
+  needs, then Titen shall report it as "not measurable from this export" and
+  shall not report it as a failure or fold it into a composite score.
+- **AC-DUR-001 — Event-driven:** When N writers concurrently submit identical
+  and overlapping content on either runtime, Titen shall hold exactly one claim
+  per canonical hash, lose zero observations, and leave no partial write from a
+  failed batch.
+
+## Falsification
+
+Written before the work so it cannot be rationalised afterwards. Each is
+checkable by a hostile third party using public tools.
+
+- **2026-11-01, 60 days after substitution ships.** Fewer than 10 distinct
+  non-maintainer GitHub accounts with `titen-memory` in a committed MCP config
+  kills the substitution play. The response is to stop investing in
+  distribution and say publicly that the download pool was noise.
+- **90 days after the audit tool ships.** Fewer than 5 distinct external runs
+  and zero published numbers kills the write-hygiene wedge. The honest
+  conclusion is then that Titen is a well-engineered library with no market.
+- **Continuous.** If Anthropic ships ranked search in the reference server, or a
+  lighter competitor ships the nine tool names and `memory.json` import first,
+  or any incumbent publishes their own junk-rate audit, the corresponding play
+  is foreclosed and we say so rather than argue methodology.
+
+If all three read zero by 2027-02-01, the correct output is a written
+post-mortem stating the category cannot be entered from here — not a v0.7
+roadmap.
+
+## Evidence
+
+Measured results in [`docs/testing/EVALS.md`](../../testing/EVALS.md) and
+published at [titen.dev/benchmark](https://titen.dev/benchmark). Landscape survey
+in
+[`docs/research/2026-08-04-memory-agent-landscape.md`](../../research/2026-08-04-memory-agent-landscape.md).


### PR DESCRIPTION
Paired spec and plan under `docs/specs/active/` and `docs/plans/active/`, so this is a decision with falsification criteria rather than a mood. Six work items filed as #278-#283.

## The uncomfortable part

**Retrieval is refuted as a wedge** — by our own pre-registered measurements. The win over a hundred-line control is real (p = 0.0011), but Titen is *indistinguishable* from Mem0's LLM-free mode (p = 1.0), and answer accuracy is a flat null across eight comparisons.

**The assets assumed uncontested are not.** A competitor publishes our governance differentiators by name in an arXiv paper with a university co-author, at ~45x our stars. The 2026 concurrency literature argues *against* leases, and zero issues across mem0/Letta/Cognee request locking primitives. A 5,873-star single Go binary tells the zero-dependency story with better packaging than a Bun runtime plus `pnpm install`.

## What survives

**A substitution gap.** `@modelcontextprotocol/server-memory` takes ~441k downloads/month, its own README calls it "not production-ready", we measured it at recall@1 **0.050** against our 0.900 — the only non-noise gap in the programme — and its entire state is one `memory.json` behind nine tool names. That is a substitution, not a race.

**An unmeasured failure mode.** Write-side rot: **97.8% junk** in the one public audit of 10,134 entries, over half of it the system re-storing its own recalled output. No benchmark, no incumbent, and our mandatory-provenance write path is shaped to constrain exactly that mechanism — though the claim is currently unprovable, which is why S3 exists.

## The plan

Make switching free (S1, S2), make the provenance claim true *before* making it (S3), then ship the instrument that measures rot in stores we do not own (S4). Plus durability proof (S5) and registry listing (S6). All hours or days.

## Non-goals, written down

No further retrieval lane. No more governance code. No coordination primitives as a headline. "Zero dependencies" demoted from wedge to supporting fact. Refusing well is most of strategy.

## Falsification, fixed in advance

Including the outcome where the honest result is a post-mortem saying the category cannot be entered from here — not a v0.7 roadmap.