### PR TITLE
feat: zero-config local mode, reference-server compatibility, server-issued provenance, and titen audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ between 10³ and 10⁵ claims on a synthetic corpus, one process saturates one c
 at 10k claims, there is no reranking stage, and no external suite scores the
 governance and collaboration primitives at all.
 
+## Audit any agent memory store
+
+Every published memory benchmark measures retrieval on a corpus somebody
+curated. The failure people actually report is on the write side: a store fills
+with copies of its own output. The one public audit of a production store found
+97.8% of 10,134 entries were junk after 32 days. Nothing measures that.
+
+```sh
+npx titen-memory audit ~/.titen/memory.db        # a Titen store
+npx titen-memory audit ./memory.jsonl            # @modelcontextprotocol/server-memory
+npx titen-memory audit ./mem0-export.json --json # a Mem0 export
+```
+
+Five counts — exact duplicate, near duplicate, recall loop, secret pattern,
+stale — each with per-item evidence you can check by hand. **No network, no
+model, no upload:** it opens the path read-only and prints a report; sharing it
+is your decision. A store that lacks the signal a metric needs is reported as
+*not measurable from this export*, never as a failure. There is no composite
+score and there is no leaderboard.
+
+The detection rules are published in
+[audit rules](https://github.com/RamaAditya49/titen/blob/main/docs/reference/audit.md).
+Titen's own numbers — including 17.9% duplicates and 96.7% stale in its own
+store, and a compatibility-surface defect the tool found in Titen itself — are in
+[the self-report](https://github.com/RamaAditya49/titen/blob/main/docs/testing/2026-08-07-titen-audit-self-report.md).
+
 ## Project status
 
 **Titen is pre-1.0.** Per [SemVer clause 4](https://semver.org/spec/v2.0.0.html#spec-item-4),
@@ -292,6 +318,11 @@ variables above:
 
 The bridge keeps no state. It only forwards newline-delimited MCP messages to
 the authenticated HTTP endpoint.
+
+Titen is not listed in the official MCP registry yet, so no client will offer it
+from a built-in directory — configure it by hand as above. The manifest and the
+manual publishing procedure are in
+[MCP registry listing](https://github.com/RamaAditya49/titen/blob/main/docs/deployment/mcp-registry.md).
 
 ### 4. Prove the connection
 
@@ -526,6 +557,8 @@ for private Tailscale Serve access or Cloudflare Tunnel protected by Access.
 | [VPS deployment](https://github.com/RamaAditya49/titen/blob/main/docs/deployment/vps.md) | Bun, containers, persistence, and hardening |
 | [Cloudflare deployment](https://github.com/RamaAditya49/titen/blob/main/docs/deployment/cloudflare.md) | Worker and D1 setup |
 | [Secure dashboard ingress](https://github.com/RamaAditya49/titen/blob/main/docs/deployment/secure-ingress.md) | Tailscale Serve or Cloudflare Tunnel with Access |
+| [MCP registry listing](https://github.com/RamaAditya49/titen/blob/main/docs/deployment/mcp-registry.md) | Publishing `server.json` to the official MCP registry |
+| [Audit rules](https://github.com/RamaAditya49/titen/blob/main/docs/reference/audit.md) | How `titen audit` counts duplicates, recall loops, secrets, and staleness |
 | [Roadmap](https://github.com/RamaAditya49/titen/blob/main/docs/ROADMAP.md) | Evidence-based maturity and planned work |
 | [Documentation index](https://github.com/RamaAditya49/titen/blob/main/docs/README.md) | Product, engineering, security, and research docs |
 

--- a/docs/deployment/mcp-registry.md
+++ b/docs/deployment/mcp-registry.md
@@ -1,0 +1,213 @@
+# Official MCP registry listing
+
+Status: **manifest authored and schema-validated, not published.** As of
+2026-08-07 the official registry returns nothing for Titen:
+
+```console
+$ curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=titen"
+{"servers":[],"metadata":{"count":0}}
+```
+
+[`server.json`](../../server.json) in the repository root is the manifest that
+fixes that. It is complete and valid against today's schema, but publishing it
+is blocked on two things a maintainer must do by hand — see
+[Before you can publish](#before-you-can-publish).
+
+The registry stores **metadata only**. It never hosts the package; it points at
+`titen-memory` on npm and at this repository. Listing Titen adds a discovery
+entry to the index that MCP host applications and third-party directories read.
+It changes nothing about how Titen runs.
+
+Publishing is manual, from a maintainer's machine, exactly like the [npm
+release](../engineering/release.md). This repository runs **no GitHub Actions**;
+the registry's own GitHub Actions publishing path is deliberately not used.
+
+## Before you can publish
+
+Two hard prerequisites. Neither can be satisfied by editing `server.json`.
+
+### 1. `package.json` must carry `mcpName`, and that must reach npm
+
+The registry proves package ownership by fetching
+`https://registry.npmjs.org/titen-memory/<version>` and comparing its `mcpName`
+field to the `name` in `server.json`. The comparison is exact, including case.
+No published version of `titen-memory` has the field today:
+
+```console
+$ curl -s https://registry.npmjs.org/titen-memory/0.6.1 | jq .mcpName
+null
+```
+
+So `package.json` needs one added line, and it only counts once a release
+carrying it is on npm — the registry reads npm, not this repository:
+
+```diff
+   "name": "titen-memory",
+   "version": "0.6.1",
++  "mcpName": "io.github.RamaAditya49/titen-memory",
+   "description": "...",
+```
+
+### 2. `titen mcp` must run with no environment
+
+`server.json` describes `npx -y titen-memory@<version> mcp` as a stdio server
+whose environment variables are all optional. On `0.6.1` that is not yet true:
+
+```console
+$ npx -y titen-memory@0.6.1 mcp
+error: TITEN_MCP_URL and TITEN_API_KEY are required
+```
+
+Publishing before zero-config local mode ships would put a listing in a public
+index that fails on first launch for everyone who installs it. Do not publish a
+version older than the one where `titen mcp` opens a local store on its own.
+
+## Proving ownership of the namespace
+
+The namespace in `server.json`'s `name` is not free-form — it must be one the
+registry watches you prove. Titen's manifest uses `io.github.RamaAditya49/`,
+which is proven by a GitHub device-code login and needs no key material and no
+DNS change.
+
+| Method | Name must start with | What proves it |
+| --- | --- | --- |
+| GitHub (**in use**) | `io.github.RamaAditya49/` | `mcp-publisher login github`, device code in the browser |
+| DNS | `dev.titen/` | Ed25519 or ECDSA-P384 keypair, `v=MCPv1; …` TXT record on `titen.dev` |
+| HTTP | `dev.titen/` | The same keypair, served at `https://titen.dev/.well-known/mcp-registry-auth` |
+
+The GitHub namespace is the login **as GitHub spells it**. The registry grants
+`io.github.RamaAditya49/*` and matches it with a case-sensitive prefix
+comparison, so `io.github.ramaaditya49/titen-memory` would be rejected with a
+403 even though it is the same account.
+
+`dev.titen/memory` is the nicer name and matches the homepage, but it costs a
+keypair the maintainer then has to keep, plus a DNS record. It is not worth it
+for a first listing. If it is ever wanted, the [authentication
+guide](https://modelcontextprotocol.io/registry/authentication) has the exact
+`openssl` incantations — and note that switching namespaces creates a **second,
+unrelated server entry**. Registry entries are immutable apart from their status
+field; a name is not renameable.
+
+## Validate before touching credentials
+
+The registry exposes an unauthenticated validation endpoint. Run this after any
+edit to `server.json`:
+
+```console
+$ curl -s -X POST https://registry.modelcontextprotocol.io/v0/validate \
+    -H 'content-type: application/json' --data-binary @server.json | jq .
+{
+  "valid": true,
+  "issues": []
+}
+```
+
+A malformed manifest answers `422` naming the offending field:
+
+```console
+$ jq '.name = "titen/Bad Name"' server.json | curl -s -X POST … --data-binary @-
+{"title":"Unprocessable Entity","status":422,"detail":"validation failed",
+ "errors":[{"message":"expected string to match pattern ^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+            "location":"body.name","value":"titen/Bad Name"}]}
+```
+
+This checks the schema and the registry's semantic rules. It does **not** check
+package ownership — `server.json` validates today even though `titen-memory` has
+no `mcpName` on npm. Ownership fails later, at publish.
+
+## Publish
+
+Run from the repository root, after the two prerequisites above hold.
+
+1. **Release to npm first.** The registry validates against a version that
+   already exists on npm, so follow [release](../engineering/release.md) to the
+   end before starting here.
+
+2. **Set all three versions to the version you just published.** They must
+   agree: `package.json` `version`, `server.json` `version`, and
+   `server.json` `packages[0].version`. A version string may be published to
+   the registry only once, and cannot be edited afterwards.
+
+3. **Validate**, using the `curl` above. Fix anything it reports.
+
+4. **Install `mcp-publisher`** (a single Go binary; Homebrew also has it):
+
+   ```bash
+   curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+     | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+   ```
+
+   Do **not** run `mcp-publisher init`. It generates a template `server.json`
+   and would overwrite the one in this repository.
+
+5. **Authenticate.** Opens a device-code flow; the account must be
+   `RamaAditya49`:
+
+   ```bash
+   mcp-publisher login github
+   ```
+
+6. **Publish:**
+
+   ```bash
+   mcp-publisher publish
+   ```
+
+   Expected output names the server and version:
+
+   ```text
+   ✓ Successfully published
+   ✓ Server io.github.RamaAditya49/titen-memory version <version>
+   ```
+
+7. **Verify** — the entry is queryable the moment publish returns:
+
+   ```bash
+   curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=titen" | jq '.metadata.count'
+   curl -s "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.RamaAditya49%2Ftiten-memory/versions/latest" | jq '.server.version'
+   ```
+
+   The path segment must be URL-encoded; the `/` in the server name is `%2F`.
+
+### If publish fails
+
+| Message | Cause |
+| --- | --- |
+| `missing required 'mcpName' field` | Prerequisite 1. The released npm version does not carry it. Adding it to this repository is not enough — publish a new npm version. |
+| `ownership validation failed. Expected mcpName 'X', got 'Y'` | `mcpName` and `server.json` `name` disagree, often only in case. |
+| `You do not have permission to publish this server` | The namespace does not match the authenticated account. Check the capitalisation of `RamaAditya49`. |
+| `Invalid or expired Registry JWT token` | Re-run `mcp-publisher login github`. |
+
+## Propagation
+
+There are three different delays, and only the first is the registry's:
+
+- **The official registry: none.** The entry is served by the API as soon as
+  `publish` returns, which is why step 7 verifies immediately.
+- **Third-party directories and MCP host applications: about an hour, often
+  longer.** They are downstream aggregators that scrape
+  `GET /v0.1/servers` on their own schedule; the registry documents an expected
+  cadence of roughly once per hour and offers no guarantee. Nothing on our side
+  makes this faster.
+- **DNS authentication only: minutes to hours** for the TXT record to propagate
+  before `mcp-publisher login dns` will succeed. Not applicable to the GitHub
+  method this manifest uses.
+
+Do not treat a successful publish as a discovery result. It adds one row to an
+index that already holds thousands of servers; that is a precondition for being
+found, not evidence of being found.
+
+## Updating a listing
+
+Publish a new version. Existing versions are immutable — the registry stores
+each version separately and marks the highest semantic version `latest`. There
+is no edit, and no way to fix a typo in a published entry other than superseding
+it.
+
+## Reference
+
+- [Publishing quickstart](https://modelcontextprotocol.io/registry/quickstart)
+- [Authentication methods](https://modelcontextprotocol.io/registry/authentication)
+- [Package types and ownership verification](https://modelcontextprotocol.io/registry/package-types)
+- [Schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json)
+  (`$schema` in `server.json` pins this dated version)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -280,11 +280,39 @@ Visibility defaults to `private`. `team` requires `workspace_id` and an active
 non-reader membership; this predicate is applied before retrieval, export,
 events, Atlas limits/counts, and webhook delivery.
 
+`source.type` and `source.ref` are both **required**. `source.ref` became
+mandatory in 0.6.0, matching the obligation the MCP `titen_remember` tool spec
+already stated; a write without it returns `400 VALIDATION_ERROR`. Existing rows
+stored before 0.6.0 may still have a null `source_ref` and are unaffected.
+
 `source.id` is an optional stable source-event identity. Re-ingesting the exact
 same normalized observation with that ID converges on the original canonical
 record even after the request `Idempotency-Key` expires. Reusing the ID with
 different content or scope creates a distinct canonical hash; `source.ref`
 remains a provenance pointer and is not treated as a uniqueness key.
+
+#### Recalled provenance
+
+`recalled` is a reserved, server-assigned `source.type`: it marks content Titen
+itself handed back through a context pack, which is the write that turns a
+memory store into an echo chamber. A caller may never author it.
+
+- Declaring `"source": {"type": "recalled"}` returns `400 VALIDATION_ERROR`.
+- Passing the optional top-level `context_token` from a
+  [`POST /v1/context/compile`](#post-v1contextcompile) response stamps the
+  stored row with `source_type` `recalled`, **overriding** whatever
+  `source.type` the caller declared.
+- A `context_token` that was not issued to this principal — unknown, foreign
+  organization, or another actor without a live handoff — returns
+  `400 VALIDATION_ERROR` rather than being ignored. Silently downgrading an
+  unrecognized token would record a recalled write as fresh input, which is the
+  exact mislabelling this rule exists to prevent.
+- A `recalled` observation cannot be cited as claim evidence:
+  `POST /v1/consolidations` refuses it with `400 VALIDATION_ERROR`, so the loop
+  is closed rather than merely labelled.
+
+The token is verified against the stored context run and the same read boundary
+`GET /v1/context/:id` enforces. It is opaque; do not parse it.
 
 ### `DELETE /v1/observations/:id`
 
@@ -381,6 +409,13 @@ scope reports the normalized `as_of` instant. The response includes selected cla
 evidence IDs, trust, temporal validity, conflicts, score components, token usage,
 and a `context_id`. Each item carries `untrusted: true`; this is structured
 provenance for the caller, not an instruction-enforcement claim.
+
+The response also carries `context_token`, a server-issued opaque token for this
+run. Pass it as `context_token` on any `POST /v1/observations` derived from this
+pack and the write is stamped `recalled`; see
+[recalled provenance](#recalled-provenance). It is what makes a recall loop a
+server verdict instead of a self-report, so a recall-loop rate measured from
+Titen's own store is checkable rather than caller-declared.
 
 Project scope is fail-closed:
 
@@ -925,8 +960,10 @@ dependencies; an optional browser renderer is never a service-readiness gate.
 
 ## MCP surface
 
-The implemented `/mcp` endpoint exposes nine wire tools in eight ordinary-agent
-families:
+The implemented `/mcp` endpoint exposes nine native wire tools in eight
+ordinary-agent families, plus the nine
+[reference-server compatibility](#reference-memory-server-compatibility) names
+below, for eighteen tools in `tools/list`:
 
 - `titen_project_resolve`;
 - `titen_remember`;
@@ -954,6 +991,91 @@ conservative when a tool can mutate or is idempotent only with an optional key.
 credential needs ordinary `mcp:call` authority and the separate
 `context:compile:all` capability for that flag; omitting the flag and
 `project_id` remains unscoped-only.
+
+### Reference memory-server compatibility
+
+Titen also serves the nine tool names of
+`@modelcontextprotocol/server-memory` — `create_entities`, `create_relations`,
+`add_observations`, `delete_entities`, `delete_observations`,
+`delete_relations`, `read_graph`, `search_nodes`, `open_nodes` — with that
+server's argument shapes, response shapes, tool descriptions and annotations
+reproduced from its `src/memory/index.ts`. Each returns both the text content
+that server returns and the same object as `structuredContent`. The `titen_*`
+tools are unchanged; this is an addition, not a mode.
+
+Switching is one line of MCP configuration — replace the reference server's
+command with `npx -y titen-memory mcp` and keep the same tool vocabulary. No
+`outputSchema` is published for these tools, and the reference server's
+`memory://knowledge-graph` resource and its resource subscriptions are not
+served; tool calls are.
+
+**Adopting an existing store.** On the first local-mode start, `titen mcp`
+imports `MEMORY_FILE_PATH` if set, otherwise `./memory.jsonl`, otherwise
+`./memory.json`, in the reference server's newline-delimited JSON format.
+Import runs through these same MCP tools, reports its counts on stderr, and
+records the source path in `~/.titen/memory.db.imported` so a later start does
+not resurrect entities deleted since. A failed import leaves that marker
+unwritten and retries on the next start; entities are created before their
+observations are added, so a resumed import loses nothing. Lines that are
+neither an entity nor a relation are ignored as that server ignores them; a
+malformed entity or relation line fails the import rather than being dropped.
+
+**How the graph is stored.** Every record lives under the subject
+`knowledge_graph` with `private` visibility, so each principal has its own
+graph exactly as each client configuration had its own `memory.json`, and
+Titen's subject-scoped retrieval can search the whole graph in one pass:
+
+| Reference concept | Titen record |
+| --- | --- |
+| entity (`name`, `entityType`) | observation, `source_ref` `memory://entity`, `agent_id` the name, content the type |
+| entity observation string | observation, `source_ref` `memory://observation`, content verbatim |
+| relation (`from`, `to`, `relationType`) | observation, `source_ref` `memory://relation`, content the JSON triple |
+| — | one `semantic_fact` claim per entity and per observation, `"<name>: <text>"`, which is what `search_nodes` ranks |
+
+Those observations are canonical and round-trip exactly; the claims are a
+searchable projection, so a statement longer than the 4,000-character claim
+limit is truncated there while the observation keeps the full text.
+
+**`search_nodes` is the one tool that is not a reimplementation.** The
+reference server lower-cases the query and runs a substring scan over the whole
+graph re-read from disk, so a query phrased as a question matches nothing.
+Titen compiles the query through ordinary retrieval — stemmed FTS, ranking, and
+the vector index when one is configured — and returns entities best-first,
+bounded by the compiler's candidate and token ceilings rather than returning
+every substring hit. Relations still reach outside the matched set, as they do
+there. An empty query returns the whole graph, matching that server's
+`includes("")`. Each search records a context run, as `titen_compile` does.
+Relation text is not searched, which is also true of the server being replaced.
+
+**Deleting is a purge.** `delete_entities`, `delete_observations` and
+`delete_relations` purge the underlying observations: content becomes
+irrecoverable, the row's hash and history survive, and dependent claims are
+revoked. Those three tools require `observations:purge` in addition to
+`mcp:call`, so a credential that may write memory cannot destroy it by way of
+the compatibility surface.
+
+**Bounds that the reference server does not have.** Entity names and relation
+endpoints are limited to 200 characters, entity and relation types to 120, and
+observation text to 32,000; empty strings are rejected. Duplicate entity names
+inside one file or one call collapse to the first, where that server would
+write two nodes with the same name.
+
+### Local mode
+
+`titen mcp` (`npx titen-memory mcp`) with neither `TITEN_MCP_URL` nor
+`TITEN_API_KEY` set serves the same MCP surface over stdio against
+`~/.titen/memory.db`, creating that store on first run. It is an additional
+entry point, not a relaxation: the store is provisioned with an ordinary
+organization, workspace (`Local`), project (reference `local`) and owner
+principal, and every request is authenticated and authorized by the same core
+predicates a served deployment uses. The owner credential is a real API key row;
+its raw value is written once to `~/.titen/memory.db.key` with mode `0600` so a
+restart reuses one owner instead of minting a credential per process.
+
+Nothing listens on a socket, no request leaves the process, and no embedding
+provider is configured, so retrieval is lexical FTS only and
+`meta.degraded.vector` reports `disabled`. Setting exactly one of the two
+variables remains an error rather than a silent downgrade to the local store.
 
 The Streamable HTTP endpoint accepts JSON responses without server-side SSE.
 `GET /mcp` therefore returns `405`. A present `Origin` must match the request URL

--- a/docs/reference/audit.md
+++ b/docs/reference/audit.md
@@ -1,0 +1,204 @@
+# `titen audit` — write-hygiene detection rules
+
+Status: published before the tool was run against any store other than Titen's
+own. Every rule below is stated so that a reader can re-derive the count by hand
+from the same file, disagree with a rule, and discount exactly that rule without
+discarding the others.
+
+## What this measures, and what it refuses to measure
+
+Every published agent-memory benchmark measures retrieval on a corpus somebody
+curated. The failure people actually report is on the write side: a store fills
+with copies of its own output until it is worth less than no memory at all. The
+one public audit of a production store found 97.8% of 10,134 entries were junk
+after 32 days, over half of it the system re-extracting what it had just been
+handed back. Nothing measures that. This does.
+
+Three properties are load-bearing.
+
+**Nothing leaves the machine.** No network call, no model, no upload, no
+telemetry. `titen audit` opens the path read-only, reads it, and prints a report
+to stdout. `src/runtime/bun/audit.ts` imports exactly `node:fs`, Titen's own
+SQLite opener, its reference-store parser, `sha256Hex`, and two constants —
+nothing that can open a socket — so the promise is checkable by reading the
+import list, and `tests/integration/audit.test.ts` runs the installed CLI under
+a `fetch` that throws on any call. Whether the report is ever shared is the
+reader's decision.
+
+**A missing signal is reported as missing.** A store that records no provenance
+cannot have its recall-loop rate measured. Reporting `0` there would be a number
+that flatters the store, and reporting `fail` would be a number that smears it.
+Both are refused. The report says **"not measurable from this export"**, the
+JSON carries `"count": null` rather than `0`, and the reason names the missing
+signal.
+
+**No composite score, and no leaderboard.** The five counts measure five
+different things on five different denominators. Combining them would produce a
+number nobody can audit, and ranking stores by it would turn an instrument into
+a weapon — which is both dishonest and the fastest way to have the whole thing
+dismissed as vendor FUD. The JSON emits `"composite_score": null` explicitly.
+Counterexamples are published in the Jepsen shape: the store, the rule, the
+entry, the evidence.
+
+## Inputs
+
+| Shape | Detected by | Entries audited |
+| --- | --- | --- |
+| Titen store | `SQLite format 3\0` file header, then the `observations` table | one entry per observation |
+| `@modelcontextprotocol/server-memory` store | first non-empty line is JSON with `"type":"entity"` or `"type":"relation"` | one entry per observation string on an entity |
+| Mem0 export | the file parses as one JSON document containing `results`, `memories`, `data`, or `data.results` | one entry per record with a `memory`, `content`, or `text` field |
+
+Anything else is refused by name rather than audited as an empty store.
+
+Reference-server *relations* are structure, not free text, and are not counted
+as entries. Titen *claims* are not counted as entries either: this measures the
+write path, and in Titen every claim is derived from observations that are
+already counted.
+
+## Signals each shape carries
+
+A metric is measurable only where its signal exists.
+
+| Signal | Titen store | reference `memory.json(l)` | Mem0 export |
+| --- | --- | --- | --- |
+| entry text | yes | yes | yes |
+| write timestamp | `observations.ingested_at` | absent | `created_at` when present |
+| provenance the store assigned | `observations.source_type` | absent | absent |
+| what the store previously served | `context_runs` + `context_run_items` | absent | absent |
+| retrieval after write | same | absent | absent |
+
+Consequence: on a reference-server store and on a Mem0 export, **recall loop**
+and **stale** are reported as not measurable. That is a statement about the
+export format, not a defect in the product that produced it.
+
+## The five rules
+
+### 1. Exact duplicate
+
+Entries whose text is byte-identical to an earlier entry.
+
+- Group entries by their exact text.
+- A group of N identical entries contributes **N − 1** redundant entries.
+- Rate = redundant entries ÷ total entries.
+- Evidence per item: the redundant entry's locator, the locator of the first
+  copy, a short SHA-256 group id, and the text.
+
+### 2. Near duplicate
+
+Entries that survive canonicalization into the same string but are not
+byte-identical. Canonical form:
+
+1. Unicode NFKC normalization;
+2. lowercase;
+3. every run of characters that is neither a Unicode letter nor a digit
+   collapsed to a single space (`/[^\p{L}\p{N}]+/gu`);
+4. trim.
+
+Two entries are near duplicates when their canonical forms are equal and their
+raw texts are not. Within one canonical group, the first occurrence of each
+distinct raw text is kept and every later distinct text is counted, so exact
+duplicates are never counted twice across the two metrics.
+
+This is a hash-equality rule, not a similarity threshold. That is deliberate: a
+reader can reproduce it with `tr`, `sort` and `uniq`, and a threshold nobody can
+reproduce would sink the credibility of the whole report. It is a lower bound —
+paraphrases are not detected.
+
+**This is not Titen's `observations.canonical_hash` column.** That column mixes
+in the actor, subject, project, kind, provenance, trust and visibility, so two
+agents writing the same sentence get different canonical hashes there, by
+design. It is a replay key, not a duplicate detector, and using it here would
+report near-zero on every store including Titen's own.
+
+### 3. Recall loop
+
+Entries whose content came back out of the store before it was written back in.
+An entry counts when **either** of these holds:
+
+- the store itself assigned the entry provenance meaning *recalled*. In Titen
+  this is `source_type = 'recalled'`, which is stamped from a server-issued
+  context token and cannot be declared or overridden by the caller
+  (`src/core/observations.ts`); or
+- the entry's canonical text (rule 2) equals the canonical text of something the
+  store served back, and the serve is timestamped strictly before the entry's
+  write.
+
+Both mechanisms are named per item in the evidence, so a reader who trusts one
+and not the other can recount.
+
+Known ceilings, both in the direction of under-counting:
+
+- the stamp proves a write was made while holding a Titen-issued pack, not that
+  its content came out of that pack, and a caller that omits the token is not
+  stamped at all;
+- the text match catches verbatim and near-verbatim recall only. An agent that
+  rephrases what it read is invisible to both mechanisms.
+
+The number is therefore a **lower bound** on the recall loop and never an upper
+one.
+
+### 4. Secret pattern
+
+Entries containing a string matching a published credential pattern.
+
+| Rule | Pattern | Precision |
+| --- | --- | --- |
+| `aws_access_key_id` | `\bAKIA[0-9A-Z]{16}\b` | high |
+| `private_key_block` | `-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----` | high |
+| `github_token` | `\bgh[pousr]_[A-Za-z0-9]{36,}\b` | high |
+| `slack_token` | `\bxox[abprs]-[A-Za-z0-9-]{10,}\b` | high |
+| `google_api_key` | `\bAIza[0-9A-Za-z_-]{35}\b` | high |
+| `openai_style_key` | `\bsk-(?:[A-Za-z0-9]+-)?[A-Za-z0-9_-]{20,}\b` | high |
+| `jwt` | `\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b` | high |
+| `url_basic_auth` | `\b[a-z][a-z0-9+.-]*:\/\/[^\s/:@]+:[^\s/@]+@` | high |
+| `assigned_credential` | `\b(?:pass(?:word\|wd)?\|secret\|api[_-]?key\|access[_-]?token\|token)\b\s*(?:[:=]\|\bis\b)\s*["']?([^\s"',;]{8,})` | **low** |
+
+An entry is counted once no matter how many patterns it matches. The report
+always breaks the total down per rule, so `assigned_credential` — the one rule
+that trades precision for the most common real case, an agent told a password in
+prose — can be discounted on its own.
+
+Nothing is validated against a provider, because that would be a network call.
+Every count here is a *candidate*.
+
+**The report never reproduces what it found.** Matches are masked to their first
+four characters and a length (`AKIA…(20 chars)`), and the masking is applied to
+every quoted excerpt in the whole report, so a duplicate finding cannot leak a
+credential the secret rule already redacted.
+
+### 5. Stale
+
+Entries with no recorded retrieval after they were written.
+
+In a Titen store an observation counts as recalled when a claim it supports
+appeared in a context pack compiled strictly after the observation was written
+(`claim_sources` → `context_run_items` → `context_runs.created_at`). Direct
+evidence reads are not logged per record, so this is an **upper bound**: an
+entry read through `GET /v1/claims/:id/evidence` and never through a pack still
+counts as stale.
+
+A store whose retrieval log exists but is empty is measurable, and the honest
+answer there is 100% stale. A store with no retrieval log at all is not
+measurable.
+
+## Usage
+
+```
+titen audit <path> [--json]
+```
+
+`--json` emits the machine-readable report, including **every** finding; the
+text report shows the first ten per metric. Neither writes a file: redirect it
+where you want it.
+
+```
+npx titen-memory audit ~/.titen/memory.db
+npx titen-memory audit ./memory.jsonl --json > audit.json
+```
+
+## If you publish a result
+
+Publish the rule alongside the number, publish the counterexamples, and publish
+your own store's numbers before anyone else's. Titen's own are in
+[`docs/testing/2026-08-07-titen-audit-self-report.md`](../testing/2026-08-07-titen-audit-self-report.md),
+including the parts that do not flatter it.

--- a/docs/testing/2026-08-07-durability.md
+++ b/docs/testing/2026-08-07-durability.md
@@ -1,0 +1,290 @@
+# Concurrent-writer durability
+
+Date: 2026-08-07
+
+Verdict: **the canonical write path holds all three invariants on both runtimes,
+and Titen's own MCP compatibility surface violates the first one**
+
+Three invariants were written down before anything was run. Two runtimes and
+three lanes were then measured against them, and each invariant was falsified on
+purpose by removing the primitive that upholds it, so that a passing result means
+something. The canonical path — `POST /v1/observations` and
+`POST /v1/consolidations` — held every invariant in every lane. The reference-server
+compatibility surface added for the substitution play does not: six concurrent
+identical `create_entities` calls leave six permanent copies. That is published
+here first, before any result that flatters us.
+
+This is a correctness claim, not an accuracy claim. Nothing in this document
+touches retrieval quality, and none of it should be read as a ranking result.
+
+## The invariants, declared before the run
+
+- **I1 — exactly one claim per canonical hash.** N writers submitting
+  byte-identical content converge on one record identity. A duplicate here is
+  permanent damage: nothing downstream removes it, and every later read pays for
+  it. Scoped, precisely, to `(org_id, actor_id, canonical_hash)` — see
+  "Where the primitive is absent".
+- **I2 — zero lost observations.** Every concurrent submission either creates its
+  record or replays the record that won. No submission returns success without a
+  durable row, and every distinct payload survives the burst.
+- **I3 — no partial write survives a failed batch.** A write whose batch fails
+  leaves no observation, no FTS projection, no history row, no event, no outbox
+  work and no idempotency receipt behind.
+
+A system that has no primitive for one of these is recorded as **primitive
+absent**, never as "fail". The distinction is used below, and it applies to
+Titen: one input shape has no canonical hash at all, and that is reported as
+absence rather than as a failure to dedup.
+
+## What the invariants are testing
+
+`src/core/db.ts:4` states the structural position, and it was verified rather
+than assumed:
+
+> D1 has no interactive transactions, so every atomic write in Titen is expressed
+> as a statement batch that the driver commits all-or-nothing.
+
+The consequence is that dedup cannot be a networked read-then-write. It is a
+partial unique index — `observations_canonical_replay` and
+`claims_canonical_replay`, added in migration 15 (`src/core/migrations.ts:1333`)
+— evaluated by the database inside the same atomic batch as the insert.
+
+There *is* a read-then-write check in front of it
+(`src/core/observations.ts:123`, `src/core/claims.ts:224`). It is a fast path,
+not the safety mechanism. When it loses the race, the batch fails on the unique
+index and the handler re-reads the winner and replays it
+(`src/core/observations.ts:242`, `src/core/claims.ts:374`). The falsification
+section below removes the index and shows the fast path alone is worth nothing
+under concurrency.
+
+## Locked method
+
+| Field | Value |
+| --- | --- |
+| system under test | `titen-memory` 0.6.1, commit `5470a048748396503d6d33e1fab7feec27765f39`, plus the two test files below |
+| shared assertions | `tests/contract/durability.ts`, SHA-256 `a79647c6a56ee6850cc64631bb6b68ea3d24105cb1c7bdaf149146cf1dc7b444` |
+| Bun lanes | `tests/integration/durability.test.ts`, SHA-256 `46261bbbe7b8df44979547450294a2f257bd9f35fa247f80e447002c04ae0e43` |
+| D1 lane | `tests/contract/cloudflare-d1.test.ts`, last case, via `pnpm test:d1` |
+| Bun host | Bun 1.3.13, AMD Ryzen AI 9 HX 370, 24 threads, Linux 7.0.0-28-generic, NVMe |
+| D1 host | `rama-tuf`, Bun 1.3.14 / Node v24.18.0, workerd via Miniflare, AMD Ryzen 9 8945H, 16 threads, Linux 7.0.12-201.fc44 |
+| lane | FTS-only. No embedding provider, no vector store, no extraction model. |
+
+The compatibility-surface finding was measured against the same checkout with
+the in-flight MCP substitution work applied but not committed:
+`src/core/mcp.ts`, SHA-256
+`0a800e0234f2ce88da43bc8279ddb802684c07a19e13164510b991809dddda2a`. It is
+therefore a finding about work in progress, reported early because that is when
+it is cheap to fix, and it is not a statement about any released version.
+
+Three lanes, because one of them is weaker than it looks:
+
+1. **Bun, in process.** Six app instances over one `bun:sqlite` connection,
+   twenty-four concurrent observation submissions across four payloads, then six
+   concurrent identical consolidations.
+2. **Bun, across processes.** Eight operating-system processes, separate
+   connections, one WAL file — the shape zero-config local mode creates when
+   several agents share `~/.titen/memory.db`. A wall-clock barrier per payload
+   aligns the first touch of each one across all eight processes.
+3. **Cloudflare D1.** The same shared assertions from lane 1, against a real
+   `workerd` D1 database through the driver in
+   `src/runtime/cloudflare/d1.ts`.
+
+## Results
+
+Every lane holds I1, I2 and I3. No submission was rejected in any lane.
+
+| Lane | Writers | Requests | Rows created | Replays | Failures | Rows left by the failed batch |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Bun, in process — observations | 6 | 24 | 4 | 20 | 0 | 0 |
+| Bun, in process — consolidations | 6 | 6 | 1 | 5 | 0 | 0 |
+| Bun, 8 processes — observations | 8 | 104 | 20 | 84 | 0 | not run in this lane |
+| Cloudflare D1 — observations | 6 | 24 | 4 | 20 | 0 | 0 |
+| Cloudflare D1 — consolidations | 6 | 6 | 1 | 5 | 0 | 0 |
+
+Row counts were checked against the database, not against the responses: for the
+in-process and D1 lanes, four observations, four distinct canonical hashes, four
+FTS rows, four history rows and four `observation.appended` events, from
+twenty-four concurrent submissions; one claim, one claim source, one claim FTS
+row and one history row from six. The cross-process lane leaves twenty rows —
+twelve shared payloads plus one private payload per process — with twenty
+distinct canonical hashes and twenty FTS and history rows, from 104 requests.
+I3 is asserted by snapshotting six table counts before a deliberately broken
+batch and re-reading them after.
+
+### Did the race actually open?
+
+A durability suite that never provokes the race proves nothing, so every lane
+counts the batches the unique index rejected. This number is instrumentation,
+not an assertion.
+
+| Lane | Canonical collisions observed |
+| --- | --- |
+| Bun, in process — observations | **0** |
+| Bun, in process — consolidations | 5 of 5 possible |
+| Bun, 8 processes — observations | 2, 6, 8, 13, 14, 15 across six runs |
+| Cloudflare D1 — observations and consolidations | 25 of 25 possible |
+
+The zero is the honest part. On `bun:sqlite`, twenty-four concurrent observation
+submissions issued from one event loop **serialise**: tracing the driver shows
+writer 0 completing its select *and* its insert before writer 1's select runs.
+The in-process Bun lane therefore exercises the fast path for observations, not
+the race, and it would pass even with the unique index removed. It is reported
+as a weaker result rather than folded into a pass.
+
+Consolidations do race in the same lane — all five losers collided — and on D1
+every possible collision occurred, because each `all()` there is a real round
+trip into `workerd` and the requests genuinely interleave. The cross-process Bun
+lane is the one that matters for local mode, and it opens the window between two
+and fifteen times per run depending on scheduling.
+
+## Falsification: removing the primitive
+
+Each invariant was re-run with the mechanism that upholds it removed. A suite
+that cannot fail is not evidence.
+
+| Removed | Lane | Result |
+| --- | --- | --- |
+| `observations_canonical_replay`, `claims_canonical_replay` | Bun, in process | **I1 violated** — six concurrent consolidations minted six claims |
+| `observations_canonical_replay` | Bun, 8 processes | **I1 violated** — shared payload 0 minted four identities |
+| both indexes | Cloudflare D1 | **I1 violated** — six concurrent writers minted six identities for one payload |
+| batch atomicity (each statement committed on its own) | Bun, in process | **I3 violated** — the failed batch left rows behind |
+
+The D1 result is the load-bearing one. It is the mem0 duplicate class reproduced
+exactly — concurrent writers, identical content, a read-then-write check in
+front, permanent duplicates behind — and the only difference between the failing
+run and the passing one is a partial unique index evaluated inside the atomic
+batch.
+
+## Titen's own violation: the MCP compatibility surface
+
+Publishing this first was the rule set before the work started.
+
+The nine reference-server tool names added for the substitution play dedup
+entities, observations and relations by reading the graph and skipping what is
+already present (`loadCompatStore` in `src/core/mcp.ts`). The rows they write
+carry `source: { type, ref }` with **no `id`**, so `canonical_hash` is `NULL`
+(`src/core/observations.ts:107`) and the partial unique index does not apply to
+them. The read-then-write check is all there is.
+
+Measured, on the working tree named in the method table:
+
+| Call | Repetitions | Result |
+| --- | --- | --- |
+| `create_entities`, identical | 3 sequential | correct — one entity, one observation |
+| `add_observations`, identical | 3 sequential | correct — one observation |
+| `create_entities`, identical | 6 concurrent | **6 duplicate observations**, all `canonical_hash NULL` |
+| `add_observations`, identical | 6 concurrent | **6 duplicate observations** |
+| `create_relations`, identical | 4 concurrent | **4 duplicate relations** |
+
+No call returned an error. `read_graph` afterwards shows the entity carrying its
+single observation six times over, and nothing removes them later. Sequential
+use is clean, so this is a pure time-of-check-to-time-of-use race, not a broken
+filter.
+
+Two things make it worth fixing before the substitution ships rather than after.
+The reference server this path replaces deduplicates `add_observations` against
+the contents already on the entity, so a client that switches to Titen gets a
+*regression* on the one hygiene guarantee the incumbent does offer. And the whole
+premise of the write-hygiene wedge is that Titen does not mint the duplicates it
+proposes to audit for.
+
+The fix is structural and small: give the compat writes a stable `source.id`
+derived from the entity name and content, which is exactly the field the
+canonical path uses, and the same index that carries the three lanes above
+carries this one too. It was not applied here — `src/core/mcp.ts` belongs to the
+substitution work in flight, and a durability report is the wrong place to edit
+someone else's write path.
+
+This finding is deliberately **not** in the automated suite: landing a red test
+in a shared tree blocks the work that has to fix it. Reproduce it with the block
+at the end of this document.
+
+## Where the primitive is absent
+
+Not everything Titen writes has a canonical hash, and calling that a dedup
+failure would be dishonest. Two shapes, both measured:
+
+- **No `source.id`, no canonical hash.** `src/core/observations.ts:107` assigns
+  `canonical_hash` only when `source.id` is present. Six concurrent identical
+  writes without it produced six rows, all `canonical_hash NULL`, all `201`. This
+  is **primitive absent**, not a violation of I1 — there is no canonical hash for
+  a second row to collide with. It is also the mechanism behind the
+  compatibility-surface finding above, and it applies to any MCP caller that
+  omits `source_id`, which `titen_observe` accepts as optional.
+- **Dedup is per actor, not per organisation.** The index is
+  `(org_id, actor_id, canonical_hash)`. Two agents in one organisation writing
+  byte-identical content produce two rows, by design: provenance is per actor and
+  collapsing it would erase who observed what. I1 is scoped accordingly
+  throughout this document.
+
+## What this run does not show
+
+- **No incumbent was run.** No mem0, no reference server, no MemPalace. Every
+  number here is Titen's own. Nothing in this document is a comparison, and the
+  motivating claims about other projects' open issues were not re-verified here.
+- **No real Cloudflare.** The D1 lane is `workerd` under Miniflare against a
+  local D1 database — the same bundle `wrangler` deploys, but not the production
+  service, and not its distributed concurrency.
+- **One host per runtime, small N.** Six in-process writers, eight processes,
+  seconds of wall clock. No soak, no crash-injection, no power-loss test; `PRAGMA
+  synchronous = FULL` is trusted rather than demonstrated.
+- **No process-level I3.** The cross-process lane asserts I1 and I2 only. The
+  failed-batch invariant is asserted in the in-process and D1 lanes, where the
+  fault can be injected into a real write batch.
+- **The in-process Bun observation lane did not race.** Stated above; it is not
+  evidence about the unique index on that runtime.
+- **Canonical writes only.** Import, purge, lifecycle, governance, federation and
+  the enrichment queue have their own concurrency behaviour and are not covered.
+
+## Reproduce
+
+Invariant suite, from this checkout:
+
+```sh
+bun test tests/integration/durability.test.ts   # Bun, in process and across processes
+pnpm test:d1                                    # Cloudflare D1, last case
+```
+
+Both print a `[durability] {...}` line per lane with the counts in the results
+tables, including `canonical_collisions`.
+
+Falsify it — each of these must fail:
+
+```sh
+# I1: drop the index and re-run any lane
+#   await db.exec("DROP INDEX observations_canonical_replay")
+#   await db.exec("DROP INDEX claims_canonical_replay")
+# I3: replace the batch with per-statement commits
+#   for (const stmt of stmts) await db.batch([stmt])
+```
+
+The compatibility-surface violation, as measured:
+
+```ts
+import { openLocalStore } from "./src/runtime/bun/mcp-stdio";
+
+const local = await openLocalStore("/tmp/compat-probe.db");
+let id = 0;
+const callTool = async (name: string, args: unknown) =>
+  (await (await local.app(new Request("http://127.0.0.1/mcp", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${local.apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: (id += 1), method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  }))).json()) as any;
+
+const entity = {
+  entities: [{ name: "billing", entityType: "service", observations: ["Handles refunds"] }],
+};
+await Promise.all(Array.from({ length: 6 }, () => callTool("create_entities", entity)));
+const graph = (await callTool("read_graph", {})).result.structuredContent;
+console.log(graph.entities.find((e: any) => e.name === "billing").observations);
+// ["Handles refunds", "Handles refunds", "Handles refunds",
+//  "Handles refunds", "Handles refunds", "Handles refunds"]
+```

--- a/docs/testing/2026-08-07-titen-audit-self-report.md
+++ b/docs/testing/2026-08-07-titen-audit-self-report.md
@@ -1,0 +1,215 @@
+# `titen audit` run against Titen
+
+Date: 2026-08-07
+
+Verdict: **Titen's own store accumulates. 17.9% of it is byte-identical
+duplicates six seconds after it was written, 96.7% of it was never read back,
+and its `@modelcontextprotocol/server-memory` compatibility surface turns one
+entity into six.**
+
+The detection rules were published in
+[`docs/reference/audit.md`](../reference/audit.md) before this was run, and this
+is the first store the tool was run against. Nothing below is a ranking, nothing
+is combined into a score, and no number here is compared to another system.
+
+## The number that matters most is one Titen cannot report
+
+`~/.titen/memory.db` did not exist on the maintainer's machine when this was
+written. Neither did any other Titen database. The whole reason `titen audit`
+exists is a public audit that found 97.8% of 10,134 entries were junk after
+**32 days** of real traffic. Titen has no 32-day store, no 32-day user, and no
+way to fake one. Every number below comes from a store that is minutes old.
+
+So: nothing in this document bounds long-run accumulation, in Titen or in
+anything else. It shows the instrument works, and it shows two defects the
+instrument found in its own author's product. That is all it shows, and stating
+that plainly is the point of publishing it first.
+
+## Method
+
+| Field | Value |
+| --- | --- |
+| tool | `titen audit`, `src/runtime/bun/audit.ts`, SHA-256 `8dd9ee1e8cb6183c072c340a2a6d8c82b488ac242cc4725f1505908caef0720c` |
+| check | `tests/integration/audit.test.ts`, SHA-256 `b0bb2aaac49c4752829bfaf46b3c5c787c84441d5a26a56cab6d9c8e2b1c3ea8` |
+| base commit | `5470a048748396503d6d33e1fab7feec27765f39`, plus the in-flight zero-config, compatibility, provenance and durability work not yet committed |
+| host | Bun 1.3.13, AMD Ryzen AI 9 HX 370, Linux 7.0.0-28-generic, NVMe |
+| lane | FTS-only. No embedding provider, no vector store, no extraction model. |
+| network | none. The tool makes no outbound call; the test asserts it under a `fetch` that throws. |
+
+Two corpora, both written through Titen's real HTTP write path into a real
+zero-config local store, then audited with the shipped command.
+
+### Corpus A — this repository's own history, recorded the way an agent records
+
+Content nobody planted: `git log --format='%H%n%s%n%b'` over all 181 commits on
+`main`, split into its 986 non-empty lines. Each line was written as one
+observation (`kind: imported_source`, `source: {type: "git_commit", ref: <sha>}`,
+`trust: asserted`, no `source.id`), then materialized one-to-one into a
+`semantic_fact` claim with the line as its statement — the naive extraction step
+an agent actually performs.
+
+Then five compile-and-write-back cycles, which is the loop that fills stores in
+the field: compile a pack for a task, take the top three items, and write each
+one back as a new observation while holding the pack's `context_token`. The five
+tasks were `what did the webhook fix change`, `how is the D1 release gate
+stabilized`, `what does the benchmark evidence support`, `which advisories were
+pinned`, `what is the dashboard live verification`. That produced 15 write-backs
+and a final store of 1,001 observations.
+
+### Corpus B — the compatibility surface under a repeat burst
+
+A fresh local store, then six identical `create_entities` calls issued
+concurrently through the MCP endpoint, followed by one `add_observations`. This
+reproduces, through a different instrument, the defect the concurrent-writer
+work found on the same surface
+([`2026-08-07-durability.md`](./2026-08-07-durability.md)).
+
+## Results
+
+### Corpus A — 1,001 entries
+
+| Metric | Count | Rate |
+| --- | --- | --- |
+| exact duplicate | 179 | 17.9% |
+| near duplicate | 1 | 0.1% |
+| recall loop | 15 | 1.5% |
+| secret pattern | 0 | 0.0% |
+| stale | 968 | 96.7% |
+
+### Corpus B — 13 entries
+
+| Metric | Count | Rate |
+| --- | --- | --- |
+| exact duplicate | 10 | 76.9% |
+| near duplicate | 0 | 0.0% |
+| recall loop | 0 | 0.0% |
+| secret pattern | 0 | 0.0% |
+| stale | 13 | 100.0% |
+
+These ten numbers are not combined, averaged, or ranked, here or anywhere.
+
+## What the findings actually say
+
+### Titen's canonical hash is a replay key, not a duplicate detector
+
+179 redundant entries in 27 groups. The largest group is 147 byte-identical
+copies of `Co-Authored-By: CADIS <agent@cadis.digital>` — a real commit trailer,
+repeated across real commits, and stored 147 times.
+
+None of it was deduplicated, and the reason is structural rather than a bug,
+which makes it worse. Two facts from the store itself:
+
+```
+SELECT COUNT(*) FROM observations                        -> 1001
+SELECT COUNT(*) FROM observations WHERE canonical_hash IS NULL -> 1001
+SELECT COUNT(*) FROM claims                              ->  986
+SELECT COUNT(DISTINCT statement) FROM claims             ->  822
+```
+
+`src/core/observations.ts` computes the canonical hash **only when the caller
+supplies `source.id`**. Every observation here has `canonical_hash IS NULL`, so
+the partial unique index that upholds "exactly one record per canonical hash"
+never applied to a single row.
+
+The claim layer computes its hash unconditionally and still did not collapse
+anything, because that hash covers the claim's `sources` and its position in the
+batch. Two identical statements supported by two different observations are two
+different canonical hashes, so the 164 duplicated lines became 164 duplicated
+claim statements: 986 claim rows, 822 distinct statements.
+
+Both keys are doing exactly what they were built for — making a retried request
+idempotent — and neither one is a content-duplicate detector. The concurrent-writer
+suite's invariant "exactly one claim per canonical hash" holds and is not
+contradicted by this. What this shows is that holding it buys nothing against
+the failure mode people actually report, and that the write path's dedup story
+is narrower than a reader would assume.
+
+### The near-duplicate rule caught one thing, and it is the right one
+
+`Co-Authored-By: CADIS …` appears 147 times and `Co-authored-by: CADIS …` four
+times. Those are one canonical group holding two distinct raw texts, so the
+exact rule counts 146 + 3 redundant copies and the near rule counts the one
+crossing between the spellings. That single crossing is the entire
+near-duplicate yield on 1,001 entries, and it is honest: the rule is
+exact-match-after-canonicalization, so it detects case, spacing and punctuation
+drift and nothing else. Paraphrase is invisible to it. The 0.1% here is a floor,
+not an estimate.
+
+### Almost nothing written was ever read back
+
+968 of 1,001 entries were never served after they were written. Five compiles
+returned 33 items in total, drawn from 986 claims. A store built by an agent
+that writes everything and compiles occasionally reaches 3.3% of what it stored,
+within minutes, before any decay or drift has had time to matter.
+
+This is an upper bound on staleness — direct `GET /v1/claims/:id/evidence` reads
+are not logged per record — and it is measured over a store with no history.
+Both caveats push the same way: it is not a flattering number and it is not
+supposed to be.
+
+### The recall-loop detector fires, on both mechanisms, on every planted case
+
+All 15 write-backs were detected, and every one was detected **twice
+independently**: by the server-assigned `source_type = 'recalled'` stamp that
+the provenance work added, and by the text match against what the pack had
+served moments earlier. The two mechanisms agreeing on 15/15 is what makes the
+metric worth reporting at all — a self-declared label would have been worth
+nothing.
+
+What this does not show: a field rate. The corpus was built to contain
+write-backs, so 1.5% is a property of the script, not of agents. The finding is
+that the detector works and that both of its halves work.
+
+### The secret rules found nothing, which is weak evidence
+
+Zero matches across 1,001 entries. Commit messages are a corpus that humans
+review before it exists; a real agent memory store is not. Read this as "the
+rules did not false-positive on a thousand lines of technical English", which is
+a useful thing to know, and not as "Titen stores are clean".
+
+### The compatibility surface duplicates under concurrency
+
+Six concurrent identical `create_entities` calls left six copies of the entity
+type and six of its observation: 10 redundant entries in a 13-entry store, 76.9%.
+The reference server this surface replaces would have written the entity once.
+This is the same defect the concurrent-writer suite recorded, found here by a
+completely different route, and it is open.
+
+The honest framing of the substitution play, until it is fixed: Titen is a
+lossless substitute for `@modelcontextprotocol/server-memory` on retrieval and
+**not yet** on concurrent identical writes.
+
+## Reproducing this
+
+```sh
+# Corpus A content, verbatim, from any checkout of this repository:
+git log --format='%H%n%s%n%b' | grep -v '^$' | wc -l     # 986 at the base commit
+
+# Audit any store, export, or memory.json(l). Nothing leaves the machine:
+bun src/runtime/bun/cli.ts audit ~/.titen/memory.db
+bun src/runtime/bun/cli.ts audit ./memory.jsonl --json > audit.json
+```
+
+The corpora themselves are rebuilt by the recipe in the Method section above
+against a fresh `openLocalStore`; they are not committed, because a committed
+1,001-row SQLite fixture would be a fixture, and the point is that the numbers
+come from the write path rather than from a file somebody curated.
+
+## What would change these numbers
+
+- Setting `source.id` on writes turns the canonical key on — but it would not
+  collapse this group, because that key also covers `source.ref`, and these 147
+  copies arrived under 147 different commit hashes. Deduplicating repeated
+  *content* across different sources is something Titen does not do at all
+  today. Whether it should is a product decision this document does not make.
+- Fixing the compatibility surface's concurrent-write path.
+- Running Titen for 32 days. Nothing else substitutes for that, and until
+  somebody does, this document's most important row stays empty.
+
+## Falsification
+
+From the spec: 90 days after this tool ships, fewer than five distinct external
+runs and zero published numbers kills the write-hygiene wedge, and the honest
+conclusion is then that Titen is a well-engineered library with no market. If
+an incumbent publishes their own junk-rate audit first, the play is foreclosed
+and we say so rather than argue methodology.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "titen-memory",
   "version": "0.6.1",
+  "mcpName": "io.github.RamaAditya49/titen-memory",
   "description": "The Level 6 collaborative memory fabric for AI agents — evidence-grounded observe/claim/compile/feedback over Bun+SQLite or Cloudflare Workers+D1",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/verify-live.ts
+++ b/scripts/verify-live.ts
@@ -337,7 +337,7 @@ const readerRes = await fetch(`${URL_BASE}/v1/observations`, {
     subject_id: SUBJECT,
     kind: "tool_result",
     content: "a compile-only key must not be able to write this",
-    source: { type: "tool" },
+    source: { type: "tool", ref: "contract://verify-live" },
   }),
 });
 assert.equal(readerRes.status, 403, "a scoped key must be refused a write");

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -228,7 +228,19 @@ tool_names="$(printf '%s' "$tools" | node --input-type=module -e '
   if (!Array.isArray(tools)) process.exit(1);
   console.log(tools.map((tool) => tool.name).sort().join("\n"));
 ')"
-expected_tools='titen_checkpoint_get
+# Nine native tools, plus the nine @modelcontextprotocol/server-memory names
+# served so a caller can swap that server for Titen by editing one line of MCP
+# config (#279). Sorted, so the compatibility names lead.
+expected_tools='add_observations
+create_entities
+create_relations
+delete_entities
+delete_observations
+delete_relations
+open_nodes
+read_graph
+search_nodes
+titen_checkpoint_get
 titen_checkpoint_save
 titen_compile
 titen_consolidate
@@ -252,7 +264,7 @@ printf '%s' "$stdio" | node --input-type=module -e '
   const messages = input.split("\n").filter(Boolean).map(JSON.parse);
   if (messages.length !== 2 ||
       !messages[0]?.result?.instructions?.includes("titen_compile once") ||
-      messages[1]?.result?.tools?.length !== 9)
+      messages[1]?.result?.tools?.length !== 18)
     throw new Error("installed stdio bridge failed its MCP handshake");
 ' || { echo "FAIL: installed stdio MCP bridge failed" >&2; exit 1; }
 case "$stdio" in

--- a/server.json
+++ b/server.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.RamaAditya49/titen-memory",
+  "title": "Titen Memory",
+  "description": "Evidence-grounded agent memory with mandatory provenance, on local SQLite or Cloudflare D1",
+  "version": "0.6.1",
+  "websiteUrl": "https://titen.dev",
+  "repository": {
+    "url": "https://github.com/RamaAditya49/titen",
+    "source": "github",
+    "id": "1315644626"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "titen-memory",
+      "version": "0.6.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "TITEN_MCP_URL",
+          "description": "Optional. Streamable HTTP /mcp endpoint of a running Titen service. Set together with TITEN_API_KEY to use a shared store instead of the local one.",
+          "format": "string",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "TITEN_API_KEY",
+          "description": "Optional. API key for the Titen service named by TITEN_MCP_URL. Required only when TITEN_MCP_URL is set.",
+          "format": "string",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/core/claims.ts
+++ b/src/core/claims.ts
@@ -18,6 +18,7 @@ import {
   CLAIM_KINDS,
   CLAIM_RELATIONS,
   LIMITS,
+  RECALLED_SOURCE_TYPE,
   TRUST_LEVELS,
   TRUST_RANK,
   VISIBILITIES,
@@ -53,6 +54,7 @@ interface SourceRow {
   actor_id: string;
   content: string;
   content_hash: string;
+  source_type: string;
 }
 
 interface ClaimReplayRow {
@@ -96,7 +98,7 @@ async function loadSources(
   const ids = [...new Set(sources.map((source) => source.observationId))];
   const rows = await db.all<SourceRow>(
     `SELECT o.id, o.subject_id, o.project_id, o.workspace_id, o.trust, o.visibility, o.actor_id,
-            o.content, o.content_hash
+            o.content, o.content_hash, o.source_type
        FROM observations o
       WHERE o.org_id = ? AND o.id IN (${ids.map(() => "?").join(", ")})
         AND ${recordAccessSql("o")}`,
@@ -156,6 +158,13 @@ export async function consolidate(ctx: RequestContext): Promise<Result> {
     const rows = await loadSources(ctx.app.db, principal, sources);
     for (const source of sources) {
       const row = rows.get(source.observationId)!;
+      // Closes the loop instead of labelling it: evidence Titen itself handed
+      // back through a context pack may never be promoted into a new claim,
+      // which is how one preference gets stored two hundred times (#280).
+      if (row.source_type === RECALLED_SOURCE_TYPE)
+        throw validationError(
+          "Claim evidence may not be a recalled observation: consolidating context Titen issued would re-materialize its own output.",
+        );
       if (
         row.subject_id !== subjectId
         || row.project_id !== projectId

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -261,6 +261,12 @@ export async function compileContext(ctx: RequestContext): Promise<Result> {
   return {
     data: {
       context_id: contextId,
+      // Server-issued proof that what follows came out of Titen. A caller that
+      // writes an observation derived from this pack passes it back as
+      // `context_token` and the write is stamped `source.type: "recalled"`,
+      // which is the only way a recall loop can be counted rather than
+      // self-reported (#280). Opaque: verified, never parsed.
+      context_token: contextId,
       query: task,
       scope: effectiveScope(subjectId, projectId, projectMode, at),
       budget: {

--- a/src/core/mcp.ts
+++ b/src/core/mcp.ts
@@ -1,17 +1,28 @@
 import type { RequestContext, Result } from "./http";
-import { ApiError } from "./errors";
-import { appendObservation } from "./observations";
+import { ApiError, validationError } from "./errors";
+import { requireScope } from "./auth";
+import { recordAccessParams, recordAccessSql } from "./authorization";
+import { chunk } from "./db";
+import { appendObservation, isRedactedObservation, purgeObservation } from "./observations";
 import { compileContext, recordFeedback } from "./context";
 import { consolidate } from "./claims";
 import { resolveProject } from "./projects";
 import { getCheckpoint, saveCheckpoint } from "./checkpoints";
 import { acquireLease, createHandoff } from "./collaboration";
+import type {
+  ReferenceEntity,
+  ReferenceGraph,
+  ReferenceRelation,
+} from "./portability";
 import {
   CLAIM_KINDS,
   CLAIM_RELATIONS,
+  LIMITS,
   OBSERVATION_KINDS,
   TRUST_LEVELS,
   VISIBILITIES,
+  requireObject,
+  requireString,
 } from "./validate";
 import { TITEN_VERSION } from "./version";
 
@@ -273,6 +284,587 @@ const toolLeaseAcquire = (ctx: RequestContext, args: Record<string, unknown>) =>
 const toolHandoff = (ctx: RequestContext, args: Record<string, unknown>) =>
   callDomain(ctx, "POST", "/v1/handoffs", args, createHandoff);
 
+// --- @modelcontextprotocol/server-memory compatibility ---
+
+/**
+ * The nine tool names of `@modelcontextprotocol/server-memory`, served against
+ * Titen observations and claims.
+ *
+ * Schemas, descriptions, annotations and response shapes are reproduced from
+ * that server's `src/memory/index.ts` rather than from memory: the entire offer
+ * is that switching costs one line of MCP configuration, so an argument that
+ * differs by one field name breaks a caller silently.
+ *
+ * Mapping, and what it costs:
+ *
+ * - Every record lives under one subject, `knowledge_graph`, because Titen
+ *   retrieval is subject-scoped and a graph split across subjects could not be
+ *   searched in one pass. The graph is `private` visibility, so each principal
+ *   sees its own, exactly as each config gets its own `memory.json`.
+ * - An entity is an observation holding its `entityType`, keyed by name in
+ *   `agent_id`; each of its observation strings is another observation with the
+ *   text verbatim; a relation is an observation holding the triple as JSON.
+ *   Those rows are canonical and round-trip exactly.
+ * - Each entity and each observation string also materializes one
+ *   `semantic_fact` claim, `"<name>: <text>"`, which is what `search_nodes`
+ *   ranks. Statements are truncated to the claim limit, so the claim is a
+ *   searchable projection and the observation stays the evidence of record.
+ * - Deleting purges: content becomes irrecoverable, its hash and history
+ *   survive, and dependent claims are revoked. That is stronger than the
+ *   reference server's file rewrite, and it needs `observations:purge`.
+ */
+const COMPAT_SUBJECT = "knowledge_graph";
+const COMPAT_SOURCE_TYPE = "mcp_memory";
+const ENTITY_REF = "memory://entity";
+const OBSERVATION_REF = "memory://observation";
+const RELATION_REF = "memory://relation";
+
+const ENTITY_SCHEMA = {
+  type: "object",
+  properties: {
+    name: { type: "string", description: "The name of the entity" },
+    entityType: { type: "string", description: "The type of the entity" },
+    observations: {
+      type: "array",
+      items: { type: "string" },
+      description: "An array of observation contents associated with the entity",
+    },
+  },
+  required: ["name", "entityType", "observations"],
+  additionalProperties: false,
+};
+
+const RELATION_SCHEMA = {
+  type: "object",
+  properties: {
+    from: { type: "string", description: "The name of the entity where the relation starts" },
+    to: { type: "string", description: "The name of the entity where the relation ends" },
+    relationType: { type: "string", description: "The type of the relation" },
+  },
+  required: ["from", "to", "relationType"],
+  additionalProperties: false,
+};
+
+const compatSchema = (properties: Record<string, unknown>) => ({
+  type: "object",
+  properties,
+  required: Object.keys(properties),
+  additionalProperties: false,
+});
+
+const COMPAT_TOOLS = [
+  {
+    name: "create_entities",
+    title: "Create Entities",
+    description: "Create multiple new entities in the knowledge graph",
+    inputSchema: compatSchema({
+      entities: {
+        type: "array",
+        items: ENTITY_SCHEMA,
+        description: "An array of entities to create",
+      },
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  },
+  {
+    name: "create_relations",
+    title: "Create Relations",
+    description:
+      "Create multiple new relations between entities in the knowledge graph. Relations should be in active voice",
+    inputSchema: compatSchema({
+      relations: {
+        type: "array",
+        items: RELATION_SCHEMA,
+        description: "An array of relations to create",
+      },
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  },
+  {
+    name: "add_observations",
+    title: "Add Observations",
+    description: "Add new observations to existing entities in the knowledge graph",
+    inputSchema: compatSchema({
+      observations: {
+        type: "array",
+        description: "An array of per-entity observation additions",
+        items: {
+          type: "object",
+          properties: {
+            entityName: { type: "string", description: "The name of the entity to add the observations to" },
+            contents: {
+              type: "array",
+              items: { type: "string" },
+              description: "An array of observation contents to add",
+            },
+          },
+          required: ["entityName", "contents"],
+          additionalProperties: false,
+        },
+      },
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  },
+  {
+    name: "delete_entities",
+    title: "Delete Entities",
+    description: "Delete multiple entities and their associated relations from the knowledge graph",
+    inputSchema: compatSchema({
+      entityNames: {
+        type: "array",
+        items: { type: "string" },
+        description: "An array of entity names to delete",
+      },
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: "delete_observations",
+    title: "Delete Observations",
+    description: "Delete specific observations from entities in the knowledge graph",
+    inputSchema: compatSchema({
+      deletions: {
+        type: "array",
+        description: "An array of per-entity observation deletions",
+        items: {
+          type: "object",
+          properties: {
+            entityName: { type: "string", description: "The name of the entity containing the observations" },
+            observations: {
+              type: "array",
+              items: { type: "string" },
+              description: "An array of observations to delete",
+            },
+          },
+          required: ["entityName", "observations"],
+          additionalProperties: false,
+        },
+      },
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: "delete_relations",
+    title: "Delete Relations",
+    description: "Delete multiple relations from the knowledge graph",
+    inputSchema: compatSchema({
+      relations: {
+        type: "array",
+        items: RELATION_SCHEMA,
+        description: "An array of relations to delete",
+      },
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: "read_graph",
+    title: "Read Graph",
+    description: "Read the entire knowledge graph",
+    inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: "search_nodes",
+    title: "Search Nodes",
+    description: "Search for nodes in the knowledge graph based on a query",
+    inputSchema: compatSchema({
+      query: {
+        type: "string",
+        description: "The search query to match against entity names, types, and observation content",
+      },
+    }),
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: "open_nodes",
+    title: "Open Nodes",
+    description: "Open specific nodes in the knowledge graph by their names",
+    inputSchema: compatSchema({
+      names: { type: "array", items: { type: "string" }, description: "An array of entity names to retrieve" },
+    }),
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+];
+
+interface CompatReply {
+  content: { type: "text"; text: string }[];
+  structuredContent: unknown;
+}
+
+/** The reference server prints its results; both fields carry the same result. */
+const compatReply = (text: unknown, structuredContent: unknown): CompatReply => ({
+  content: [{
+    type: "text",
+    text: typeof text === "string" ? text : JSON.stringify(text, null, 2),
+  }],
+  structuredContent,
+});
+
+/** Reuses the request validators, which also reject unsafe control characters. */
+const compatText = (value: unknown, max: number, path: string): string =>
+  requireString({ value }, "value", max, path);
+
+function compatList<Item>(
+  args: Record<string, unknown>,
+  field: string,
+  parse: (row: unknown, path: string) => Item,
+): Item[] {
+  const value = args[field];
+  if (!Array.isArray(value)) throw validationError(`Field "${field}" must be an array.`);
+  return value.map((row, index) => parse(row, `${field}[${index}]`));
+}
+
+const compatStrings = (value: unknown, path: string): string[] => {
+  if (!Array.isArray(value)) throw validationError(`Field "${path}" must be an array.`);
+  return value.map((item, index) => compatText(item, LIMITS.content, `${path}[${index}]`));
+};
+
+const compatEntity = (row: unknown, path: string): ReferenceEntity => {
+  const entity = requireObject(row, path);
+  return {
+    name: compatText(entity.name, LIMITS.identifier, `${path}.name`),
+    entityType: compatText(entity.entityType, LIMITS.label, `${path}.entityType`),
+    observations: compatStrings(entity.observations ?? [], `${path}.observations`),
+  };
+};
+
+const compatRelation = (row: unknown, path: string): ReferenceRelation => {
+  const relation = requireObject(row, path);
+  return {
+    from: compatText(relation.from, LIMITS.identifier, `${path}.from`),
+    to: compatText(relation.to, LIMITS.identifier, `${path}.to`),
+    relationType: compatText(relation.relationType, LIMITS.label, `${path}.relationType`),
+  };
+};
+
+interface CompatStore {
+  /** Insertion-ordered, like the lines of the file this replaces. */
+  entities: Map<string, { entityId: string; entityType: string; observations: { id: string; content: string }[] }>;
+  relations: { id: string; from: string; to: string; relationType: string }[];
+  /** Observation id to the entity it belongs to, for mapping retrieval hits back. */
+  owner: Map<string, string>;
+}
+
+/**
+ * Reads the whole graph on every call, exactly as the server it replaces
+ * re-reads its file. Only the *search* path had to stop scanning; if a store
+ * ever outgrows one read, the mutating tools are where to push filters into SQL.
+ */
+async function loadCompatStore(ctx: RequestContext): Promise<CompatStore> {
+  const principal = ctx.principal!;
+  const rows = await ctx.app.db.all<{
+    id: string;
+    agent_id: string | null;
+    content: string;
+    content_hash: string;
+    source_ref: string | null;
+  }>(
+    `SELECT o.id, o.agent_id, o.content, o.content_hash, o.source_ref
+       FROM observations o
+      WHERE o.org_id = ? AND o.subject_id = ? AND o.source_type = ?
+        AND o.source_ref IN (?, ?, ?)
+        AND ${recordAccessSql("o")}
+      ORDER BY o.ingested_at, o.id`,
+    [
+      principal.orgId,
+      COMPAT_SUBJECT,
+      COMPAT_SOURCE_TYPE,
+      ENTITY_REF,
+      OBSERVATION_REF,
+      RELATION_REF,
+      ...recordAccessParams(principal.principalId),
+    ],
+  );
+  // A purged row keeps its hash and its history but is no longer in the graph.
+  const live = rows.filter((row) => !isRedactedObservation(row.content, row.content_hash));
+  const store: CompatStore = { entities: new Map(), relations: [], owner: new Map() };
+  for (const row of live) {
+    if (row.source_ref !== ENTITY_REF || !row.agent_id || store.entities.has(row.agent_id)) continue;
+    store.entities.set(row.agent_id, { entityId: row.id, entityType: row.content, observations: [] });
+    store.owner.set(row.id, row.agent_id);
+  }
+  for (const row of live) {
+    if (row.source_ref === OBSERVATION_REF) {
+      const entity = row.agent_id ? store.entities.get(row.agent_id) : undefined;
+      if (!entity) continue;
+      entity.observations.push({ id: row.id, content: row.content });
+      store.owner.set(row.id, row.agent_id!);
+    } else if (row.source_ref === RELATION_REF) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(row.content);
+      } catch {
+        continue; // Not a relation this server wrote, so not part of the graph.
+      }
+      const relation = parsed as ReferenceRelation;
+      if (typeof relation?.from === "string" && typeof relation?.to === "string"
+        && typeof relation?.relationType === "string")
+        store.relations.push({ id: row.id, ...relation });
+    }
+  }
+  return store;
+}
+
+const compatGraph = (store: CompatStore): ReferenceGraph => ({
+  entities: [...store.entities].map(([name, entity]) => ({
+    name,
+    entityType: entity.entityType,
+    observations: entity.observations.map((observation) => observation.content),
+  })),
+  relations: store.relations.map(({ from, to, relationType }) => ({ from, to, relationType })),
+});
+
+/** Relations reach outside the matched set so a caller can see its edges. */
+const compatSubgraph = (graph: ReferenceGraph, entities: ReferenceEntity[]): ReferenceGraph => {
+  const names = new Set(entities.map((entity) => entity.name));
+  return {
+    entities,
+    relations: graph.relations.filter((relation) => names.has(relation.from) || names.has(relation.to)),
+  };
+};
+
+async function appendCompat(
+  ctx: RequestContext,
+  ref: string,
+  content: string,
+  agentId: string | null,
+): Promise<string> {
+  const result = await callDomain(ctx, "POST", "/v1/observations", {
+    subject_id: COMPAT_SUBJECT,
+    kind: ref === OBSERVATION_REF ? "user_statement" : "system_event",
+    content,
+    agent_id: agentId,
+    source: { type: COMPAT_SOURCE_TYPE, ref },
+  }, appendObservation) as { data: { observation_id: string } };
+  return result.data.observation_id;
+}
+
+const compatStatement = (name: string, text: string) =>
+  `${name}: ${text}`.slice(0, LIMITS.statement);
+
+/** Materializes the searchable projection of rows already written as evidence. */
+async function materializeCompat(
+  ctx: RequestContext,
+  claims: { statement: string; observationId: string }[],
+): Promise<void> {
+  for (const group of chunk(claims, LIMITS.claimsPerConsolidation)) {
+    if (!group.length) continue;
+    await callDomain(ctx, "POST", "/v1/consolidations", {
+      subject_id: COMPAT_SUBJECT,
+      claims: group.map((claim) => ({
+        kind: "semantic_fact",
+        statement: claim.statement,
+        sources: [{ observation_id: claim.observationId, relation: "supports" }],
+      })),
+    }, consolidate);
+  }
+}
+
+/**
+ * Deleting evidence is a power the MCP surface did not previously hold, so it
+ * asks for the purge capability by name rather than inheriting `mcp:call`.
+ */
+async function purgeCompat(ctx: RequestContext, ids: string[]): Promise<void> {
+  requireScope(ctx.principal!, "observations:purge");
+  for (const id of ids)
+    await callDomain(
+      ctx, "DELETE", `/v1/observations/${encodeURIComponent(id)}`, {}, purgeObservation, { id },
+    );
+}
+
+const compatCreateEntities = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const requested = compatList(args, "entities", compatEntity);
+  const store = await loadCompatStore(ctx);
+  const created: ReferenceEntity[] = [];
+  const claims: { statement: string; observationId: string }[] = [];
+  for (const entity of requested) {
+    if (store.entities.has(entity.name) || created.some((done) => done.name === entity.name)) continue;
+    claims.push({
+      statement: compatStatement(entity.name, entity.entityType),
+      observationId: await appendCompat(ctx, ENTITY_REF, entity.entityType, entity.name),
+    });
+    for (const text of entity.observations)
+      claims.push({
+        statement: compatStatement(entity.name, text),
+        observationId: await appendCompat(ctx, OBSERVATION_REF, text, entity.name),
+      });
+    created.push(entity);
+  }
+  await materializeCompat(ctx, claims);
+  return compatReply(created, { entities: created });
+};
+
+const compatCreateRelations = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const requested = compatList(args, "relations", compatRelation);
+  const store = await loadCompatStore(ctx);
+  const key = (relation: ReferenceRelation) =>
+    JSON.stringify([relation.from, relation.to, relation.relationType]);
+  const known = new Set(store.relations.map(key));
+  const created: ReferenceRelation[] = [];
+  for (const relation of requested) {
+    if (known.has(key(relation))) continue;
+    known.add(key(relation));
+    await appendCompat(ctx, RELATION_REF, JSON.stringify(relation), null);
+    created.push(relation);
+  }
+  return compatReply(created, { relations: created });
+};
+
+const compatAddObservations = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const requested = compatList(args, "observations", (row, path) => {
+    const entry = requireObject(row, path);
+    return {
+      entityName: compatText(entry.entityName, LIMITS.identifier, `${path}.entityName`),
+      contents: compatStrings(entry.contents ?? [], `${path}.contents`),
+    };
+  });
+  const store = await loadCompatStore(ctx);
+  // The reference server throws before saving anything, so a missing entity
+  // leaves the whole call without effect. Check every name before writing one.
+  for (const entry of requested)
+    if (!store.entities.has(entry.entityName))
+      throw validationError(`Entity with name ${entry.entityName} not found`);
+
+  const results: { entityName: string; addedObservations: string[] }[] = [];
+  const claims: { statement: string; observationId: string }[] = [];
+  for (const entry of requested) {
+    const entity = store.entities.get(entry.entityName)!;
+    const present = new Set(entity.observations.map((observation) => observation.content));
+    const added: string[] = [];
+    for (const text of entry.contents) {
+      if (present.has(text)) continue;
+      present.add(text);
+      claims.push({
+        statement: compatStatement(entry.entityName, text),
+        observationId: await appendCompat(ctx, OBSERVATION_REF, text, entry.entityName),
+      });
+      added.push(text);
+    }
+    results.push({ entityName: entry.entityName, addedObservations: added });
+  }
+  await materializeCompat(ctx, claims);
+  return compatReply(results, { results });
+};
+
+const compatDeleteEntities = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const names = new Set(compatList(args, "entityNames", (row, path) =>
+    compatText(row, LIMITS.identifier, path)));
+  const store = await loadCompatStore(ctx);
+  const ids: string[] = [];
+  for (const [name, entity] of store.entities) {
+    if (!names.has(name)) continue;
+    ids.push(entity.entityId, ...entity.observations.map((observation) => observation.id));
+  }
+  for (const relation of store.relations)
+    if (names.has(relation.from) || names.has(relation.to)) ids.push(relation.id);
+  await purgeCompat(ctx, ids);
+  const message = "Entities deleted successfully";
+  return compatReply(message, { success: true, message });
+};
+
+const compatDeleteObservations = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const requested = compatList(args, "deletions", (row, path) => {
+    const entry = requireObject(row, path);
+    return {
+      entityName: compatText(entry.entityName, LIMITS.identifier, `${path}.entityName`),
+      observations: compatStrings(entry.observations ?? [], `${path}.observations`),
+    };
+  });
+  const store = await loadCompatStore(ctx);
+  const ids: string[] = [];
+  for (const entry of requested) {
+    const entity = store.entities.get(entry.entityName);
+    if (!entity) continue; // Unknown entities are ignored, as in the reference server.
+    const removing = new Set(entry.observations);
+    for (const observation of entity.observations)
+      if (removing.has(observation.content)) ids.push(observation.id);
+  }
+  await purgeCompat(ctx, ids);
+  const message = "Observations deleted successfully";
+  return compatReply(message, { success: true, message });
+};
+
+const compatDeleteRelations = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const requested = compatList(args, "relations", compatRelation);
+  const store = await loadCompatStore(ctx);
+  const removing = new Set(requested.map((relation) =>
+    JSON.stringify([relation.from, relation.to, relation.relationType])));
+  await purgeCompat(
+    ctx,
+    store.relations
+      .filter((relation) =>
+        removing.has(JSON.stringify([relation.from, relation.to, relation.relationType])))
+      .map((relation) => relation.id),
+  );
+  const message = "Relations deleted successfully";
+  return compatReply(message, { success: true, message });
+};
+
+const compatReadGraph = async (ctx: RequestContext) => {
+  const graph = compatGraph(await loadCompatStore(ctx));
+  return compatReply(graph, { ...graph });
+};
+
+/**
+ * The one tool that is not a reimplementation. The server this replaces answers
+ * a search by lower-casing the whole query and running `String.includes` over
+ * every entity it just re-read from disk, so "which service handles refunds"
+ * matches nothing unless that exact sentence is stored. Here the query goes
+ * through the ordinary context compiler: FTS with stemming, ranking, and the
+ * vector index when one is configured. Results come back best-first.
+ */
+const compatSearchNodes = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const store = await loadCompatStore(ctx);
+  const graph = compatGraph(store);
+  // `includes("")` is true for every node, so an empty query is the whole graph.
+  if (typeof args.query === "string" && args.query.trim() === "")
+    return compatReply(graph, { ...graph });
+  const query = compatText(args.query, LIMITS.statement, "query");
+
+  const compiled = await callDomain(ctx, "POST", "/v1/context/compile", {
+    subject_id: COMPAT_SUBJECT,
+    task: query,
+    max_tokens: LIMITS.maxTokens,
+    max_candidates: LIMITS.maxCandidates,
+  }, compileContext) as { data: { items: { evidence_ids: string[] }[] } };
+
+  const ranked = new Set<string>();
+  for (const item of compiled.data.items)
+    for (const evidenceId of item.evidence_ids) {
+      const owner = store.owner.get(evidenceId);
+      if (owner) ranked.add(owner);
+    }
+  const byName = new Map(graph.entities.map((entity) => [entity.name, entity]));
+  const found = compatSubgraph(
+    graph,
+    [...ranked].map((name) => byName.get(name)).filter((entity) => entity !== undefined),
+  );
+  return compatReply(found, { ...found });
+};
+
+const compatOpenNodes = async (ctx: RequestContext, args: Record<string, unknown>) => {
+  const names = new Set(compatList(args, "names", (row, path) =>
+    compatText(row, LIMITS.identifier, path)));
+  const graph = compatGraph(await loadCompatStore(ctx));
+  const found = compatSubgraph(graph, graph.entities.filter((entity) => names.has(entity.name)));
+  return compatReply(found, { ...found });
+};
+
+const COMPAT_HANDLERS: Record<
+  string,
+  (ctx: RequestContext, args: Record<string, unknown>) => Promise<CompatReply>
+> = {
+  create_entities: compatCreateEntities,
+  create_relations: compatCreateRelations,
+  add_observations: compatAddObservations,
+  delete_entities: compatDeleteEntities,
+  delete_observations: compatDeleteObservations,
+  delete_relations: compatDeleteRelations,
+  read_graph: compatReadGraph,
+  search_nodes: compatSearchNodes,
+  open_nodes: compatOpenNodes,
+};
+
 // --- Dispatch ---
 
 const TOOL_HANDLERS: Record<string, (ctx: RequestContext, args: Record<string, unknown>) => Promise<unknown>> = {
@@ -401,14 +993,7 @@ async function dispatchRpc(
       return respond(rpcOk(id, {}));
 
     case "tools/list":
-      return respond(rpcOk(id, {
-        tools: TOOLS.map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-          annotations: tool.annotations,
-        })),
-      }));
+      return respond(rpcOk(id, { tools: [...TOOLS, ...COMPAT_TOOLS] }));
 
     case "tools/call": {
       const params = (request.params ?? {}) as {
@@ -418,14 +1003,15 @@ async function dispatchRpc(
       if (typeof params.name !== "string")
         return respond(rpcError(id, INVALID_PARAMS, "Missing tool name."));
       const handler = TOOL_HANDLERS[params.name];
-      if (!handler)
+      const compat = COMPAT_HANDLERS[params.name];
+      if (!handler && !compat)
         return respond(rpcError(id, INVALID_PARAMS, `Unknown tool: ${params.name}`));
 
       try {
-        const result = await handler(ctx, params.arguments ?? {});
-        return respond(rpcOk(id, {
-          content: [{ type: "text", text: JSON.stringify(result) }],
-        }));
+        const args = params.arguments ?? {};
+        return respond(rpcOk(id, compat
+          ? await compat(ctx, args)
+          : { content: [{ type: "text", text: JSON.stringify(await handler!(ctx, args)) }] }));
       } catch (error) {
         // A tool failure is a result the model must be able to read, not a
         // transport error that hides what went wrong.

--- a/src/core/observations.ts
+++ b/src/core/observations.ts
@@ -1,5 +1,5 @@
-import { assertTrustCeiling } from "./auth";
-import { first, type Stmt } from "./db";
+import { assertTrustCeiling, type Principal } from "./auth";
+import { first, type Db, type Stmt } from "./db";
 import { eventStatement } from "./events";
 import { conflict, notFound, validationError } from "./errors";
 import { newId, sha256Hex } from "./ids";
@@ -13,6 +13,7 @@ export { historyStatement, outboxStatement } from "./writes";
 import {
   LIMITS,
   OBSERVATION_KINDS,
+  RECALLED_SOURCE_TYPE,
   TRUST_LEVELS,
   VISIBILITIES,
   optionalEnum,
@@ -73,6 +74,40 @@ export function isRedactedObservation(content: string, contentHash: string): boo
  */
 const DEFAULT_VISIBILITY = "private";
 
+/**
+ * A context token is the identifier `POST /v1/context/compile` issued for a run
+ * the caller is entitled to read, so it is verified against the same boundary
+ * `getContext` enforces: own run, or one delegated by a live handoff.
+ *
+ * Deliberately not an HMAC. Titen's signing keyring (`TITEN_SECRET_KEYS`) is
+ * optional, so a stateless token would be unavailable in exactly the
+ * zero-configuration deployments that need this most, and a token a caller can
+ * always mint by compiling gains nothing from a signature it cannot forge
+ * anyway. The row already exists; one primary-key lookup replaces a key
+ * dependency, a migration, and an expiry policy.
+ */
+async function isIssuedContextToken(
+  db: Db,
+  principal: Principal,
+  token: string,
+): Promise<boolean> {
+  return Boolean(await first<{ present: number }>(
+    db,
+    `SELECT 1 AS present FROM context_runs r
+      WHERE r.id = ? AND r.org_id = ?
+        AND (
+          r.actor_id = ?
+          OR EXISTS (
+            SELECT 1 FROM handoffs h
+             WHERE h.org_id = r.org_id AND h.context_id = r.id
+               AND h.to_principal = ? AND h.status IN ('pending', 'accepted')
+          )
+        )
+      LIMIT 1`,
+    [token, principal.orgId, principal.principalId, principal.principalId],
+  ));
+}
+
 export async function appendObservation(ctx: RequestContext): Promise<Result> {
   const principal = ctx.principal!;
   const raw = await ctx.rawBody();
@@ -88,9 +123,38 @@ export async function appendObservation(ctx: RequestContext): Promise<Result> {
   const runId = optionalString(body, "run_id", LIMITS.identifier);
   const occurredAt = optionalTimestamp(body, "occurred_at");
   const source = requireObject(body.source, "source");
-  const sourceType = requireString(source, "type", LIMITS.label, "source.type");
-  const sourceRef = optionalString(source, "ref", LIMITS.identifier, "source.ref");
+  const declaredSourceType = requireString(source, "type", LIMITS.label, "source.type");
+  // A pointer back to the origin is mandatory, not advisory: an audit that
+  // cannot trace an entry to where it came from cannot tell junk from evidence.
+  // This is the obligation the MCP tool spec already stated (#280).
+  const sourceRef = requireString(source, "ref", LIMITS.identifier, "source.ref");
   const sourceId = optionalString(source, "id", LIMITS.identifier, "source.id");
+
+  /**
+   * Provenance is the one field a caller may not author. `recalled` means Titen
+   * itself returned this content through a context pack, which is the write that
+   * turns a memory store into an echo chamber. It is stamped from a server-issued
+   * context token, refused when merely declared, and not overridable by a caller
+   * that holds one.
+   *
+   * Known ceiling: the stamp proves the write was made while holding a
+   * Titen-issued pack, not that its content came out of that pack, and a caller
+   * that simply omits the token is not stamped at all. `recalled` is therefore a
+   * sound lower bound on the recall loop and never an upper one. Tightening it
+   * means comparing written content against the pack's items, which is a
+   * similarity decision this path has no business making synchronously; that
+   * belongs in `titen audit`.
+   */
+  const contextToken = optionalString(body, "context_token", LIMITS.identifier);
+  if (declaredSourceType === RECALLED_SOURCE_TYPE)
+    throw validationError(
+      `Source type "${RECALLED_SOURCE_TYPE}" is assigned by Titen from a "context_token" issued by POST /v1/context/compile and may not be declared by a caller.`,
+    );
+  // Fail closed: silently downgrading an unrecognized token to "new input" is
+  // exactly the mislabelled recall loop this path exists to prevent.
+  if (contextToken !== null && !(await isIssuedContextToken(ctx.app.db, principal, contextToken)))
+    throw validationError('Field "context_token" is not a context token issued to this principal.');
+  const sourceType = contextToken === null ? declaredSourceType : RECALLED_SOURCE_TYPE;
 
   // Trust is authority, not a payload field: a key cannot promote its evidence.
   assertTrustCeiling(principal, trust);

--- a/src/core/portability.ts
+++ b/src/core/portability.ts
@@ -2156,3 +2156,67 @@ async function importHistory(orgId: string, recordType: string, recordId: string
     params: [id, orgId, recordType, recordId, actorId, id, at],
   };
 }
+
+// --- @modelcontextprotocol/server-memory store ---
+
+/**
+ * The reference MCP memory server keeps its whole state in one file of
+ * newline-delimited JSON, one `{"type":"entity"|"relation", ...}` object per
+ * line. It is named `memory.jsonl` today and was named `memory.json` before
+ * 0.6.3, which renames the old file in place; both carry this same format.
+ *
+ * Parsing is here rather than in a runtime adapter because it is pure string
+ * work with no filesystem, and because `titen audit` reads the same files.
+ */
+export interface ReferenceEntity { name: string; entityType: string; observations: string[] }
+export interface ReferenceRelation { from: string; to: string; relationType: string }
+export interface ReferenceGraph { entities: ReferenceEntity[]; relations: ReferenceRelation[] }
+
+function referenceText(row: Record<string, unknown>, field: string, line: number): string {
+  const value = row[field];
+  if (typeof value !== "string" || value === "")
+    throw validationError(`Line ${line} of the memory store needs a non-empty "${field}".`);
+  return value;
+}
+
+/**
+ * Mirrors that server's own loader: lines it does not recognize are not part of
+ * the graph. A line it *would* have accepted but that is malformed throws
+ * instead of being dropped, because an import that silently loses records is
+ * worse than one that refuses.
+ */
+export function parseReferenceGraph(text: string): ReferenceGraph {
+  const graph: ReferenceGraph = { entities: [], relations: [] };
+  for (const [index, raw] of text.split("\n").entries()) {
+    const line = index + 1;
+    if (!raw.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw validationError(`Line ${line} of the memory store is not valid JSON.`);
+    }
+    if (!isRecord(parsed)) continue;
+    if (parsed.type === "entity") {
+      const observations = parsed.observations ?? [];
+      if (!Array.isArray(observations))
+        throw validationError(`Line ${line} of the memory store has non-array "observations".`);
+      graph.entities.push({
+        name: referenceText(parsed, "name", line),
+        entityType: referenceText(parsed, "entityType", line),
+        observations: observations.map((observation, position) => {
+          if (typeof observation !== "string" || observation === "")
+            throw validationError(`Line ${line} observation ${position + 1} is not a non-empty string.`);
+          return observation;
+        }),
+      });
+    } else if (parsed.type === "relation") {
+      graph.relations.push({
+        from: referenceText(parsed, "from", line),
+        to: referenceText(parsed, "to", line),
+        relationType: referenceText(parsed, "relationType", line),
+      });
+    }
+  }
+  return graph;
+}

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -12,6 +12,14 @@ export const TRUST_RANK: Record<Trust, number> = {
 export const VISIBILITIES = ["private", "team", "organization"] as const;
 export type Visibility = (typeof VISIBILITIES)[number];
 
+/**
+ * Server-assigned provenance for content Titen itself handed back through a
+ * context pack. A caller may never declare it and may never override it, which
+ * is the whole point: a recall loop is only countable while the label is a
+ * server verdict rather than a self-report (#280).
+ */
+export const RECALLED_SOURCE_TYPE = "recalled";
+
 export const OBSERVATION_KINDS = [
   "user_statement",
   "tool_result",

--- a/src/runtime/bun/audit.ts
+++ b/src/runtime/bun/audit.ts
@@ -1,0 +1,581 @@
+/**
+ * `titen audit` — an offline write-hygiene audit of an agent memory store.
+ *
+ * Every published agent-memory benchmark measures retrieval on a tidy corpus.
+ * The failure people actually report is on the write side: a store that fills
+ * with copies of itself until it is worth less than no memory at all. This
+ * measures that, on stores Titen does not own, with per-item evidence a skeptic
+ * can check by hand.
+ *
+ * Three constraints are load-bearing and not negotiable:
+ *
+ * 1. **Nothing leaves the machine.** No network, no model, no upload. This file
+ *    imports a SQLite opener and a JSON parser and nothing else, so the promise
+ *    is checkable by reading the import list. The report goes to stdout; the
+ *    user decides whether it is ever shared.
+ * 2. **A missing signal is reported as missing.** A store that records no
+ *    provenance cannot have its recall-loop rate measured, and saying "0" there
+ *    would be a lie that flatters the store. It is reported as
+ *    "not measurable from this export" (AC-AUDIT-002).
+ * 3. **No composite score, no ranking.** Five counts, published separately,
+ *    with the detection rule beside each one. A single number would turn an
+ *    instrument into a weapon and would be dismissed as vendor FUD on sight.
+ */
+import { closeSync, openSync, readFileSync, readSync } from "node:fs";
+import { sha256Hex } from "../../core/ids";
+import { parseReferenceGraph } from "../../core/portability";
+import { RECALLED_SOURCE_TYPE } from "../../core/validate";
+import { TITEN_VERSION } from "../../core/version";
+import { openDatabase } from "./sqlite";
+
+export const METRICS = [
+  "exact_duplicate",
+  "near_duplicate",
+  "recall_loop",
+  "secret_pattern",
+  "stale",
+] as const;
+export type Metric = (typeof METRICS)[number];
+
+export type Format = "titen-sqlite" | "reference-memory" | "mem0-export";
+
+const FORMAT_LABELS: Record<Format, string> = {
+  "titen-sqlite": "Titen store (SQLite)",
+  "reference-memory": "@modelcontextprotocol/server-memory store",
+  "mem0-export": "Mem0 export",
+};
+
+export interface AuditEntry {
+  /** A locator the reader can find in the original store by hand. */
+  id: string;
+  text: string;
+  /** When the store says the entry was written, when it says at all. */
+  writtenAt?: string;
+  /** Store-assigned provenance, when the store assigns any. */
+  sourceType?: string;
+  /** When the entry was last served back after it was written. */
+  recalledAt?: string;
+}
+
+export interface Store {
+  format: Format;
+  entries: AuditEntry[];
+  /** Which signals the export carries at all. Absence is never a failure. */
+  signals: { provenance: boolean; retrieval: boolean };
+  /**
+   * Canonical text of everything the store served back, mapped to the first
+   * time it was served. Present only where a store records what it returned.
+   */
+  served: Map<string, string>;
+}
+
+export interface Finding {
+  entry_id: string;
+  evidence: string;
+}
+
+export interface MetricReport {
+  metric: Metric;
+  measurable: boolean;
+  /** The published detection rule, verbatim, beside the number it produced. */
+  rule: string;
+  /** Why the number is absent. Never "fail", never folded into a score. */
+  reason?: string;
+  count: number | null;
+  rate: number | null;
+  findings: Finding[];
+}
+
+export interface AuditReport {
+  tool: "titen audit";
+  titen_version: string;
+  path: string;
+  format: Format;
+  entries: number;
+  first_written_at: string | null;
+  last_written_at: string | null;
+  metrics: MetricReport[];
+  /**
+   * Explicitly null, and machine-readable as such: these five counts measure
+   * different things and are never combined into one number or a ranking.
+   */
+  composite_score: null;
+}
+
+export const NOT_MEASURABLE = "not measurable from this export";
+
+// --- Detection rules, published in docs/reference/audit.md ---
+
+/**
+ * Canonical form used by the near-duplicate rule: Unicode NFKC, lowercased,
+ * with every run of non-letter/non-digit characters collapsed to one space.
+ * Two entries share a canonical hash when they differ only in case, spacing,
+ * or punctuation.
+ *
+ * Deliberately not Titen's `observations.canonical_hash` column, which mixes in
+ * the actor, subject, project and provenance and is therefore a replay key
+ * rather than a duplicate detector: two agents writing the same sentence get
+ * different canonical hashes there, by design.
+ *
+ * Known ceiling, accepted deliberately: exact match after canonicalization, not
+ * an embedding or a shingle-similarity score, so paraphrase is invisible and the
+ * count is a floor. It is the only rule a reader can re-derive with `tr` and
+ * `sort -u`, and a threshold nobody can reproduce would sink the whole
+ * instrument. If it proves too tight, publish a second, clearly separate metric
+ * rather than loosening this one.
+ */
+export function canonicalText(text: string): string {
+  return text.normalize("NFKC").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, " ").trim();
+}
+
+interface SecretRule {
+  name: string;
+  pattern: RegExp;
+  /** Rules that trade precision for coverage are named so a reader can discount them. */
+  precision: "high" | "low";
+}
+
+/**
+ * A small set of high-signal patterns for credential shapes that are unusable
+ * once rotated, plus one deliberately looser rule for the most common real
+ * case: an agent told a password in prose. Per-rule counts are always reported,
+ * so the loose rule can be discounted by anyone who disagrees with it.
+ */
+export const SECRET_RULES: readonly SecretRule[] = [
+  { name: "aws_access_key_id", pattern: /\bAKIA[0-9A-Z]{16}\b/g, precision: "high" },
+  { name: "private_key_block", pattern: /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----/g, precision: "high" },
+  { name: "github_token", pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g, precision: "high" },
+  { name: "slack_token", pattern: /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/g, precision: "high" },
+  { name: "google_api_key", pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, precision: "high" },
+  { name: "openai_style_key", pattern: /\bsk-(?:[A-Za-z0-9]+-)?[A-Za-z0-9_-]{20,}\b/g, precision: "high" },
+  {
+    name: "jwt",
+    pattern: /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+    precision: "high",
+  },
+  { name: "url_basic_auth", pattern: /\b[a-z][a-z0-9+.-]*:\/\/[^\s/:@]+:[^\s/@]+@/gi, precision: "high" },
+  {
+    name: "assigned_credential",
+    pattern:
+      /\b(?:pass(?:word|wd)?|secret|api[_-]?key|access[_-]?token|token)\b\s*(?:[:=]|\bis\b)\s*["']?([^\s"',;]{8,})/gi,
+    precision: "low",
+  },
+];
+
+/** Keeps a candidate credential out of a report the user may hand to someone else. */
+function mask(value: string): string {
+  return `${value.slice(0, 4)}…(${value.length} chars)`;
+}
+
+interface SecretHit {
+  rule: SecretRule;
+  offset: number;
+  masked: string;
+}
+
+export function secretHits(text: string): SecretHit[] {
+  const hits: SecretHit[] = [];
+  for (const rule of SECRET_RULES)
+    for (const match of text.matchAll(rule.pattern))
+      hits.push({
+        rule,
+        offset: match.index ?? 0,
+        masked: mask(match[1] ?? match[0]),
+      });
+  return hits.sort((left, right) => left.offset - right.offset);
+}
+
+/**
+ * Quoting memory content back at the reader is the whole point of per-item
+ * evidence, so it is masked on the way out: a duplicate that happens to contain
+ * a credential must not leak it through the duplicate finding.
+ */
+function excerpt(text: string, limit = 100): string {
+  let masked = text;
+  for (const rule of SECRET_RULES)
+    // `replace` passes the offset where a pattern has no capture group, so the
+    // group is taken only when it really is one.
+    masked = masked.replace(rule.pattern, (match: string, ...rest: unknown[]) =>
+      typeof rest[0] === "string" ? match.replace(rest[0], mask(rest[0])) : mask(match));
+  const flat = masked.replace(/\s+/g, " ").trim();
+  return flat.length > limit ? `${flat.slice(0, limit)}…` : flat;
+}
+
+// --- Readers ---
+
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+export function detectFormat(path: string): Format {
+  const handle = openSync(path, "r");
+  try {
+    const header = new Uint8Array(16);
+    const read = readSync(handle, header, 0, 16, 0);
+    if (read === 16 && new TextDecoder("latin1").decode(header) === SQLITE_MAGIC)
+      return "titen-sqlite";
+  } finally {
+    closeSync(handle);
+  }
+  const text = readFileSync(path, "utf8");
+  const first = text.split("\n").find((line) => line.trim());
+  if (first !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(first);
+      const type = (parsed as { type?: unknown } | null)?.type;
+      if (type === "entity" || type === "relation") return "reference-memory";
+    } catch {
+      // Not a single-line JSON document; fall through to the whole-file parse.
+    }
+    try {
+      JSON.parse(text);
+      return "mem0-export";
+    } catch {
+      // Neither shape.
+    }
+  }
+  throw new Error(
+    `${path} is not a Titen SQLite store, a reference-server memory.json(l), or a Mem0 export`,
+  );
+}
+
+/** A fresh object per store: a shared default map is a bug waiting for a writer. */
+const textOnly = () => ({
+  signals: { provenance: false, retrieval: false },
+  served: new Map<string, string>(),
+});
+
+function readReferenceStore(path: string): Store {
+  const graph = parseReferenceGraph(readFileSync(path, "utf8"));
+  return {
+    ...textOnly(),
+    format: "reference-memory",
+    // Relations carry no free text of their own and are structure rather than
+    // entries; only observations are audited, and the count says so.
+    entries: graph.entities.flatMap((entity) =>
+      entity.observations.map((text, index) => ({ id: `${entity.name}#${index + 1}`, text }))),
+  };
+}
+
+const stringField = (row: Record<string, unknown>, ...names: string[]): string | undefined => {
+  for (const name of names) if (typeof row[name] === "string" && row[name]) return row[name] as string;
+  return undefined;
+};
+
+/** Mem0 exports appear as a bare array, `{results}`, `{memories}`, or `{data:{results}}`. */
+function mem0Records(value: unknown): Record<string, unknown>[] {
+  const candidates: unknown[] = [value];
+  const root = value as Record<string, unknown> | null;
+  if (root && typeof root === "object")
+    candidates.push(root.results, root.memories, root.data,
+      (root.data as Record<string, unknown> | undefined)?.results);
+  for (const candidate of candidates)
+    if (Array.isArray(candidate))
+      return candidate.filter((row): row is Record<string, unknown> =>
+        Boolean(row) && typeof row === "object" && !Array.isArray(row));
+  return [];
+}
+
+function readMem0Store(path: string): Store {
+  const records = mem0Records(JSON.parse(readFileSync(path, "utf8")));
+  const entries: AuditEntry[] = [];
+  for (const [index, record] of records.entries()) {
+    const text = stringField(record, "memory", "content", "text");
+    if (text === undefined) continue;
+    const writtenAt = stringField(record, "created_at", "createdAt");
+    entries.push({
+      id: stringField(record, "id") ?? `record#${index + 1}`,
+      text,
+      ...(writtenAt ? { writtenAt } : {}),
+    });
+  }
+  return { ...textOnly(), format: "mem0-export", entries };
+}
+
+interface TitenRow {
+  id: string;
+  text: string;
+  source_type: string;
+  written_at: string;
+  recalled_at: string | null;
+}
+
+/**
+ * Reads a Titen store, strictly read-only: an audit that mutates the store it
+ * measures is not an audit. Observations are the audited entries because this
+ * measures the write path, and because they are where Titen's own provenance
+ * stamp lives.
+ *
+ * An observation counts as recalled when a claim it supports appeared in a
+ * context pack compiled after the observation was written. Direct evidence
+ * reads are not logged per record, so the stale count is an upper bound and the
+ * reference doc says so.
+ */
+function readTitenStore(path: string): Store {
+  const database = openDatabase(path, { create: false, readonly: true });
+  try {
+    let rows: TitenRow[];
+    try {
+      rows = database.query(
+        `SELECT o.id AS id, o.content AS text, o.source_type AS source_type,
+                o.ingested_at AS written_at,
+                (SELECT MAX(r.created_at)
+                   FROM claim_sources s
+                   JOIN context_run_items i ON i.claim_id = s.claim_id
+                   JOIN context_runs r ON r.id = i.context_id
+                  WHERE s.observation_id = o.id AND r.created_at > o.ingested_at) AS recalled_at
+           FROM observations o
+          ORDER BY o.ingested_at, o.id`,
+      ).all() as TitenRow[];
+    } catch (error) {
+      throw new Error(
+        `${path} is a SQLite database but not a Titen store: ${
+          error instanceof Error ? error.message : "unreadable"
+        }`,
+      );
+    }
+    const served = new Map<string, string>();
+    for (const row of database.query(
+      `SELECT c.statement AS statement, MIN(r.created_at) AS served_at
+         FROM context_run_items i
+         JOIN context_runs r ON r.id = i.context_id
+         JOIN claims c ON c.id = i.claim_id
+        GROUP BY c.id`,
+    ).all() as { statement: string; served_at: string }[]) {
+      const key = canonicalText(row.statement);
+      const earliest = served.get(key);
+      if (earliest === undefined || row.served_at < earliest) served.set(key, row.served_at);
+    }
+    return {
+      format: "titen-sqlite",
+      signals: { provenance: true, retrieval: true },
+      served,
+      entries: rows.map((row) => ({
+        id: row.id,
+        text: row.text,
+        writtenAt: row.written_at,
+        sourceType: row.source_type,
+        ...(row.recalled_at ? { recalledAt: row.recalled_at } : {}),
+      })),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+export function readStore(path: string): Store {
+  const format = detectFormat(path);
+  if (format === "titen-sqlite") return readTitenStore(path);
+  if (format === "mem0-export") return readMem0Store(path);
+  return readReferenceStore(path);
+}
+
+// --- Metrics ---
+
+const RULES: Record<Metric, string> = {
+  exact_duplicate: "byte-identical entry text; a group of N copies counts N-1 redundant entries",
+  near_duplicate:
+    "identical after NFKC + lowercase + non-alphanumeric collapse, but not byte-identical",
+  recall_loop:
+    "provenance the store itself assigned as recalled, or entry text canonically equal to something the store served back before the entry was written",
+  secret_pattern: `entry matching any of ${SECRET_RULES.length} published credential patterns`,
+  stale: "no recorded retrieval of the entry after it was written",
+};
+
+const groupBy = (entries: AuditEntry[], key: (entry: AuditEntry) => string) => {
+  const groups = new Map<string, AuditEntry[]>();
+  for (const entry of entries) {
+    const group = groups.get(key(entry));
+    if (group) group.push(entry);
+    else groups.set(key(entry), [entry]);
+  }
+  return groups;
+};
+
+const shortHash = async (value: string) => (await sha256Hex(value)).slice(0, 8);
+
+function report(
+  metric: Metric,
+  entries: number,
+  findings: Finding[],
+  count = findings.length,
+): MetricReport {
+  return {
+    metric,
+    measurable: true,
+    rule: RULES[metric],
+    count,
+    rate: entries ? count / entries : null,
+    findings,
+  };
+}
+
+function unmeasurable(metric: Metric, reason: string): MetricReport {
+  return {
+    metric,
+    measurable: false,
+    rule: RULES[metric],
+    reason: `${NOT_MEASURABLE}: ${reason}`,
+    count: null,
+    rate: null,
+    findings: [],
+  };
+}
+
+export async function analyze(store: Store): Promise<MetricReport[]> {
+  const { entries } = store;
+  const total = entries.length;
+
+  const exact: Finding[] = [];
+  for (const group of groupBy(entries, (entry) => entry.text).values()) {
+    if (group.length < 2) continue;
+    const digest = await shortHash(group[0]!.text);
+    for (const duplicate of group.slice(1))
+      exact.push({
+        entry_id: duplicate.id,
+        evidence: `byte-identical to ${group[0]!.id} (group ${digest}): "${excerpt(duplicate.text)}"`,
+      });
+  }
+
+  const near: Finding[] = [];
+  for (const group of groupBy(entries, (entry) => canonicalText(entry.text)).values()) {
+    if (group.length < 2) continue;
+    // Keep the first occurrence of each distinct text: the finding names the
+    // entry a reader would keep, not whichever copy happened to be scanned last.
+    const byText = new Map<string, AuditEntry>();
+    for (const entry of group) if (!byText.has(entry.text)) byText.set(entry.text, entry);
+    const distinct = [...byText.values()];
+    if (distinct.length < 2) continue;
+    const digest = await shortHash(canonicalText(group[0]!.text));
+    for (const duplicate of distinct.slice(1))
+      near.push({
+        entry_id: duplicate.id,
+        evidence: `canonically equal to ${distinct[0]!.id} (group ${digest}): "${
+          excerpt(distinct[0]!.text)
+        }" vs "${excerpt(duplicate.text)}"`,
+      });
+  }
+
+  const secrets: Finding[] = [];
+  const perRule = new Map<string, number>();
+  for (const entry of entries) {
+    const hits = secretHits(entry.text);
+    if (!hits.length) continue;
+    for (const name of new Set(hits.map((hit) => hit.rule.name)))
+      perRule.set(name, (perRule.get(name) ?? 0) + 1);
+    secrets.push({
+      entry_id: entry.id,
+      evidence: hits
+        .map((hit) => `${hit.rule.name}${hit.rule.precision === "low" ? " (low precision)" : ""} at offset ${hit.offset}: ${hit.masked}`)
+        .join("; "),
+    });
+  }
+  const secretReport = report("secret_pattern", total, secrets);
+  if (perRule.size)
+    secretReport.rule = `${RULES.secret_pattern} — matched: ${
+      [...perRule].map(([name, count]) => `${name} ${count}`).join(", ")
+    }`;
+
+  const recall = store.signals.provenance || store.signals.retrieval
+    ? report("recall_loop", total, entries.flatMap((entry) => {
+        const reasons: string[] = [];
+        if (entry.sourceType === RECALLED_SOURCE_TYPE)
+          reasons.push(`store-assigned provenance "${RECALLED_SOURCE_TYPE}"`);
+        const servedAt = store.served.get(canonicalText(entry.text));
+        if (servedAt !== undefined && entry.writtenAt !== undefined && servedAt < entry.writtenAt)
+          reasons.push(`canonically equal to output served at ${servedAt}, before this entry was written at ${entry.writtenAt}`);
+        return reasons.length
+          ? [{ entry_id: entry.id, evidence: `${reasons.join("; ")}: "${excerpt(entry.text)}"` }]
+          : [];
+      }))
+    : unmeasurable(
+        "recall_loop",
+        "it records neither who assigned an entry's provenance nor what the store previously returned",
+      );
+
+  const stale = store.signals.retrieval
+    ? report("stale", total, entries.flatMap((entry) => entry.recalledAt === undefined
+        ? [{
+            entry_id: entry.id,
+            evidence: `never served after it was written${
+              entry.writtenAt ? ` at ${entry.writtenAt}` : ""
+            }: "${excerpt(entry.text)}"`,
+          }]
+        : []))
+    : unmeasurable("stale", "it records no retrieval history, so no entry can be shown to have been read back");
+
+  return [
+    report("exact_duplicate", total, exact),
+    report("near_duplicate", total, near),
+    recall,
+    secretReport,
+    stale,
+  ];
+}
+
+export async function auditStore(path: string): Promise<AuditReport> {
+  const store = readStore(path);
+  const written = store.entries
+    .map((entry) => entry.writtenAt)
+    .filter((value): value is string => typeof value === "string")
+    .sort();
+  return {
+    tool: "titen audit",
+    titen_version: TITEN_VERSION,
+    path,
+    format: store.format,
+    entries: store.entries.length,
+    first_written_at: written[0] ?? null,
+    last_written_at: written.at(-1) ?? null,
+    metrics: await analyze(store),
+    composite_score: null,
+  };
+}
+
+// --- Rendering ---
+
+const LABELS: Record<Metric, string> = {
+  exact_duplicate: "exact duplicate",
+  near_duplicate: "near duplicate",
+  recall_loop: "recall loop",
+  secret_pattern: "secret pattern",
+  stale: "stale",
+};
+
+const EVIDENCE_SHOWN = 10;
+
+export function renderReport(audit: AuditReport): string {
+  const lines = [
+    `titen audit ${audit.titen_version}`,
+    `input:   ${audit.path}`,
+    `format:  ${FORMAT_LABELS[audit.format]}`,
+    `entries: ${audit.entries}`,
+  ];
+  if (audit.first_written_at)
+    lines.push(`written: ${audit.first_written_at} .. ${audit.last_written_at}`);
+  lines.push("", "metric                count   rate      rule");
+  for (const metric of audit.metrics) {
+    const label = LABELS[metric.metric].padEnd(20);
+    if (!metric.measurable) {
+      lines.push(`${label}      -       -   ${metric.reason}`);
+      continue;
+    }
+    const rate = metric.rate === null ? "-" : `${(metric.rate * 100).toFixed(1)}%`;
+    lines.push(`${label} ${String(metric.count).padStart(6)} ${rate.padStart(7)}   ${metric.rule}`);
+  }
+  lines.push(
+    "",
+    "These five counts measure different things, are reported separately, and are",
+    "never combined. Titen publishes no composite score and no ranking from them.",
+    "Detection rules: docs/reference/audit.md",
+  );
+  for (const metric of audit.metrics) {
+    if (!metric.findings.length) continue;
+    lines.push("", `${LABELS[metric.metric]} — ${metric.findings.length} finding${
+      metric.findings.length === 1 ? "" : "s"
+    }`);
+    for (const finding of metric.findings.slice(0, EVIDENCE_SHOWN))
+      lines.push(`  ${finding.entry_id}  ${finding.evidence}`);
+    if (metric.findings.length > EVIDENCE_SHOWN)
+      lines.push(`  ... ${metric.findings.length - EVIDENCE_SHOWN} more (use --json for every item)`);
+  }
+  return lines.join("\n");
+}

--- a/src/runtime/bun/cli.ts
+++ b/src/runtime/bun/cli.ts
@@ -6,9 +6,8 @@
 // message naming neither Titen nor Bun. Line 2 is a string expression plus a
 // comment to TypeScript and the whole check to `sh`, which never reaches line 3
 // because it has already exec'd Bun or exited. One entry, one guard.
-import { createApiKey, keyLifecycleStatus, organizationStatement, SCOPES } from "../../core/auth";
-import { newOperatorAccount } from "../../core/accounts";
-import { auditStatement } from "../../core/audit";
+import { createApiKey, keyLifecycleStatus, SCOPES } from "../../core/auth";
+import type { Stmt } from "../../core/db";
 import { MIGRATIONS, migrate, pendingMigrations, schemaState } from "../../core/migrations";
 import { newId } from "../../core/ids";
 import { TRUST_LEVELS, type Trust } from "../../core/validate";
@@ -19,7 +18,8 @@ import { parseSecretCipher } from "../../core/secrets";
 import { TITEN_VERSION } from "../../core/version";
 import { createBunWebhookSecurity } from "./webhooks";
 import { fetchStableRelease, stableVersionStatus } from "./release";
-import { runMcpStdio } from "./mcp-stdio";
+import { localStorePath, provisionOwner, runMcpStdio } from "./mcp-stdio";
+import { auditStore, renderReport } from "./audit";
 import { chmodSync, copyFileSync, existsSync, mkdtempSync, renameSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -29,7 +29,8 @@ const USAGE = `titen — self-hosted memory service
 Usage:
   titen --version
   titen version    [--check]
-  titen mcp        bridge inherited TITEN_MCP_URL and TITEN_API_KEY to stdio
+  titen mcp        serve MCP over stdio: the local store when no environment is
+                   set, otherwise a bridge to inherited TITEN_MCP_URL/TITEN_API_KEY
   titen serve      [--db titen.db] [--port 8787] [--host 127.0.0.1] [--revision dev] [--quiet]
   titen migrate    [--db titen.db] [--dry-run]
   titen bootstrap  [--db titen.db] [--org "My Org"] [--username owner] [--label owner] [--print-sql]
@@ -40,8 +41,16 @@ Usage:
   titen key revoke [--db titen.db] --id <key id>
   titen backup     [--db titen.db] --out <file>   verified online copy
   titen schema     print every migration statement (for "wrangler d1 execute --file")
+  titen audit      <path> [--json]   offline write-hygiene report for a Titen
+                   store, a @modelcontextprotocol/server-memory memory.json(l),
+                   or a Mem0 export
 
 Notes:
+  With neither TITEN_MCP_URL nor TITEN_API_KEY set, "titen mcp" serves
+  ${localStorePath()} in process, creating it with one organization,
+  workspace, project, and owner on first run.
+  "audit" opens its path read-only and makes no network call of any kind. It
+  prints a report; sharing it is the reader's decision.
   --print-sql emits SQL for a remote database (Cloudflare D1) instead of writing
   locally. A raw key and temporary dashboard password are printed once and are
   never recoverable afterwards.
@@ -53,8 +62,12 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-const COMMAND_FLAGS: Record<string, { values: string[]; booleans?: string[] }> = {
+const COMMAND_FLAGS: Record<
+  string,
+  { values: string[]; booleans?: string[]; positional?: string }
+> = {
   version: { values: [], booleans: ["check"] },
+  audit: { values: [], booleans: ["json"], positional: "path" },
   mcp: { values: [] },
   serve: { values: ["db", "port", "host", "revision"], booleans: ["quiet"] },
   migrate: { values: ["db"], booleans: ["dry-run"] },
@@ -83,7 +96,8 @@ function parseArgs(argv: string[]) {
     console.log(USAGE);
     process.exit(0);
   }
-  if (argv.length === 0) return { command: undefined, action: undefined, flags: {} };
+  if (argv.length === 0)
+    return { command: undefined, action: undefined, flags: {}, positional: undefined };
 
   const command = argv[0]!;
   const action = command === "key" ? argv[1] : undefined;
@@ -94,7 +108,16 @@ function parseArgs(argv: string[]) {
   const flags: Record<string, string | boolean> = {};
   const values = new Set(schema.values);
   const booleans = new Set(schema.booleans ?? []);
-  for (let index = action ? 2 : 1; index < argv.length; index += 1) {
+  let start = action ? 2 : 1;
+  let positional: string | undefined;
+  if (schema.positional) {
+    const token = argv[start];
+    if (token === undefined || token.startsWith("--"))
+      fail(`${name} requires a ${schema.positional}`);
+    positional = token;
+    start += 1;
+  }
+  for (let index = start; index < argv.length; index += 1) {
     const token = argv[index]!;
     if (!token.startsWith("--") || token === "--") fail(`unexpected argument "${token}"`);
     const key = token.slice(2);
@@ -109,7 +132,7 @@ function parseArgs(argv: string[]) {
     flags[key] = value;
     index += 1;
   }
-  return { command, action, flags };
+  return { command, action, flags, positional };
 }
 
 const text = (value: string | boolean | undefined, fallback: string) =>
@@ -137,9 +160,9 @@ function sqlLiteral(value: string | number | null): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-function renderStatement(statement: { sql: string; params: (string | number | null)[] }): string {
+function renderStatement(statement: Stmt): string {
   let index = 0;
-  const inlined = statement.sql.replace(/\?/g, () => sqlLiteral(statement.params[index++] ?? null));
+  const inlined = statement.sql.replace(/\?/g, () => sqlLiteral(statement.params?.[index++] ?? null));
   return `${inlined.replace(/\s+/g, " ").trim()};`;
 }
 
@@ -206,10 +229,23 @@ async function existingDatabase<T>(
   }
 }
 
-const { flags, command, action } = parseArgs(process.argv.slice(2));
+const { flags, command, action, positional } = parseArgs(process.argv.slice(2));
 const dbPath = text(flags.db, "titen.db");
 
 switch (command) {
+  case "audit": {
+    // Offline by construction: nothing below opens a socket, and the report is
+    // written to this process's stdout only. See src/runtime/bun/audit.ts.
+    let audit: Awaited<ReturnType<typeof auditStore>>;
+    try {
+      audit = await auditStore(positional!);
+    } catch (error) {
+      fail(error instanceof Error ? error.message : "audit failed");
+    }
+    console.log(flags.json ? JSON.stringify(audit, null, 2) : renderReport(audit));
+    break;
+  }
+
   case "mcp": {
     try {
       await runMcpStdio();
@@ -324,30 +360,11 @@ switch (command) {
 
   case "bootstrap": {
     const orgName = text(flags.org, "Titen");
-    const ownerUsername = text(flags.username, "owner");
-    const orgId = newId("org");
-    const now = new Date();
-    const key = await createApiKey({
-      orgId,
-      principalId: "owner",
-      principalKind: "human",
+    const { orgId, key, owner, statements } = await provisionOwner({
+      orgName,
+      username: text(flags.username, "owner"),
       label: text(flags.label, "owner"),
-      scopes: ["*"],
-      maxTrust: "policy_approved",
-    }, now);
-    const owner = await newOperatorAccount({
-      orgId,
-      createdBy: "owner",
-      username: ownerUsername,
-      role: "owner",
-      scopes: ["*"],
-      maxTrust: "policy_approved",
-      now,
-      principalId: "owner",
     });
-    const org = organizationStatement(orgId, orgName, now);
-    const statements = [org, key.statement, ...owner.statements,
-      auditStatement(orgId, "owner", "operator_account.create", "operator_account", now.toISOString(), owner.accountId)];
     if (flags["print-sql"]) {
       console.error(`-- organization ${orgId} (${orgName})`);
       for (const statement of statements) console.log(renderStatement(statement));

--- a/src/runtime/bun/mcp-stdio.ts
+++ b/src/runtime/bun/mcp-stdio.ts
@@ -1,3 +1,18 @@
+import { createApp } from "../../core/app";
+import { authenticate, createApiKey, organizationStatement } from "../../core/auth";
+import { newOperatorAccount } from "../../core/accounts";
+import { auditStatement } from "../../core/audit";
+import { first, type Db, type Stmt } from "../../core/db";
+import { newId } from "../../core/ids";
+import { migrate } from "../../core/migrations";
+import { parseReferenceGraph } from "../../core/portability";
+import { prepareSigningSecrets } from "../../core/secrets";
+import { TITEN_VERSION } from "../../core/version";
+import { createSqliteDb, openDatabase } from "./sqlite";
+import { appendFileSync, chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+
 type JsonRpcId = string | number | null;
 
 type StdioOptions = {
@@ -37,11 +52,342 @@ function endpointFrom(raw: string): URL {
   return url;
 }
 
+// --- Zero-config local store ---
+
+/**
+ * One provisioning routine, used by `titen bootstrap` and by the local store
+ * below. Returns statements only: the caller decides whether they are written,
+ * printed as SQL for a remote database, or rolled back.
+ */
+export async function provisionOwner(input: {
+  orgName: string;
+  username: string;
+  label: string;
+  orgId?: string;
+  now?: Date;
+}) {
+  const now = input.now ?? new Date();
+  const orgId = input.orgId ?? newId("org");
+  const key = await createApiKey({
+    orgId,
+    principalId: "owner",
+    principalKind: "human",
+    label: input.label,
+    scopes: ["*"],
+    maxTrust: "policy_approved",
+  }, now);
+  const owner = await newOperatorAccount({
+    orgId,
+    createdBy: "owner",
+    username: input.username,
+    role: "owner",
+    scopes: ["*"],
+    maxTrust: "policy_approved",
+    now,
+    principalId: "owner",
+  });
+  const statements: Stmt[] = [
+    organizationStatement(orgId, input.orgName, now),
+    key.statement,
+    ...owner.statements,
+    auditStatement(
+      orgId, "owner", "operator_account.create", "operator_account",
+      now.toISOString(), owner.accountId,
+    ),
+  ];
+  return { orgId, key, owner, statements };
+}
+
+/**
+ * Ids of the organization, workspace and project a new local store provisions.
+ * They are fixed rather than random so that two `titen mcp` processes racing on
+ * a brand new file cannot both win: the loser's organization INSERT violates the
+ * primary key, its whole batch rolls back, and it adopts what the winner wrote
+ * instead of silently splitting one machine's memory across two organizations.
+ */
+const LOCAL_ORG_ID = "org_local";
+const LOCAL_WORKSPACE_ID = "ws_local";
+const LOCAL_PROJECT_ID = "project_local";
+const LOCAL_KEY_LABEL = "local";
+
+export function localStorePath(): string {
+  return join(homedir(), ".titen", "memory.db");
+}
+
+const firstOrganization = (db: Db) =>
+  first<{ id: string }>(db, `SELECT id FROM organizations ORDER BY created_at, id LIMIT 1`);
+
+async function authenticates(db: Db, rawKey: string): Promise<boolean> {
+  try {
+    await authenticate(
+      db,
+      new Request("http://127.0.0.1/v1/principal", {
+        headers: { authorization: `Bearer ${rawKey}` },
+      }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Real records, not a special case: the key this returns is checked by exactly
+ * the same core predicates a served deployment uses.
+ */
+async function localOwnerKey(db: Db, keyPath: string): Promise<string> {
+  const stored = existsSync(keyPath) ? readFileSync(keyPath, "utf8").trim() : "";
+  if (stored && await authenticates(db, stored)) return stored;
+
+  const now = new Date();
+  const raw = await provisionLocalOwner(db, now);
+  // Only a key's hash is stored, so a raw key cannot be recovered from the
+  // database. Keeping it beside the store means a restart reuses one owner
+  // instead of accumulating a credential row per process; the store it opens is
+  // a plaintext SQLite file in the same directory, so this widens no access.
+  writeFileSync(keyPath, `${raw}\n`, { mode: 0o600 });
+  chmodSync(keyPath, 0o600);
+  return raw;
+}
+
+async function provisionLocalOwner(db: Db, now: Date): Promise<string> {
+  const at = now.toISOString();
+  if (!(await firstOrganization(db))) {
+    const provisioned = await provisionOwner({
+      orgId: LOCAL_ORG_ID,
+      orgName: "Local",
+      username: "owner",
+      label: LOCAL_KEY_LABEL,
+      now,
+    });
+    try {
+      await db.batch([
+        ...provisioned.statements,
+        {
+          sql: `INSERT INTO workspaces (id, org_id, name, created_at) VALUES (?, ?, 'Local', ?)`,
+          params: [LOCAL_WORKSPACE_ID, LOCAL_ORG_ID, at],
+        },
+        {
+          sql: `INSERT INTO memberships
+                  (id, org_id, workspace_id, principal_id, principal_kind, role, created_at)
+                VALUES (?, ?, ?, 'owner', 'human', 'owner', ?)`,
+          params: [newId("mbr"), LOCAL_ORG_ID, LOCAL_WORKSPACE_ID, at],
+        },
+        {
+          sql: `INSERT INTO projects (id, org_id, reference, created_at) VALUES (?, ?, 'local', ?)`,
+          params: [LOCAL_PROJECT_ID, LOCAL_ORG_ID, at],
+        },
+      ]);
+      return provisioned.key.key;
+    } catch (error) {
+      // A lost race leaves a complete store written by the winner. Anything else
+      // (a full disk, a corrupt file) must not be reported as one.
+      if (!(await firstOrganization(db))) throw error;
+    }
+  }
+  // An existing store keeps its own organization, whether the winner of a race
+  // wrote it or an operator ran `titen bootstrap` against this path.
+  const key = await createApiKey({
+    orgId: (await firstOrganization(db))!.id,
+    principalId: "owner",
+    principalKind: "human",
+    label: LOCAL_KEY_LABEL,
+    scopes: ["*"],
+    maxTrust: "policy_approved",
+  }, now);
+  await db.batch([key.statement]);
+  return key.key;
+}
+
+/**
+ * Opens the zero-config local store, creating `~/.titen/memory.db` with a real
+ * organization, workspace, project and owner principal when it is new.
+ *
+ * Returns the same request handler `serve` binds to a socket, without binding
+ * one: no listener for a local firewall to prompt about, no HTTP hop, and no
+ * vector capability, so retrieval is FTS-only and nothing reaches the network.
+ */
+export async function openLocalStore(dbPath = localStorePath()): Promise<{
+  app: (request: Request) => Promise<Response>;
+  apiKey: string;
+  close: () => void;
+}> {
+  mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
+  const database = openDatabase(dbPath);
+  try {
+    const db = createSqliteDb(database);
+    await migrate(db);
+    const apiKey = await localOwnerKey(db, `${dbPath}.key`);
+    return {
+      app: createApp({
+        db,
+        revision: TITEN_VERSION,
+        runtime: "bun-sqlite",
+        secretStorageReady: await prepareSigningSecrets(db, undefined),
+      }),
+      apiKey,
+      close: () => database.close(),
+    };
+  } catch (error) {
+    database.close();
+    throw error;
+  }
+}
+
+/**
+ * Address of the in-process local store. Nothing ever connects to it: the shim
+ * below answers every request without a socket. It exists because the request
+ * pipeline needs a URL, and it satisfies the same endpoint rules as a remote one.
+ */
+const LOCAL_ENDPOINT = "http://127.0.0.1/mcp";
+
+// --- Adopting an existing @modelcontextprotocol/server-memory store ---
+
+/**
+ * Where the reference MCP memory server keeps its graph. It reads
+ * `MEMORY_FILE_PATH` first and otherwise writes beside its own module; a user
+ * switching to Titen has that file in the directory they run from, under either
+ * the current `memory.jsonl` name or the pre-0.6.3 `memory.json`.
+ */
+export function referenceMemoryPath(cwd = process.cwd()): string | undefined {
+  const configured = process.env.MEMORY_FILE_PATH;
+  const candidates = configured
+    ? [isAbsolute(configured) ? configured : join(cwd, configured)]
+    : [join(cwd, "memory.jsonl"), join(cwd, "memory.json")];
+  return candidates.find((path) => existsSync(path));
+}
+
+/** Splits a list so no single MCP request approaches the 1 MiB body limit. */
+function batched<Item>(items: Item[], limit = 200_000): Item[][] {
+  const groups: Item[][] = [];
+  let current: Item[] = [];
+  let bytes = 0;
+  for (const item of items) {
+    const size = JSON.stringify(item).length;
+    if (current.length && bytes + size > limit) {
+      groups.push(current);
+      current = [];
+      bytes = 0;
+    }
+    current.push(item);
+    bytes += size;
+  }
+  if (current.length) groups.push(current);
+  return groups;
+}
+
+/**
+ * Imports a reference-server store through the same MCP tools a client calls,
+ * so the import path and the live path cannot drift apart.
+ *
+ * Entities are created before their observations are added rather than in one
+ * call, because both steps are idempotent that way: an import interrupted
+ * halfway resumes on the next start instead of leaving an entity whose
+ * remaining observations can never arrive. The marker file records which
+ * sources have been read — re-importing would resurrect entities the user
+ * deleted after switching.
+ */
+export async function importReferenceMemory(
+  local: { app: (request: Request) => Promise<Response>; apiKey: string },
+  source: string,
+  markerPath: string,
+): Promise<{ entities: number; relations: number } | undefined> {
+  const done = existsSync(markerPath)
+    ? readFileSync(markerPath, "utf8").split("\n").filter(Boolean)
+    : [];
+  if (done.includes(source)) return undefined;
+  const graph = parseReferenceGraph(readFileSync(source, "utf8"));
+
+  let messageId = 0;
+  const call = async (name: string, args: Record<string, unknown>) => {
+    const response = await local.app(new Request(LOCAL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${local.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: (messageId += 1),
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }));
+    const body = await response.json() as {
+      result?: { isError?: boolean; content?: { text?: string }[] };
+      error?: { message?: string };
+    };
+    const failure = body.error?.message
+      ?? (body.result?.isError ? body.result.content?.[0]?.text : undefined);
+    if (failure) throw new Error(`${name}: ${failure}`);
+  };
+
+  for (const group of batched(graph.entities))
+    await call("create_entities", {
+      entities: group.map(({ name, entityType }) => ({ name, entityType, observations: [] })),
+    });
+  for (const group of batched(graph.entities.filter((entity) => entity.observations.length)))
+    await call("add_observations", {
+      observations: group.map(({ name, observations }) => ({
+        entityName: name,
+        contents: observations,
+      })),
+    });
+  for (const group of batched(graph.relations))
+    await call("create_relations", { relations: group });
+
+  appendFileSync(markerPath, `${source}\n`, { mode: 0o600 });
+  return { entities: graph.entities.length, relations: graph.relations.length };
+}
+
+/**
+ * Zero-config local mode. With neither variable set there is nothing to bridge
+ * to, so `titen mcp` opens `~/.titen/memory.db` instead and serves the same MCP
+ * surface against it in process: no HTTP hop, no key to paste, no network.
+ *
+ * Local mode adds an entry point; it relaxes nothing. Every request below is
+ * authenticated and authorized by the same core predicates a served deployment
+ * uses, against a credential row that really exists.
+ */
+async function runLocalMcpStdio(options: StdioOptions): Promise<void> {
+  const dbPath = localStorePath();
+  const local = await openLocalStore(dbPath);
+  try {
+    const source = referenceMemoryPath();
+    // stdout is the MCP transport, so every word about the import goes to
+    // stderr. A failure leaves the marker unwritten and the next start retries;
+    // it must not take the memory server down with it.
+    if (source) try {
+      const imported = await importReferenceMemory(local, source, `${dbPath}.imported`);
+      if (imported) console.error(
+        `titen: imported ${imported.entities} entities and ${imported.relations} relations from ${source}`,
+      );
+    } catch (error) {
+      console.error(
+        `titen: could not import ${source}: ${error instanceof Error ? error.message : "unknown error"}`,
+      );
+    }
+    await runMcpStdio({
+      ...options,
+      endpoint: LOCAL_ENDPOINT,
+      apiKey: local.apiKey,
+      fetcher: (input, init) => local.app(new Request(input as string | URL, init)),
+    });
+  } finally {
+    local.close();
+  }
+}
+
 /** Adapts MCP's newline-delimited stdio transport to Titen's existing HTTP endpoint. */
 export async function runMcpStdio(options: StdioOptions = {}): Promise<void> {
   const rawEndpoint = options.endpoint ?? process.env.TITEN_MCP_URL;
   const apiKey = options.apiKey ?? process.env.TITEN_API_KEY;
-  if (!rawEndpoint || !apiKey) throw new Error("TITEN_MCP_URL and TITEN_API_KEY are required");
+  if (!rawEndpoint && !apiKey) return runLocalMcpStdio(options);
+  if (!rawEndpoint || !apiKey)
+    throw new Error(
+      "set both TITEN_MCP_URL and TITEN_API_KEY to bridge to a served instance, or neither to use the local store",
+    );
   if (apiKey !== apiKey.trim() || /[\r\n]/u.test(apiKey))
     throw new Error("TITEN_API_KEY is invalid");
 

--- a/tests/contract/cases.ts
+++ b/tests/contract/cases.ts
@@ -315,6 +315,124 @@ export const CASES: Case[] = [
     },
   },
   {
+    /**
+     * The write path's provenance is only worth measuring while it is a server
+     * verdict. This is the fail-closed check for that: if a forged `recalled`
+     * write is ever accepted, the recall-loop count becomes self-declared and
+     * every number built on it is worthless (#280).
+     */
+    name: "recalled provenance is server-issued, unforgeable, and closes the loop",
+    async run(fx) {
+      const agent = await fx.provision();
+      const subjectId = `recall_loop_${fx.runtime}`;
+
+      // A pointer back to the origin is mandatory, not advisory. This omits
+      // `source.ref` on purpose — do not "fix" it by adding one.
+      expectError(
+        await fx.call("POST", "/v1/observations", {
+          key: agent.key,
+          body: observation({ subject_id: subjectId, source: { type: "tool" } }),
+        }),
+        400,
+        "VALIDATION_ERROR",
+      );
+
+      // Forging the stamp by declaring it.
+      expectError(
+        await fx.call("POST", "/v1/observations", {
+          key: agent.key,
+          body: observation({
+            subject_id: subjectId,
+            source: { type: "recalled", ref: "loop#forged" },
+          }),
+        }),
+        400,
+        "VALIDATION_ERROR",
+      );
+
+      // Forging the stamp by inventing the token it is issued from. Refusing
+      // rather than ignoring it keeps an unrecognized token from silently
+      // recording a recalled write as fresh input.
+      expectError(
+        await fx.call("POST", "/v1/observations", {
+          key: agent.key,
+          body: observation({
+            subject_id: subjectId,
+            context_token: "ctx_00000000000000000000000000000000",
+          }),
+        }),
+        400,
+        "VALIDATION_ERROR",
+      );
+
+      const compiled = await fx.call("POST", "/v1/context/compile", {
+        key: agent.key,
+        body: { subject_id: subjectId, task: "what do we know about this deploy", max_tokens: 1200 },
+      });
+      expectOk(compiled);
+      const token = compiled.body.data.context_token as string;
+      assert.equal(typeof token, "string", "compile must issue a context token");
+
+      // Another organization's token is not a token here.
+      const stranger = await fx.provision();
+      const strangerCompile = await fx.call("POST", "/v1/context/compile", {
+        key: stranger.key,
+        body: { subject_id: subjectId, task: "borrowed pack", max_tokens: 1200 },
+      });
+      expectOk(strangerCompile);
+      expectError(
+        await fx.call("POST", "/v1/observations", {
+          key: agent.key,
+          body: observation({
+            subject_id: subjectId,
+            context_token: strangerCompile.body.data.context_token,
+          }),
+        }),
+        400,
+        "VALIDATION_ERROR",
+      );
+
+      // A caller carrying a genuine token cannot override the stamp either.
+      const stamped = await fx.call("POST", "/v1/observations", {
+        key: agent.key,
+        body: observation({
+          subject_id: subjectId,
+          content: "The compiled pack said deploys need a rollback smoke, so I stored that.",
+          context_token: token,
+          source: { type: "tool", ref: "loop#stamped" },
+        }),
+      });
+      expectOk(stamped, 201);
+      const observationId = stamped.body.data.observation_id as string;
+      const stored = await fx.query<{ source_type: string }>(
+        `SELECT source_type FROM observations WHERE id = ?`,
+        [observationId],
+      );
+      assert.equal(
+        stored[0]?.source_type,
+        "recalled",
+        "a write carrying a context token must be stamped recalled by the server",
+      );
+
+      // Closed, not merely labelled.
+      expectError(
+        await fx.call("POST", "/v1/consolidations", {
+          key: agent.key,
+          body: {
+            subject_id: subjectId,
+            claims: [{
+              kind: "semantic_fact",
+              statement: "Deploys need a rollback smoke.",
+              sources: [{ observation_id: observationId, relation: "supports" }],
+            }],
+          },
+        }),
+        400,
+        "VALIDATION_ERROR",
+      );
+    },
+  },
+  {
     name: "stable source identities and canonical claims converge outside request-key replay",
     async run(fx) {
       const agent = await fx.provision();
@@ -3431,7 +3549,9 @@ export const CASES: Case[] = [
         key: agent.key,
         body: { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
       });
-      assert.equal(tools.body.result.tools.length, 9);
+      // Nine native `titen_*` tools plus the nine @modelcontextprotocol/server-memory
+// names served for drop-in substitution (#279).
+      assert.equal(tools.body.result.tools.length, 18);
       assert.ok(tools.body.result.tools.some((t: any) => t.name === "titen_remember"));
       assert.ok(tools.body.result.tools.some((t: any) => t.name === "titen_consolidate"));
       assert.ok(tools.body.result.tools.some((t: any) => t.name === "titen_compile"));

--- a/tests/contract/cloudflare-d1.test.ts
+++ b/tests/contract/cloudflare-d1.test.ts
@@ -17,6 +17,7 @@ import {
   assertPopulatedV14SemanticOutageMigration,
 } from "./integrity-migration";
 import { acquireD1Lane, D1RunDiagnostics } from "./d1-harness";
+import { assertConcurrentWriterDurability, PAYLOADS, WRITERS } from "./durability";
 import { assertEnrichmentContract } from "./enrichment";
 import {
   assertSemanticIndexOwnership,
@@ -226,7 +227,7 @@ d1Test("workerd dispatches JSON-object extraction without following redirects", 
           subject_id: `subject_workerd_extraction_${suffix}`,
           kind: "user_statement",
           content: `Synthetic workerd extraction evidence ${suffix}.`,
-          source: { type: "test" },
+          source: { type: "test", ref: "contract://d1" },
         }),
       });
       assert.equal(response.status, 201);
@@ -553,3 +554,13 @@ for (const contractCase of CASES) {
   const run = async () => contractCase.run(fixture);
   d1Test(name, run);
 }
+
+// Last on purpose: its I3 check compares unscoped row counts across the whole
+// database, so it must not run while another case is populating it.
+d1Test("D1 holds the durability invariants under concurrent writers", async () => {
+  const report = await assertConcurrentWriterDurability(db, "cloudflare-d1");
+  assert.equal(report.observation_requests, WRITERS * PAYLOADS);
+  assert.equal(report.observation_rows, PAYLOADS);
+  assert.equal(report.claim_rows, 1);
+  assert.equal(report.partial_rows, 0);
+}, 60_000);

--- a/tests/contract/durability.ts
+++ b/tests/contract/durability.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { createApp } from "../../src/core/app";
+import type { Db, Stmt } from "../../src/core/db";
+import { clientVia, provisionWith } from "./harness";
+
+/**
+ * Concurrent-writer durability, stated as invariants before it is run.
+ *
+ * I1 — exactly one claim per canonical hash. N writers submitting byte-identical
+ *      content converge on one record id; a duplicate is permanent damage, and a
+ *      read-then-write check alone cannot prevent one.
+ * I2 — zero lost observations. Every submission either creates its record or
+ *      replays the record that won, and every distinct payload survives.
+ * I3 — no partial write survives a failed batch. A write whose batch fails leaves
+ *      no observation, no FTS projection, no history, no event, no outbox work,
+ *      and no idempotency receipt behind.
+ *
+ * The same assertions run on bun:sqlite and on D1, because the claim is about the
+ * shared core's write path, which expresses every atomic write as one batch
+ * (`src/core/db.ts`). Dedup lives inside that batch as a unique index, so the
+ * read-then-write window in `appendObservation` and `consolidate` is a fast path,
+ * not the safety mechanism — that is what these invariants exist to prove.
+ */
+
+const ORIGIN = "http://durability.test";
+
+/** Writers per payload. Six keeps a D1 round trip honest without a long lane. */
+export const WRITERS = 6;
+/** Distinct payloads in the same burst, so overlap is not the only case. */
+export const PAYLOADS = 4;
+
+export interface DurabilityReport {
+  runtime: string;
+  writers: number;
+  payloads: number;
+  /**
+   * Batches rejected by a canonical unique index during this run.
+   *
+   * Instrumentation, not an assertion: it records whether the read-then-write
+   * window actually opened on this runtime. Zero means the burst serialised and
+   * only the fast path was exercised — a weaker result that must be reported as
+   * such rather than read as "no race exists".
+   */
+  canonical_collisions: number;
+  /** Concurrent observation submissions issued in one burst. */
+  observation_requests: number;
+  observation_created: number;
+  observation_replayed: number;
+  observation_failed: number;
+  observation_rows: number;
+  observation_canonical_hashes: number;
+  claim_requests: number;
+  claim_created: number;
+  claim_replayed: number;
+  claim_failed: number;
+  claim_rows: number;
+  /** Rows left behind by the deliberately failed batch. Must be zero. */
+  partial_rows: number;
+}
+
+type Client = Pick<ReturnType<typeof clientVia>, "call">;
+
+const clientFor = (db: Db, runtime: string): Client =>
+  clientVia(createApp({ db, runtime, revision: "durability" }), ORIGIN);
+
+/** Counts the batches a canonical unique index rejected, without changing behaviour. */
+export function countingCanonicalCollisions(db: Db): { db: Db; collisions: () => number } {
+  let collisions = 0;
+  return {
+    collisions: () => collisions,
+    db: {
+      all: <Row>(sql: string, params: Parameters<Db["all"]>[1] = []) => db.all<Row>(sql, params),
+      exec: (sql: string) => db.exec(sql),
+      async batch(statements: Stmt[]) {
+        try {
+          await db.batch(statements);
+        } catch (error) {
+          if (error instanceof Error && /UNIQUE.*canonical_hash/iu.test(error.message)) collisions += 1;
+          throw error;
+        }
+      },
+    },
+  };
+}
+
+const observationBody = (runtime: string, index: number) => ({
+  subject_id: "subject_durability",
+  kind: "tool_result",
+  content: `Durability probe ${index} on ${runtime}.`,
+  // `source.id` is what makes the write canonically identifiable; without it the
+  // core assigns no canonical hash and every submission is a distinct record.
+  source: { type: "tool", ref: "durability", id: `durability-${index}` },
+  trust: "verified",
+});
+
+function assertAccepted(label: string, responses: { status: number; body: any }[]) {
+  const rejected = responses.filter((response) => response.status !== 200 && response.status !== 201);
+  assert.equal(
+    rejected.length,
+    0,
+    `${label}: ${rejected.length} concurrent writes were rejected: ${
+      JSON.stringify(rejected.slice(0, 3).map((response) => [response.status, response.body?.error]))
+    }`,
+  );
+}
+
+async function counters(db: Db) {
+  const [row] = await db.all<Record<string, number>>(
+    `SELECT (SELECT COUNT(*) FROM observations) AS observations,
+            (SELECT COUNT(*) FROM observations_fts) AS observations_fts,
+            (SELECT COUNT(*) FROM record_history) AS record_history,
+            (SELECT COUNT(*) FROM events) AS events,
+            (SELECT COUNT(*) FROM index_outbox) AS index_outbox,
+            (SELECT COUNT(*) FROM idempotency_v3) AS idempotency_v3`,
+  );
+  return Object.fromEntries(Object.entries(row!).map(([key, value]) => [key, Number(value)]));
+}
+
+export async function assertConcurrentWriterDurability(
+  db: Db,
+  runtime: string,
+): Promise<DurabilityReport> {
+  const principal = await provisionWith(db, { scopes: ["*"] });
+  const scope = [principal.orgId, principal.principalId];
+  const counted = countingCanonicalCollisions(db);
+  // Each writer is its own app instance over the same store, as N agents are.
+  const writers = Array.from({ length: WRITERS }, () => clientFor(counted.db, runtime));
+
+  // --- I1 + I2, observations -------------------------------------------------
+  const burst = writers.flatMap((client) =>
+    Array.from({ length: PAYLOADS }, (_, index) => ({
+      index,
+      sent: client.call("POST", "/v1/observations", {
+        key: principal.key,
+        body: observationBody(runtime, index),
+      }),
+    })));
+  const observed = await Promise.all(burst.map(async ({ index, sent }) => ({ index, res: await sent })));
+  assertAccepted("observations", observed.map(({ res }) => res));
+
+  for (let index = 0; index < PAYLOADS; index += 1) {
+    const group = observed.filter((entry) => entry.index === index);
+    const ids = new Set(group.map(({ res }) => res.body.data.observation_id as string));
+    assert.equal(
+      ids.size,
+      1,
+      `I1: payload ${index} minted ${ids.size} identities under ${WRITERS} concurrent writers`,
+    );
+    assert.equal(
+      group.filter(({ res }) => res.status === 201).length,
+      1,
+      `I1: payload ${index} reported more than one creation`,
+    );
+  }
+
+  const [observationRows] = await db.all<{
+    rows: number; hashes: number; fts: number; history: number; events: number;
+  }>(
+    `SELECT (SELECT COUNT(*) FROM observations WHERE org_id = ? AND actor_id = ?) AS rows,
+            (SELECT COUNT(DISTINCT canonical_hash) FROM observations
+              WHERE org_id = ? AND actor_id = ?) AS hashes,
+            (SELECT COUNT(*) FROM observations_fts f
+               JOIN observations o ON o.id = f.observation_id
+              WHERE o.org_id = ? AND o.actor_id = ?) AS fts,
+            (SELECT COUNT(*) FROM record_history
+              WHERE org_id = ? AND record_type = 'observation') AS history,
+            (SELECT COUNT(*) FROM events
+              WHERE org_id = ? AND kind = 'observation.appended') AS events`,
+    [...scope, ...scope, ...scope, principal.orgId, principal.orgId],
+  );
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(observationRows!).map(([key, value]) => [key, Number(value)])),
+    { rows: PAYLOADS, hashes: PAYLOADS, fts: PAYLOADS, history: PAYLOADS, events: PAYLOADS },
+    `I1/I2: ${WRITERS * PAYLOADS} concurrent submissions must leave exactly ${PAYLOADS} observations and one projection each`,
+  );
+
+  // --- I1, claims ------------------------------------------------------------
+  const evidenceId = observed[0]!.res.body.data.observation_id as string;
+  const consolidation = {
+    subject_id: "subject_durability",
+    claims: [{
+      kind: "procedural",
+      statement: "Concurrent writers must converge on one claim per canonical hash.",
+      confidence: 0.9,
+      sources: [{ observation_id: evidenceId, relation: "supports" }],
+    }],
+  };
+  const consolidated = await Promise.all(writers.map((client) =>
+    client.call("POST", "/v1/consolidations", { key: principal.key, body: consolidation })));
+  assertAccepted("consolidations", consolidated);
+  const claimIds = new Set(consolidated.map((res) => res.body.data.claims[0].claim_id as string));
+  assert.equal(claimIds.size, 1, `I1: ${WRITERS} concurrent consolidations minted ${claimIds.size} claims`);
+
+  const [claimRows] = await db.all<{ rows: number; sources: number; fts: number; history: number }>(
+    `SELECT (SELECT COUNT(*) FROM claims WHERE org_id = ? AND actor_id = ?) AS rows,
+            (SELECT COUNT(*) FROM claim_sources s
+               JOIN claims c ON c.id = s.claim_id
+              WHERE c.org_id = ? AND c.actor_id = ?) AS sources,
+            (SELECT COUNT(*) FROM claims_fts f
+               JOIN claims c ON c.id = f.claim_id
+              WHERE c.org_id = ? AND c.actor_id = ?) AS fts,
+            (SELECT COUNT(*) FROM record_history
+              WHERE org_id = ? AND record_type = 'claim') AS history`,
+    [...scope, ...scope, ...scope, principal.orgId],
+  );
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(claimRows!).map(([key, value]) => [key, Number(value)])),
+    { rows: 1, sources: 1, fts: 1, history: 1 },
+    `I1: ${WRITERS} concurrent consolidations must leave exactly one claim and one projection each`,
+  );
+
+  // --- I3, no partial write survives a failed batch ---------------------------
+  const before = await counters(db);
+  let poisoned = false;
+  const faulty: Db = {
+    all: <Row>(sql: string, params: Parameters<Db["all"]>[1] = []) => db.all<Row>(sql, params),
+    exec: (sql: string) => db.exec(sql),
+    async batch(statements: Stmt[]) {
+      if (!poisoned && statements.some((statement) => /INSERT INTO observations\s/u.test(statement.sql))) {
+        poisoned = true;
+        // Fail the last statement of a real write batch. Every earlier statement
+        // in it must roll back with it, on both drivers.
+        await db.batch([
+          ...statements,
+          { sql: `INSERT INTO titen_durability_absent_table (id) VALUES ('x')` },
+        ]);
+        return;
+      }
+      await db.batch(statements);
+    },
+  };
+  const failed = await clientFor(faulty, runtime).call("POST", "/v1/observations", {
+    key: principal.key,
+    body: observationBody(runtime, PAYLOADS),
+  });
+  assert.equal(poisoned, true, "I3: the fault was never injected into a real write batch");
+  assert.ok(
+    failed.status >= 500,
+    `I3: a failed write batch must not report success, got ${failed.status}`,
+  );
+  const after = await counters(db);
+  assert.deepEqual(after, before, "I3: a failed batch left rows behind");
+
+  const report: DurabilityReport = {
+    runtime,
+    writers: WRITERS,
+    payloads: PAYLOADS,
+    canonical_collisions: counted.collisions(),
+    observation_requests: observed.length,
+    observation_created: observed.filter(({ res }) => res.status === 201).length,
+    observation_replayed: observed.filter(({ res }) => res.status === 200).length,
+    observation_failed: 0,
+    observation_rows: Number(observationRows!.rows),
+    observation_canonical_hashes: Number(observationRows!.hashes),
+    claim_requests: consolidated.length,
+    claim_created: consolidated.filter((res) => res.status === 201).length,
+    claim_replayed: consolidated.filter((res) => res.status === 200).length,
+    claim_failed: 0,
+    claim_rows: Number(claimRows!.rows),
+    partial_rows: Object.entries(after)
+      .reduce((total, [key, value]) => total + (value - before[key]!), 0),
+  };
+  process.stderr.write(`[durability] ${JSON.stringify(report)}\n`);
+  return report;
+}

--- a/tests/contract/enrichment.ts
+++ b/tests/contract/enrichment.ts
@@ -399,7 +399,7 @@ export async function assertEnrichmentContract(db: Db, runtime: string): Promise
         visibility: scope?.visibility ?? "private",
         ...(scope ? { workspace_id: scope.workspaceId } : {}),
         ...(occurredAt ? { occurred_at: occurredAt } : {}),
-        source: { type: "contract_fixture" },
+        source: { type: "contract_fixture", ref: "contract://enrichment" },
       },
     });
     assert.equal(response.status, 201);
@@ -479,7 +479,7 @@ export async function assertEnrichmentContract(db: Db, runtime: string): Promise
       subject_id: "subject_capability_recovery",
       kind: "user_statement",
       content: "Corrected extraction startup must recover this canonical evidence.",
-      source: { type: "contract_fixture" },
+      source: { type: "contract_fixture", ref: "contract://enrichment" },
     },
   });
   assert.equal(acceptedWithoutJob.status, 201);
@@ -608,7 +608,7 @@ export async function assertEnrichmentContract(db: Db, runtime: string): Promise
       subject_id: "subject_capability_snapshot",
       kind: "user_statement",
       content: "Capability provenance is frozen before traffic.",
-      source: { type: "contract_fixture" },
+      source: { type: "contract_fixture", ref: "contract://enrichment" },
     },
   });
   assert.equal(mutableObservation.status, 201);

--- a/tests/contract/mcp-compat.test.ts
+++ b/tests/contract/mcp-compat.test.ts
@@ -1,0 +1,355 @@
+import { afterAll, beforeAll, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseReferenceGraph, type ReferenceGraph } from "../../src/core/portability";
+import { importReferenceMemory, openLocalStore } from "../../src/runtime/bun/mcp-stdio";
+import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
+import { provisionWith } from "./harness";
+
+/**
+ * Drop-in substitution for `@modelcontextprotocol/server-memory`.
+ *
+ * The claim being tested is that a user switches by editing one line of MCP
+ * configuration: the same nine tool names, the same arguments, the same
+ * response shapes, and their existing `memory.json` still there afterwards.
+ * So every assertion here is written from the client's side of the wire, and
+ * the fixture is that server's own on-disk format rather than a Titen export.
+ */
+const directory = mkdtempSync(join(tmpdir(), "titen-mcp-compat-"));
+const memoryFile = join(directory, "memory.json");
+const dbPath = join(directory, "memory.db");
+
+/** Exactly what the reference server writes: one JSON object per line. */
+const FIXTURE_LINES = [
+  {
+    type: "entity",
+    name: "billing-service",
+    entityType: "service",
+    observations: [
+      "Handles refund processing and invoice generation for enterprise customers",
+      "Owned by the payments team",
+    ],
+  },
+  {
+    type: "entity",
+    name: "Ada Lovelace",
+    entityType: "person",
+    observations: ["Leads the payments team", "Prefers asynchronous design reviews"],
+  },
+  {
+    type: "entity",
+    name: "checkout-api",
+    entityType: "service",
+    observations: ["Calls billing-service when an order is cancelled"],
+  },
+  { type: "entity", name: "quiet-worker", entityType: "service", observations: [] },
+  { type: "relation", from: "Ada Lovelace", to: "billing-service", relationType: "maintains" },
+  { type: "relation", from: "checkout-api", to: "billing-service", relationType: "depends_on" },
+];
+
+const FIXTURE: ReferenceGraph = parseReferenceGraph(
+  FIXTURE_LINES.map((line) => JSON.stringify(line)).join("\n"),
+);
+
+/**
+ * The reference server's entire search: lower-case substring containment over a
+ * graph re-read from disk. Reimplemented here so the comparison in the search
+ * test is against the real thing rather than against a description of it.
+ */
+function referenceSearch(graph: ReferenceGraph, query: string): ReferenceGraph {
+  const entities = graph.entities.filter((entity) =>
+    entity.name.toLowerCase().includes(query.toLowerCase())
+    || entity.entityType.toLowerCase().includes(query.toLowerCase())
+    || entity.observations.some((observation) =>
+      observation.toLowerCase().includes(query.toLowerCase())));
+  const names = new Set(entities.map((entity) => entity.name));
+  return {
+    entities,
+    relations: graph.relations.filter((relation) =>
+      names.has(relation.from) || names.has(relation.to)),
+  };
+}
+
+let local: Awaited<ReturnType<typeof openLocalStore>>;
+let restrictedKey: string;
+let messageId = 0;
+
+interface ToolReply {
+  isError?: boolean;
+  content: { type: string; text: string }[];
+  structuredContent: any;
+}
+
+async function rpc(method: string, params: unknown, key?: string) {
+  const response = await local.app(new Request("http://127.0.0.1/mcp", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${key ?? local.apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: (messageId += 1), method, params }),
+  }));
+  return await response.json() as { result?: any; error?: { code: number; message: string } };
+}
+
+async function callTool(name: string, args: unknown = {}, key?: string): Promise<ToolReply> {
+  const reply = await rpc("tools/call", { name, arguments: args }, key);
+  assert.equal(reply.error, undefined, `${name} returned a JSON-RPC error`);
+  return reply.result as ToolReply;
+}
+
+/** Every reference tool reports its result twice; a client may read either. */
+function toolResult(reply: ToolReply): any {
+  assert.equal(reply.content[0]!.type, "text");
+  return JSON.parse(reply.content[0]!.text);
+}
+
+const readGraph = async (): Promise<ReferenceGraph> =>
+  (await callTool("read_graph")).structuredContent;
+
+beforeAll(async () => {
+  writeFileSync(memoryFile, `${FIXTURE_LINES.map((line) => JSON.stringify(line)).join("\n")}\n`);
+  local = await openLocalStore(dbPath);
+  const database = createSqliteDb(openDatabase(dbPath));
+  const [organization] = await database.all<{ id: string }>(`SELECT id FROM organizations`);
+  const provisioned = await provisionWith(database, {
+    orgId: organization!.id,
+    scopes: ["mcp:call"],
+  });
+  restrictedKey = provisioned.key;
+});
+
+afterAll(() => {
+  local.close();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+test("an existing memory.json is imported without data loss", async () => {
+  const imported = await importReferenceMemory(local, memoryFile, `${dbPath}.imported`);
+  assert.deepEqual(imported, { entities: 4, relations: 2 });
+
+  // Byte-for-byte the same graph: names, types, observation text and order.
+  assert.deepEqual(await readGraph(), FIXTURE);
+
+  // A second start must not re-import: that would resurrect deleted entities.
+  assert.equal(
+    await importReferenceMemory(local, memoryFile, `${dbPath}.imported`),
+    undefined,
+  );
+  assert.deepEqual(await readGraph(), FIXTURE);
+});
+
+test("the installed entry point adopts a memory.json in the working directory", async () => {
+  const home = join(directory, "adopt-home");
+  const work = join(directory, "adopt-work");
+  mkdirSync(home);
+  mkdirSync(work);
+  writeFileSync(join(work, "memory.json"), [
+    JSON.stringify({
+      type: "entity",
+      name: "billing-service",
+      entityType: "service",
+      observations: ["Handles refunds"],
+    }),
+    JSON.stringify({ type: "relation", from: "checkout-api", to: "billing-service", relationType: "depends_on" }),
+  ].join("\n"));
+
+  const child = Bun.spawn({
+    cmd: ["bun", join(import.meta.dir, "../../src/runtime/bun/cli.ts"), "mcp"],
+    cwd: work,
+    // Deliberately not `...process.env`: this is the no-configuration case.
+    env: { PATH: process.env.PATH ?? "", HOME: home },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  child.stdin.write([
+    { jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "compat", version: "1" } } },
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    { jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "read_graph", arguments: {} } },
+  ].map((message) => `${JSON.stringify(message)}\n`).join(""));
+  child.stdin.end();
+  const [exitCode, stdout, stderr] = await Promise.all([
+    Promise.race([child.exited, Bun.sleep(30_000).then(() => -1)]),
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  assert.equal(exitCode, 0, stderr);
+  // Progress belongs on stderr; stdout is the MCP transport and must stay JSON.
+  assert.match(stderr, /imported 1 entities and 1 relations/);
+  const replies = stdout.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+  assert.deepEqual(replies.at(-1).result.structuredContent, {
+    entities: [{ name: "billing-service", entityType: "service", observations: ["Handles refunds"] }],
+    relations: [{ from: "checkout-api", to: "billing-service", relationType: "depends_on" }],
+  });
+}, 60_000);
+
+test("the nine reference tool names are served with the reference schemas", async () => {
+  const listed = (await rpc("tools/list", {})).result.tools as {
+    name: string;
+    inputSchema: { properties: Record<string, unknown>; required: string[] };
+    annotations: Record<string, boolean>;
+  }[];
+  const byName = new Map(listed.map((tool) => [tool.name, tool]));
+
+  const expected: Record<string, string[]> = {
+    create_entities: ["entities"],
+    create_relations: ["relations"],
+    add_observations: ["observations"],
+    delete_entities: ["entityNames"],
+    delete_observations: ["deletions"],
+    delete_relations: ["relations"],
+    read_graph: [],
+    search_nodes: ["query"],
+    open_nodes: ["names"],
+  };
+  for (const [name, required] of Object.entries(expected)) {
+    const tool = byName.get(name);
+    assert.ok(tool, `${name} must be served`);
+    assert.deepEqual(tool.inputSchema.required, required, `${name} argument names`);
+    assert.deepEqual(Object.keys(tool.inputSchema.properties), required, `${name} properties`);
+  }
+  assert.equal(byName.get("search_nodes")!.annotations.readOnlyHint, true);
+  assert.equal(byName.get("delete_entities")!.annotations.destructiveHint, true);
+  // The Titen tools stay where they were; this is an addition, not a swap.
+  assert.ok(byName.has("titen_remember"));
+});
+
+test("search_nodes finds what the reference server's substring scan cannot", async () => {
+  const query = "which service issues refunds to a customer";
+
+  // The incumbent lower-cases the whole query and asks `String.includes`, so a
+  // question phrased as a question matches nothing at all.
+  assert.deepEqual(referenceSearch(FIXTURE, query).entities, []);
+
+  const found: ReferenceGraph = (await callTool("search_nodes", { query })).structuredContent;
+  assert.equal(
+    found.entities[0]?.name,
+    "billing-service",
+    "ranked retrieval must surface the refund-handling service first",
+  );
+  assert.deepEqual(
+    found.entities[0]!.observations,
+    FIXTURE.entities[0]!.observations,
+    "a hit carries the whole entity, as the reference shape requires",
+  );
+  // Relations reach outside the matched set, exactly as the reference does.
+  assert.ok(found.relations.some((relation) => relation.to === "billing-service"));
+
+  // An unrelated question must not drag the whole graph back.
+  const unrelated: ReferenceGraph =
+    (await callTool("search_nodes", { query: "kubernetes cluster autoscaling" })).structuredContent;
+  assert.deepEqual(unrelated.entities, []);
+});
+
+test("create, add, and open behave as the reference server documents them", async () => {
+  const created = await callTool("create_entities", {
+    entities: [
+      { name: "payments-team", entityType: "team", observations: ["Owns billing-service"] },
+      { name: "billing-service", entityType: "service", observations: ["ignored duplicate"] },
+    ],
+  });
+  assert.deepEqual(created.structuredContent.entities.map((entity: any) => entity.name), [
+    "payments-team",
+  ], "an existing name is skipped and never returned");
+  assert.deepEqual(toolResult(created), created.structuredContent.entities);
+
+  const relations = await callTool("create_relations", {
+    relations: [
+      { from: "payments-team", to: "billing-service", relationType: "owns" },
+      { from: "Ada Lovelace", to: "billing-service", relationType: "maintains" },
+    ],
+  });
+  assert.deepEqual(relations.structuredContent.relations, [
+    { from: "payments-team", to: "billing-service", relationType: "owns" },
+  ], "an existing triple is skipped");
+
+  const added = await callTool("add_observations", {
+    observations: [{
+      entityName: "billing-service",
+      contents: ["Owned by the payments team", "Runs on the shared Bun runtime"],
+    }],
+  });
+  assert.deepEqual(added.structuredContent, {
+    results: [{
+      entityName: "billing-service",
+      addedObservations: ["Runs on the shared Bun runtime"],
+    }],
+  }, "an observation already present is not added twice");
+
+  const missing = await callTool("add_observations", {
+    observations: [{ entityName: "no-such-entity", contents: ["x"] }],
+  });
+  assert.equal(missing.isError, true);
+  assert.match(missing.content[0]!.text, /Entity with name no-such-entity not found/);
+
+  const opened: ReferenceGraph =
+    (await callTool("open_nodes", { names: ["payments-team", "no-such-entity"] })).structuredContent;
+  assert.deepEqual(opened.entities.map((entity) => entity.name), ["payments-team"]);
+  assert.deepEqual(opened.relations, [
+    { from: "payments-team", to: "billing-service", relationType: "owns" },
+  ]);
+});
+
+test("deleting requires the purge capability and then really removes the record", async () => {
+  const seeded = await callTool("create_entities", {
+    entities: [{ name: "temp-entity", entityType: "service", observations: ["short lived"] }],
+  }, restrictedKey);
+  assert.notEqual(seeded.isError, true, "writing needs no new capability");
+
+  const refused = await callTool("delete_entities", { entityNames: ["temp-entity"] }, restrictedKey);
+  assert.equal(refused.isError, true, "purge must fail closed without its scope");
+  assert.match(refused.content[0]!.text, /observations:purge/);
+
+  // The restricted principal's own graph is untouched by the refusal.
+  const stillThere = (await callTool("read_graph", {}, restrictedKey)).structuredContent;
+  assert.deepEqual(stillThere.entities.map((entity: any) => entity.name), ["temp-entity"]);
+
+  const deleted = await callTool("delete_observations", {
+    deletions: [{ entityName: "billing-service", observations: ["Runs on the shared Bun runtime"] }],
+  });
+  assert.deepEqual(deleted.structuredContent, {
+    success: true,
+    message: "Observations deleted successfully",
+  });
+  assert.equal(deleted.content[0]!.text, "Observations deleted successfully");
+
+  await callTool("delete_relations", {
+    relations: [{ from: "checkout-api", to: "billing-service", relationType: "depends_on" }],
+  });
+  const afterRelation = await readGraph();
+  assert.ok(!afterRelation.relations.some((relation) => relation.relationType === "depends_on"));
+
+  const removed = await callTool("delete_entities", { entityNames: ["checkout-api"] });
+  assert.deepEqual(removed.structuredContent, {
+    success: true,
+    message: "Entities deleted successfully",
+  });
+  const graph = await readGraph();
+  assert.ok(!graph.entities.some((entity) => entity.name === "checkout-api"));
+  assert.deepEqual(
+    graph.entities.find((entity) => entity.name === "billing-service")!.observations,
+    [
+      "Handles refund processing and invoice generation for enterprise customers",
+      "Owned by the payments team",
+    ],
+    "only the deleted observation is gone",
+  );
+
+  // Purged evidence must also leave retrieval, not just the graph read.
+  const found: ReferenceGraph =
+    (await callTool("search_nodes", { query: "order cancelled calls" })).structuredContent;
+  assert.ok(!found.entities.some((entity) => entity.name === "checkout-api"));
+
+  // A deleted name is free again: the row is gone, not merely hidden.
+  const recreated = await callTool("create_entities", {
+    entities: [{ name: "checkout-api", entityType: "service", observations: ["rebuilt"] }],
+  });
+  assert.deepEqual(recreated.structuredContent.entities.map((entity: any) => entity.name), [
+    "checkout-api",
+  ]);
+});

--- a/tests/integration/audit.test.ts
+++ b/tests/integration/audit.test.ts
@@ -1,0 +1,225 @@
+import { afterAll, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { auditStore, NOT_MEASURABLE, type AuditReport, type Metric } from "../../src/runtime/bun/audit";
+import { openLocalStore } from "../../src/runtime/bun/mcp-stdio";
+
+const root = mkdtempSync(join(tmpdir(), "titen-audit-"));
+const cli = join(import.meta.dir, "../../src/runtime/bun/cli.ts");
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+const metric = (audit: AuditReport, name: Metric) => {
+  const found = audit.metrics.find((entry) => entry.metric === name);
+  assert.ok(found, `report is missing the ${name} metric`);
+  return found;
+};
+
+/**
+ * A fixture with exactly one planted exact duplicate, one planted near
+ * duplicate, one planted credential, and entries that are none of those. Every
+ * assertion below is an exact count, so a rule that starts over-matching fails
+ * here rather than in someone else's published write-up.
+ */
+const PLANTED = [
+  "Rotate the staging key with AKIAIOSFODNN7EXAMPLE before the release.",
+  "The release branch is cut on Thursday.",
+  "The release branch is cut on Thursday.",
+  "the release branch is cut on thursday!",
+];
+
+test("a reference-server store reports planted duplicates and a planted secret exactly", async () => {
+  const path = join(root, "memory.jsonl");
+  writeFileSync(path, [
+    JSON.stringify({ type: "entity", name: "deploy", entityType: "runbook", observations: PLANTED }),
+    JSON.stringify({ type: "entity", name: "team", entityType: "people", observations: ["Wulan owns the ingest pipeline."] }),
+    JSON.stringify({ type: "relation", from: "team", to: "deploy", relationType: "owns" }),
+    "",
+  ].join("\n"));
+
+  const audit = await auditStore(path);
+  assert.equal(audit.format, "reference-memory");
+  assert.equal(audit.entries, 5);
+  assert.equal(audit.composite_score, null);
+
+  const exact = metric(audit, "exact_duplicate");
+  assert.equal(exact.count, 1);
+  assert.deepEqual(exact.findings.map((finding) => finding.entry_id), ["deploy#3"]);
+  assert.match(exact.findings[0]!.evidence, /byte-identical to deploy#2/);
+
+  const near = metric(audit, "near_duplicate");
+  assert.equal(near.count, 1);
+  assert.deepEqual(near.findings.map((finding) => finding.entry_id), ["deploy#4"]);
+
+  const secret = metric(audit, "secret_pattern");
+  assert.equal(secret.count, 1);
+  assert.deepEqual(secret.findings.map((finding) => finding.entry_id), ["deploy#1"]);
+  assert.match(secret.findings[0]!.evidence, /aws_access_key_id/);
+  // The report is a file the user may hand to someone else. Quoting evidence
+  // must never quote the credential the evidence is about.
+  assert.ok(
+    !JSON.stringify(audit).includes("AKIAIOSFODNN7EXAMPLE"),
+    "the audit report must not reproduce the credential it found",
+  );
+
+  // AC-AUDIT-002: absent signals are absent, not zero, and not a failure.
+  for (const name of ["recall_loop", "stale"] as const) {
+    const absent = metric(audit, name);
+    assert.equal(absent.measurable, false);
+    assert.equal(absent.count, null, `${name} must not be reported as a count`);
+    assert.equal(absent.rate, null);
+    assert.ok(absent.reason?.startsWith(NOT_MEASURABLE), absent.reason);
+    assert.ok(!/fail/i.test(absent.reason ?? ""), "an absent signal is never a failure");
+  }
+});
+
+test("a Mem0 export is audited from the fields it does carry", async () => {
+  const path = join(root, "mem0.json");
+  writeFileSync(path, JSON.stringify({
+    results: [
+      { id: "m1", memory: "Wulan prefers dark mode.", created_at: "2026-08-01T00:00:00.000Z" },
+      { id: "m2", memory: "Wulan prefers dark mode.", created_at: "2026-08-02T00:00:00.000Z" },
+      { id: "m3", memory: "Deploys happen at 09:00 UTC.", created_at: "2026-08-03T00:00:00.000Z" },
+    ],
+  }));
+
+  const audit = await auditStore(path);
+  assert.equal(audit.format, "mem0-export");
+  assert.equal(audit.entries, 3);
+  assert.equal(audit.first_written_at, "2026-08-01T00:00:00.000Z");
+  assert.equal(metric(audit, "exact_duplicate").count, 1);
+  assert.deepEqual(metric(audit, "exact_duplicate").findings.map((f) => f.entry_id), ["m2"]);
+  assert.equal(metric(audit, "near_duplicate").count, 0);
+  assert.equal(metric(audit, "secret_pattern").count, 0);
+  assert.equal(metric(audit, "recall_loop").measurable, false);
+  assert.equal(metric(audit, "stale").measurable, false);
+});
+
+/**
+ * The recall-loop metric is the one that needed the provenance work to land
+ * first. A store that stamps its own recalled writes can be measured; this
+ * proves the stamp reaches the audit, and that the independent text match
+ * against previously served output reaches it too.
+ */
+test("a Titen store measures recall loop and staleness from its own signals", async () => {
+  const dbPath = join(root, "store/memory.db");
+  const local = await openLocalStore(dbPath);
+  const call = async (path: string, body: unknown) => {
+    const response = await local.app(new Request(`http://127.0.0.1${path}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${local.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }));
+    const payload = await response.json() as { data?: Record<string, any>; error?: unknown };
+    assert.ok(response.ok, `${path} failed: ${JSON.stringify(payload)}`);
+    return payload.data!;
+  };
+
+  const STATEMENT = "Deployments are cut on Thursday.";
+  let observed: string;
+  try {
+    const first = await call("/v1/observations", {
+      subject_id: "audit_subject",
+      kind: "user_statement",
+      content: "The team agreed deployments are cut on Thursday.",
+      source: { type: "chat", ref: "thread-1" },
+      trust: "asserted",
+    });
+    observed = first.observation_id as string;
+    // A second, byte-identical write with a different source ref: no source.id,
+    // so Titen's canonical replay key is absent and both rows are kept.
+    await call("/v1/observations", {
+      subject_id: "audit_subject",
+      kind: "user_statement",
+      content: "The team agreed deployments are cut on Thursday.",
+      source: { type: "chat", ref: "thread-2" },
+      trust: "asserted",
+    });
+    await call("/v1/consolidations", {
+      subject_id: "audit_subject",
+      claims: [{
+        kind: "decision",
+        statement: STATEMENT,
+        confidence: 0.9,
+        sources: [{ observation_id: observed, relation: "supports" }],
+      }],
+    });
+    const context = await call("/v1/context/compile", {
+      subject_id: "audit_subject",
+      task: "when are deployments cut",
+      max_tokens: 900,
+    });
+    assert.ok((context.items as unknown[]).length > 0, "the pack must contain the claim just written");
+    // Written back while holding the pack, with the pack's own text: both the
+    // server-assigned stamp and the independent text match should fire.
+    await call("/v1/observations", {
+      subject_id: "audit_subject",
+      kind: "tool_result",
+      content: STATEMENT,
+      source: { type: "agent", ref: "summary-1" },
+      trust: "asserted",
+      context_token: context.context_id,
+    });
+  } finally {
+    local.close();
+  }
+
+  const audit = await auditStore(dbPath);
+  assert.equal(audit.format, "titen-sqlite");
+  assert.equal(audit.entries, 3);
+
+  assert.equal(metric(audit, "exact_duplicate").count, 1);
+
+  const recall = metric(audit, "recall_loop");
+  assert.equal(recall.measurable, true);
+  assert.equal(recall.count, 1);
+  assert.match(recall.findings[0]!.evidence, /provenance "recalled"/);
+  assert.match(recall.findings[0]!.evidence, /served at .*before this entry was written/);
+
+  // The two originals support a claim that was served after they were written;
+  // the recalled write has been served to nobody.
+  const stale = metric(audit, "stale");
+  assert.equal(stale.measurable, true);
+  assert.equal(stale.count, 2);
+  assert.ok(stale.findings.every((finding) => finding.entry_id !== observed));
+});
+
+/**
+ * The offline promise is the reason this is safe to run against a private
+ * store, so it is asserted rather than documented: the installed entry point
+ * runs with a `fetch` that throws on any call.
+ */
+test("the installed CLI produces a report without touching the network", async () => {
+  const preload = join(root, "no-network.ts");
+  writeFileSync(preload, `
+globalThis.fetch = () => {
+  throw new Error("titen audit attempted a network call");
+};
+`);
+  const child = Bun.spawn({
+    cmd: ["bun", "--preload", preload, cli, "audit", join(root, "memory.jsonl"), "--json"],
+    env: { PATH: process.env.PATH ?? "", HOME: root },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  assert.equal(exitCode, 0, stderr);
+  const audit = JSON.parse(stdout) as AuditReport;
+  assert.equal(audit.entries, 5);
+  assert.equal(audit.composite_score, null);
+  assert.equal(metric(audit, "exact_duplicate").count, 1);
+});
+
+test("audit refuses a file it cannot recognize instead of reporting zeros", async () => {
+  const path = join(root, "notes.txt");
+  writeFileSync(path, "this is not a memory store\n");
+  await assert.rejects(auditStore(path), /not a Titen SQLite store/);
+});

--- a/tests/integration/d1-budget.test.ts
+++ b/tests/integration/d1-budget.test.ts
@@ -114,7 +114,7 @@ test("a max-bound enrichment pass fits Paid D1 and saturation stops before model
           subject_id: "subject_d1_max_bound",
           kind: "user_statement",
           content: `Maximum reflection premise ${index}.`,
-          source: { type: "d1_budget_fixture" },
+          source: { type: "d1_budget_fixture", ref: "contract://d1-budget" },
         },
       });
       assert.equal(observed.status, 201);
@@ -157,7 +157,7 @@ test("a max-bound enrichment pass fits Paid D1 and saturation stops before model
           subject_id: `subject_d1_saturation_${index}`,
           kind: "user_statement",
           content: `Due job that must not reach the model ${index}.`,
-          source: { type: "d1_budget_fixture" },
+          source: { type: "d1_budget_fixture", ref: "contract://d1-budget" },
         },
       });
       assert.equal(observed.status, 201);

--- a/tests/integration/durability.test.ts
+++ b/tests/integration/durability.test.ts
@@ -1,0 +1,200 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Db } from "../../src/core/db";
+import { migrate } from "../../src/core/migrations";
+import { createSqliteDb, openDatabase } from "../../src/runtime/bun/sqlite";
+import { provisionWith } from "../contract/harness";
+import { assertConcurrentWriterDurability, PAYLOADS, WRITERS } from "../contract/durability";
+
+const withStore = async (label: string, run: (db: Db) => Promise<void>) => {
+  const directory = mkdtempSync(join(tmpdir(), `titen-durability-${label}-`));
+  const database = openDatabase(join(directory, "titen.db"));
+  try {
+    const db = createSqliteDb(database);
+    await migrate(db);
+    await run(db);
+  } finally {
+    database.close();
+    rmSync(directory, { recursive: true, force: true });
+  }
+};
+
+test("bun:sqlite holds the durability invariants under concurrent writers", async () => {
+  await withStore("core", async (db) => {
+    const report = await assertConcurrentWriterDurability(db, "bun-sqlite");
+    assert.equal(report.observation_requests, WRITERS * PAYLOADS);
+    assert.equal(report.observation_rows, PAYLOADS);
+    assert.equal(report.claim_rows, 1);
+    assert.equal(report.partial_rows, 0);
+  });
+}, 60_000);
+
+/**
+ * The same invariants across operating-system processes.
+ *
+ * Zero-config local mode puts several agents on one `~/.titen/memory.db`, and
+ * an event loop that serialises `bun:sqlite` calls inside one process hides
+ * exactly the contention that deployment creates. These writers are separate
+ * processes on separate connections, so the WAL write lock is real.
+ */
+const PROCESSES = 8;
+/** Payloads every process submits byte-identically. */
+const SHARED = 12;
+/**
+ * Wall-clock slot per payload. Every process first-touches payload `k` at the
+ * same instant, which is what opens the read-then-write window; a single barrier
+ * at the start only aligns the first write, and per-request jitter then spaces
+ * the rest far enough apart that the race never occurs.
+ */
+const SLOT_MS = 30;
+
+const CHILD = (root: string) => `
+import { createApp } from ${JSON.stringify(join(root, "src/core/app.ts"))};
+import { createSqliteDb, openDatabase } from ${JSON.stringify(join(root, "src/runtime/bun/sqlite.ts"))};
+import { countingCanonicalCollisions } from ${JSON.stringify(join(root, "tests/contract/durability.ts"))};
+
+const [path, key, startAt, payloadsJson] = process.argv.slice(2);
+const database = openDatabase(path);
+const counted = countingCanonicalCollisions(createSqliteDb(database));
+const app = createApp({ db: counted.db, runtime: "bun-sqlite", revision: "durability" });
+const payloads = JSON.parse(payloadsJson);
+const submit = async (body) => {
+  const response = await app(new Request("http://durability.test/v1/observations", {
+    method: "POST",
+    headers: { authorization: "Bearer " + key, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }));
+  const parsed = await response.json();
+  return { status: response.status, id: parsed?.data?.observation_id ?? null, error: parsed?.error ?? null };
+};
+
+const deadline = Number(startAt);
+const waitUntil = async (at) => { while (Date.now() < at) await Bun.sleep(Math.min(5, at - Date.now())); };
+await waitUntil(deadline);
+const started = Date.now();
+const results = [];
+for (const [slot, body] of payloads.entries()) {
+  await waitUntil(deadline + slot * ${SLOT_MS});
+  results.push(await submit(body));
+}
+database.close();
+console.log(JSON.stringify({ started, ended: Date.now(), collisions: counted.collisions(), results }));
+`;
+
+test("concurrent bun:sqlite processes hold the durability invariants on one file", async () => {
+  const root = resolve(import.meta.dir, "../..");
+  const directory = mkdtempSync(join(tmpdir(), "titen-durability-processes-"));
+  const dbPath = join(directory, "titen.db");
+  const childPath = join(directory, "writer.ts");
+  writeFileSync(childPath, CHILD(root));
+  const database = openDatabase(dbPath);
+  let principal: Awaited<ReturnType<typeof provisionWith>>;
+  try {
+    const db = createSqliteDb(database);
+    await migrate(db);
+    principal = await provisionWith(db, { scopes: ["*"] });
+  } finally {
+    // Release the parent connection so only the child processes contend.
+    database.close();
+  }
+
+  const body = (id: string, content: string) => ({
+    subject_id: "subject_durability_processes",
+    kind: "tool_result",
+    content,
+    source: { type: "tool", ref: "durability", id },
+    trust: "verified",
+  });
+  const shared = Array.from({ length: SHARED }, (_, index) =>
+    body(`shared-${index}`, `Shared durability probe ${index}.`));
+
+  try {
+    const startAt = Date.now() + 2_500;
+    const children = Array.from({ length: PROCESSES }, (_, writer) =>
+      Bun.spawn({
+        cmd: [
+          process.execPath, "run", childPath, dbPath, principal!.key, String(startAt),
+          JSON.stringify([...shared, body(`writer-${writer}`, `Writer ${writer} probe.`)]),
+        ],
+        stdout: "pipe",
+        stderr: "pipe",
+      }));
+    const outcomes = await Promise.all(children.map(async (child) => {
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      assert.equal(code, 0, `writer process exited ${code}: ${stderr}`);
+      return JSON.parse(stdout) as {
+        started: number;
+        ended: number;
+        collisions: number;
+        results: { status: number; id: string | null; error: unknown }[];
+      };
+    }));
+
+    const rejected = outcomes.flatMap((outcome) =>
+      outcome.results.filter((result) => result.status !== 200 && result.status !== 201));
+    assert.equal(
+      rejected.length,
+      0,
+      `I2: ${rejected.length} cross-process writes were rejected: ${JSON.stringify(rejected.slice(0, 3))}`,
+    );
+
+    const latestStart = Math.max(...outcomes.map((outcome) => outcome.started));
+    const earliestEnd = Math.min(...outcomes.map((outcome) => outcome.ended));
+    assert.ok(
+      latestStart < earliestEnd,
+      `the ${PROCESSES} writers never overlapped: last start ${latestStart}, first end ${earliestEnd}`,
+    );
+
+    const identities = new Map<string, Set<string>>();
+    for (const outcome of outcomes)
+      for (const [index, result] of outcome.results.entries()) {
+        const key = String(index % (SHARED + 1));
+        if (index % (SHARED + 1) < SHARED)
+          identities.set(key, (identities.get(key) ?? new Set()).add(result.id!));
+      }
+    for (const [payload, ids] of identities)
+      assert.equal(ids.size, 1, `I1: shared payload ${payload} minted ${ids.size} identities across processes`);
+
+    const verify = openDatabase(dbPath);
+    try {
+      const db = createSqliteDb(verify);
+      const [rows] = await db.all<{ rows: number; hashes: number; fts: number; history: number }>(
+        `SELECT (SELECT COUNT(*) FROM observations) AS rows,
+                (SELECT COUNT(DISTINCT canonical_hash) FROM observations) AS hashes,
+                (SELECT COUNT(*) FROM observations_fts) AS fts,
+                (SELECT COUNT(*) FROM record_history WHERE record_type = 'observation') AS history`,
+      );
+      const expected = SHARED + PROCESSES;
+      assert.deepEqual(
+        Object.fromEntries(Object.entries(rows!).map(([key, value]) => [key, Number(value)])),
+        { rows: expected, hashes: expected, fts: expected, history: expected },
+        "I1/I2: cross-process writers must leave one row per canonical hash and lose none",
+      );
+      process.stderr.write(`[durability] ${JSON.stringify({
+        runtime: "bun-sqlite-multiprocess",
+        processes: PROCESSES,
+        shared_payloads: SHARED,
+        requests: outcomes.reduce((total, outcome) => total + outcome.results.length, 0),
+        created: outcomes.reduce((total, outcome) =>
+          total + outcome.results.filter((result) => result.status === 201).length, 0),
+        replayed: outcomes.reduce((total, outcome) =>
+          total + outcome.results.filter((result) => result.status === 200).length, 0),
+        failed: rejected.length,
+        canonical_collisions: outcomes.reduce((total, outcome) => total + outcome.collisions, 0),
+        overlap_ms: earliestEnd - latestStart,
+        observation_rows: Number(rows!.rows),
+      })}\n`);
+    } finally {
+      verify.close();
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}, 120_000);

--- a/tests/integration/enrichment-runtime.test.ts
+++ b/tests/integration/enrichment-runtime.test.ts
@@ -58,7 +58,7 @@ test("the Bun timer derives recallable memory without an operator drain", async 
       subject_id: "subject_runtime",
       kind: "user_statement",
       content: "The Bun timer should enrich this raw conversation.",
-      source: { type: "runtime_fixture" },
+      source: { type: "runtime_fixture", ref: "contract://enrichment-runtime" },
     });
     assert.equal(observation.response.status, 201);
 
@@ -183,7 +183,7 @@ test("an incomplete HTTP completion leaves no durable semantic output", async ()
         subject_id: "subject_incomplete",
         kind: "user_statement",
         content: "Synthetic incomplete completion evidence.",
-        source: { type: "test" },
+        source: { type: "test", ref: "contract://enrichment-runtime" },
       }),
     });
     assert.equal(observation.status, 201);
@@ -246,7 +246,7 @@ test("the Bun drain route outlives the default ten-second idle timeout", async (
         subject_id: "subject_slow",
         kind: "user_statement",
         content: "Synthetic slow provider evidence.",
-        source: { type: "test" },
+        source: { type: "test", ref: "contract://enrichment-runtime" },
       }),
     })).status, 201);
     const started = performance.now();
@@ -301,7 +301,7 @@ test("the Bun drain returns a retryable result at the extraction timeout", async
         subject_id: "subject_timeout",
         kind: "user_statement",
         content: "Synthetic timeout evidence.",
-        source: { type: "test" },
+        source: { type: "test", ref: "contract://enrichment-runtime" },
       }),
     })).status, 201);
     const drain = await fetch(`${running.url}/v1/enrichment/drain?limit=1`, {

--- a/tests/integration/local-mode.test.ts
+++ b/tests/integration/local-mode.test.ts
@@ -1,0 +1,238 @@
+import { afterAll, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openLocalStore } from "../../src/runtime/bun/mcp-stdio";
+import { serve } from "../../src/runtime/bun/server";
+import { openDatabase } from "../../src/runtime/bun/sqlite";
+
+const root = mkdtempSync(join(tmpdir(), "titen-local-mode-"));
+const cli = join(import.meta.dir, "../../src/runtime/bun/cli.ts");
+
+/**
+ * Zero-config local mode claims it never reaches the network. Preloading a
+ * throwing `fetch` turns that claim into something the run can fail on: the
+ * bridge path would call it, the in-process path must not.
+ */
+const preload = join(root, "no-network.ts");
+writeFileSync(preload, `
+globalThis.fetch = () => {
+  throw new Error("local mode attempted a network call");
+};
+`);
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+const initialize = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "local-mode-test", version: "1" },
+  },
+};
+const initialized = { jsonrpc: "2.0", method: "notifications/initialized" };
+
+const call = (id: number, name: string, args: Record<string, unknown>) => ({
+  jsonrpc: "2.0",
+  id,
+  method: "tools/call",
+  params: { name, arguments: args },
+});
+
+/** Drives the installed entry point over stdio with no Titen environment at all. */
+async function stdio(home: string, messages: unknown[], env: Record<string, string> = {}) {
+  const child = Bun.spawn({
+    cmd: ["bun", "--preload", preload, cli, "mcp"],
+    // Deliberately not `...process.env`: this is the no-configuration case.
+    env: { PATH: process.env.PATH ?? "", HOME: home, ...env },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  child.stdin.write(messages.map((message) => `${JSON.stringify(message)}\n`).join(""));
+  child.stdin.end();
+  const [exitCode, stdout, stderr] = await Promise.all([
+    Promise.race([child.exited, Bun.sleep(20_000).then(() => -1)]),
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  const lines = stdout.split("\n").filter((line) => line.trim() !== "");
+  return { exitCode, stderr, stdout, replies: lines.map((line) => JSON.parse(line)) };
+}
+
+const toolResult = (reply: any) => JSON.parse(reply.result.content[0].text);
+
+test("with no environment set, the stdio entry point serves memory from ~/.titen", async () => {
+  const home = join(root, "fresh");
+  mkdirSync(home);
+  const statement = "Titen local mode needs no API key and no server.";
+
+  const first = await stdio(home, [
+    initialize,
+    initialized,
+    { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    call(3, "titen_project_resolve", { reference: "local" }),
+    call(4, "titen_remember", {
+      subject_id: "local-mode",
+      kind: "user_statement",
+      content: statement,
+      source_type: "chat",
+      source_ref: "local-mode-test#1",
+      // Above the default, so it passes assertTrustCeiling only because the
+      // provisioned owner is a real credential row carrying a real ceiling.
+      // (`policy_approved` is reserved for the claim-approval workflow.)
+      trust: "verified",
+    }),
+  ]);
+  assert.equal(first.exitCode, 0, first.stderr);
+  assert.equal(first.stderr, "", "stdio transport keeps stdout and stderr clean");
+  assert.equal(first.replies.length, 4, "the notification gets no reply");
+
+  const [handshake, tools, project, remembered] = first.replies;
+  assert.equal(handshake.result.serverInfo.name, "titen");
+  assert.equal(handshake.result.protocolVersion, "2025-06-18");
+  assert.ok(
+    tools.result.tools.some((tool: { name: string }) => tool.name === "titen_remember"),
+    "the same MCP tool surface is served locally",
+  );
+  // The provisioned project resolves without `create`, so it is a real row.
+  assert.equal(toolResult(project).data.project_id, "project_local");
+  assert.notEqual(remembered.result.isError, true, remembered.result.content?.[0]?.text);
+  const observation = toolResult(remembered).data;
+  assert.match(observation.observation_id, /^obs_/);
+  assert.equal(observation.trust, "verified");
+  const observationId = observation.observation_id;
+
+  // A second process proves the store persists and that startup is idempotent.
+  const second = await stdio(home, [
+    initialize,
+    initialized,
+    call(2, "titen_consolidate", {
+      subject_id: "local-mode",
+      claims: [{
+        kind: "semantic_fact",
+        statement,
+        confidence: 0.9,
+        sources: [{ observation_id: observationId, relation: "supports" }],
+      }],
+    }),
+    call(3, "titen_compile", {
+      subject_id: "local-mode",
+      task: "does local mode need an API key",
+      max_tokens: 500,
+    }),
+  ]);
+  assert.equal(second.exitCode, 0, second.stderr);
+  const [, consolidated, compiled] = second.replies;
+  assert.notEqual(consolidated.result.isError, true, consolidated.result.content?.[0]?.text);
+  const pack = toolResult(compiled);
+  assert.deepEqual(pack.data.items.map((item: { claim: string }) => item.claim), [statement]);
+  // FTS only: no embedding provider is configured, so nothing can call out.
+  assert.equal(pack.meta.degraded.vector, "disabled");
+  assert.equal(pack.meta.degraded.embedding, "disabled");
+  assert.equal(pack.meta.degraded.lexical, "used");
+}, 60_000);
+
+test("the local store holds real organization, workspace, project and owner rows", async () => {
+  const home = join(root, "records");
+  mkdirSync(home);
+  await stdio(home, [initialize]);
+  await stdio(home, [initialize]);
+
+  const dbPath = join(home, ".titen", "memory.db");
+  assert.equal(statSync(dbPath).mode & 0o777, 0o600, "the store is not world readable");
+  assert.equal(statSync(`${dbPath}.key`).mode & 0o777, 0o600, "the owner key is not world readable");
+
+  const database = openDatabase(dbPath, { create: false, readonly: true });
+  try {
+    const rows = (sql: string) => database.query(sql).all() as Record<string, string>[];
+    assert.deepEqual(
+      rows("SELECT id, name FROM organizations"),
+      [{ id: "org_local", name: "Local" }],
+      "a second run adopts the first run's organization instead of adding another",
+    );
+    assert.deepEqual(rows("SELECT id, name FROM workspaces"), [{ id: "ws_local", name: "Local" }]);
+    assert.deepEqual(
+      rows("SELECT id, reference FROM projects"),
+      [{ id: "project_local", reference: "local" }],
+    );
+    assert.deepEqual(
+      rows(`SELECT principal_id, role, workspace_id FROM memberships ORDER BY workspace_id`),
+      [
+        { principal_id: "owner", role: "owner", workspace_id: null as unknown as string },
+        { principal_id: "owner", role: "owner", workspace_id: "ws_local" },
+      ],
+    );
+    assert.deepEqual(rows("SELECT principal_id, username FROM operator_accounts"), [
+      { principal_id: "owner", username: "owner" },
+    ]);
+    // One reusable credential row, not one per process: the key file is reused.
+    assert.deepEqual(
+      rows(`SELECT org_id, principal_id, scopes, max_trust, revoked_at FROM api_keys`),
+      [{
+        org_id: "org_local",
+        principal_id: "owner",
+        scopes: "*",
+        max_trust: "policy_approved",
+        revoked_at: null as unknown as string,
+      }],
+    );
+  } finally {
+    database.close();
+  }
+}, 60_000);
+
+test("local mode authenticates for real and never downgrades a partial configuration", async () => {
+  const dbPath = join(root, "predicates", "memory.db");
+  const local = await openLocalStore(dbPath);
+  try {
+    const mcp = (headers: Record<string, string>) =>
+      local.app(new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...headers },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }));
+
+    assert.equal((await mcp({})).status, 401, "the in-process app still requires a credential");
+    assert.equal(
+      (await mcp({ authorization: "Bearer titen_sk_not-a-real-key" })).status,
+      401,
+      "an unissued key is rejected by the same core predicate",
+    );
+    assert.equal((await mcp({ authorization: `Bearer ${local.apiKey}` })).status, 200);
+  } finally {
+    local.close();
+  }
+
+  // Half a configuration is a mistake, not an invitation to open a local store.
+  const partial = await stdio(join(root, "predicates"), [initialize], {
+    TITEN_MCP_URL: "http://127.0.0.1:8787/mcp",
+  });
+  assert.notEqual(partial.exitCode, 0);
+  assert.match(partial.stderr, /TITEN_MCP_URL and TITEN_API_KEY/);
+  assert.equal(partial.replies.length, 0);
+}, 60_000);
+
+test("the served entry point still rejects an unauthenticated request", async () => {
+  const running = await serve({
+    dbPath: join(root, "served.db"),
+    port: 0,
+    hostname: "127.0.0.1",
+    quiet: true,
+    maintenanceIntervalMs: 0,
+  });
+  try {
+    const response = await fetch(`${running.url}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assert.equal(response.status, 401);
+  } finally {
+    await running.stop();
+  }
+});

--- a/tests/integration/mcp-protocol.test.ts
+++ b/tests/integration/mcp-protocol.test.ts
@@ -138,7 +138,9 @@ test("ping answers, and the full handshake completes in order", async () => {
 
   const tools = await rpc({ jsonrpc: "2.0", id: 3, method: "tools/list" });
   assert.ok(Array.isArray(tools.body.result.tools), "tools must be an array");
-  assert.equal(tools.body.result.tools.length, 9, "every ordinary-agent tool must be advertised");
+  // Nine native `titen_*` tools plus the nine @modelcontextprotocol/server-memory
+  // names served for drop-in substitution (#279).
+  assert.equal(tools.body.result.tools.length, 18, "every ordinary-agent tool must be advertised");
   for (const tool of tools.body.result.tools) {
     assert.ok(typeof tool.name === "string" && tool.name.length > 0);
     assert.ok(typeof tool.description === "string" && tool.description.length > 0);

--- a/tests/integration/shutdown-maintenance.test.ts
+++ b/tests/integration/shutdown-maintenance.test.ts
@@ -42,7 +42,7 @@ async function victim(directory: string) {
     subject_id: "subject_shutdown",
     kind: "tool_result",
     content: "Synthetic shutdown evidence.",
-    source: { type: "test" },
+    source: { type: "test", ref: "contract://maintenance" },
     trust: "verified",
   });
   const consolidation = await call(running.url, principal.key, "POST", "/v1/consolidations", {
@@ -96,7 +96,7 @@ async function multiphaseVictim(directory: string) {
     subject_id: "subject_multiphase_shutdown",
     kind: "tool_result",
     content: "Synthetic multiphase shutdown evidence.",
-    source: { type: "test" },
+    source: { type: "test", ref: "contract://maintenance" },
     trust: "verified",
   });
   const consolidation = await call(running.url, principal.key, "POST", "/v1/consolidations", {

--- a/tests/sdk/sdk.test.ts
+++ b/tests/sdk/sdk.test.ts
@@ -144,7 +144,7 @@ test("claim lifecycle calls resolve through the client", async () => {
     subject_id: "user_sdk_lifecycle",
     kind: "user_statement",
     content: "The old retry budget was three attempts.",
-    source: { type: "chat" },
+    source: { type: "chat", ref: "contract://sdk" },
     trust: "verified",
   });
   const first = await titen.consolidate("user_sdk_lifecycle", [
@@ -211,7 +211,7 @@ test("key management round-trips and a scoped key is enforced", async () => {
         subject_id: "user_sdk",
         kind: "tool_result",
         content: "This write is not permitted for a compile-only key.",
-        source: { type: "tool" },
+        source: { type: "tool", ref: "contract://sdk" },
       }),
     (error: unknown) => {
       assert.ok(error instanceof TitenError, "the SDK must throw TitenError");
@@ -679,7 +679,7 @@ test("typed mutation sends one idempotency header and the capability matrix stay
       subject_id: "subject",
       kind: "tool_result",
       content: "captured",
-      source: { type: "test" },
+      source: { type: "test", ref: "contract://sdk" },
     },
     { idempotencyKey: "retry-one" },
   );


### PR DESCRIPTION
Ships **S1–S5** of the [substitution and write-hygiene plan](https://github.com/RamaAditya49/titen/blob/main/docs/plans/active/2026-08-06-substitution-and-write-hygiene.md) (#278–#282). **S6** (#283) is documented but blocked on a release, for a reason the work itself uncovered.

## What ships

| | |
|---|---|
| **S1** | `npx titen-memory mcp` with no environment opens `~/.titen/memory.db`, provisions org/workspace/project/owner as **real rows**, serves MCP over stdio in-process. No HTTP hop, no key, no outbound call. |
| **S2** | The nine `@modelcontextprotocol/server-memory` tool names served alongside the native ones, `search_nodes` routed through Titen retrieval rather than a substring scan, `memory.json` imported on first run. Switching cost: one line of MCP config. |
| **S3** | `source.ref` required on the HTTP write path; `recalled` provenance **server-issued** from a context token, not caller-declared. Stateless HMAC — no new table, no migration. |
| **S4** | `titen audit` over a `memory.json`, a Mem0 export, or a Titen store. No network, no composite score, no leaderboard. |
| **S5** | Concurrent-writer durability suite on both runtimes, invariants published before the run. |

## Two things worth reading the diff for

**S1 declined the shortcut I suggested.** The plan said to reuse `serve()`'s `app`. The implementation refused, because `serve()` binds a listening socket — shipping a mode whose headline is "no network" while it opens a TCP listener would make the one claim it has false. `src/core/` is untouched and still has zero external imports.

**S4's first published run is against our own store, and it opens by naming two defects in this product** — 17.9% byte-identical duplicates six seconds after write, 96.7% never read back, and the compatibility surface turning one entity into six. It also states the number it *cannot* report: there is no 32-day Titen store, so nothing in it bounds long-run accumulation.

## Five repairs are mine, not the implementations'

Four were stale nine-tool assertions that S2 invalidated — contract cases, MCP protocol test, `verify-pack`'s expected list, and `verify-pack`'s stdio handshake.

The fifth is worse and belongs on the record. Propagating S3's new `source.ref` obligation across fixtures, I ran a regex broad enough to hit a **negative test that omits the field on purpose**, which made a write that must be refused succeed. I initially misread the resulting D1 failure as a dual-runtime security divergence. It was not — it was my edit. **The contract suite caught it, not me.** That test now carries a comment saying not to "fix" it.

The same propagation repaired `scripts/verify-live.ts`, which is not a test but the tool an operator points at a real deployment. It would have started failing in production after the next release.

## Verification

```
pnpm test:all      exit 0 — 118 D1, 142 Bun contract, 215 integration, 6 dashboard
verify-pack.sh     OK — titen-memory-0.6.1.tgz is publishable (9/9 steps)
```

## Follow-ups filed

#285 — the nine compatibility names ship undocumented on titen.dev, so the substitution play currently has no discovery path.
