### PR TITLE
fix: ask the OS for a test port instead of guessing one inside the ephemeral range

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const port = process.env.PLAYWRIGHT_PORT ?? String(20_000 + [...process.cwd()].reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) >>> 0, 0) % 40_000);
+// Deterministic per worktree so parallel checkouts do not collide and
+// reuseExistingServer can find its own server. Kept under 32768 — the kernel's
+// ephemeral floor — so it is never a port an unrelated outbound socket holds.
+const port = process.env.PLAYWRIGHT_PORT ?? String(20_000 + [...process.cwd()].reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) >>> 0, 0) % 12_000);
 
 export default defineConfig({
   testDir: "./tests",

--- a/scripts/verify-dashboard-live.ts
+++ b/scripts/verify-dashboard-live.ts
@@ -222,7 +222,12 @@ await call("/v1/handoffs", {
   message: "Verify the live dashboard product map as its human owner.",
 }, approver);
 
-const port = 44_000 + Math.floor(Math.random() * 1000);
+// The adapter binds in a child process, so its port has to be known first.
+// Reserve one from the OS and release it: a narrow race, unlike guessing a
+// number inside the kernel's ephemeral range.
+const reservation = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("reserved") });
+const port = reservation.port;
+await reservation.stop(true);
 const adapter = Bun.spawn({
   cmd: [process.execPath, "scripts/dashboard-adapter.ts"],
   env: {

--- a/tests/integration/dashboard-session.test.ts
+++ b/tests/integration/dashboard-session.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-const upstreamPort = 47_000 + Math.floor(Math.random() * 1_000);
-const adapterPort = 48_000 + Math.floor(Math.random() * 1_000);
-const base = `http://127.0.0.1:${adapterPort}`;
+let upstreamPort = 0;
+let adapterPort = 0;
+let base = "";
 const sessionKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const principals: Record<string, Record<string, unknown>> = {
   titen_sk_session_a: {
@@ -87,7 +87,7 @@ async function startAdapter(sharedKey = true) {
 beforeAll(async () => {
   upstream = Bun.serve({
     hostname: "127.0.0.1",
-    port: upstreamPort,
+    port: 0,
     async fetch(request) {
       const url = new URL(request.url);
       const key = bearer(request);
@@ -172,6 +172,14 @@ beforeAll(async () => {
       return Response.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
     },
   });
+  upstreamPort = upstream.port;
+  // The adapter binds in a child process, so its port has to be known first.
+  // Reserve one from the OS and release it: a narrow race, unlike guessing a
+  // number inside the kernel's ephemeral range.
+  const reservation = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("reserved") });
+  adapterPort = reservation.port;
+  base = `http://127.0.0.1:${adapterPort}`;
+  await reservation.stop(true);
   await startAdapter();
 });
 


### PR DESCRIPTION
Fixes #289.

## What changed

`tests/integration/dashboard-session.test.ts` picked both of its ports by rolling a die inside 47000-48999. That window sits inside `/proc/sys/net/ipv4/ip_local_port_range` (`32768 60999`), so any unrelated process holding ephemeral sockets could own the number the test guessed, and `beforeAll` would fail the whole file as one unnamed failure.

- **upstream mock** — `Bun.serve({ port: 0 })`, read back `server.port`. The constant is gone.
- **adapter port** — the adapter binds in a child process via `TITEN_DASHBOARD_PORT`, so the number has to exist before the bind. Uses the reservation shape already in `tests/integration/dashboard-adapter.test.ts:7` and `tests/integration/cli.test.ts:459`: bind `port: 0`, read `.port`, `stop(true)`.
- **`scripts/verify-dashboard-live.ts:225`** — same guess (44000-44999), same reservation.
- **`playwright.config.ts:3`** — hashes cwd into a port; `reuseExistingServer: true` depends on that determinism, so the hash stays. Its range moved from `% 40_000` (20000-59999, ~70% inside the ephemeral range — this worktree drew 48545) to `% 12_000` (20000-31999, entirely below the ephemeral floor). One number.

No retry, no sleep, no `EADDRINUSE` catch. `src/core/**` untouched; no new dependency.

## What this does *not* cover

The adapter fix is a **narrowed race, not an eliminated one**. Between `reservation.stop(true)` and the child process binding, the kernel can hand that port to someone else. The window is microseconds instead of the whole test run, and the port is one the OS just told us was free rather than one we invented — but it is not airtight. Eliminating it needs socket inheritance across the spawn, which is more machinery than this bug is worth.

The `playwright.config.ts` change assumes an ephemeral floor of 32768. That is the value on both hosts here and the Linux default; a host tuned lower would still be exposed.

## Verification

Reproduced first, on this laptop.

**Deterministic — both guess windows occupied by 2000 listeners:**

| | result |
|---|---|
| old code | **0/5 passed** — `error: Failed to start server. Is port 47688 in use?` (and 47248, 47349, 47218, 47101) |
| new code | **5/5 passed** |

The error text matches the three reports in the issue verbatim.

**Faithful — 24000 held ephemeral sockets (625 of them inside 47000-47999), which is the condition the issue describes after a benchmark run:**

| | result |
|---|---|
| old code | **2/10 passed.** 6 failed with `Is port 47xxx in use?`; 2 failed as `hook timed out` — that is the *adapter* port (48xxx) losing, where the child cannot bind and `startAdapter` polls out. Both windows demonstrated. |
| new code | **20/20 passed** |

**Repeat runs of the affected file, new code:** 10/10 clean, 20/20 under the socket pressure above. 35/35 total across all conditions, 0 failures.

**Required gate:**

- `pnpm test:all` — pass. 9 route-doc, 142 contract across 3 files, 215 integration across 27 files, `verify-dashboard-live` OK, 6 browser passed / 2 skipped (on port 28545, the new hash). Run twice, both green.
- `bash scripts/verify-pack.sh` — `OK — titen-memory-0.7.0.tgz is publishable.`
- `node scripts/check-workflow-docs.mjs` — `workflow docs OK (102 artifacts)`
- `node scripts/check-ponytail-debt.mjs` — `OK (1 tracked markers)`

## Sweep

Every other `Bun.serve`/`serve()` in `tests/` and `scripts/` already uses `port: 0` or the reservation pattern — `embedding-validation`, `sqlite-vec`, `webhooks`, `cli`, `mcp-protocol`, `dashboard-adapter`, and the rest. The two random-port sites above were the only offenders. The remaining fixed numbers are either unreachable-on-purpose (`127.0.0.1:9`), outbound URLs to services that are not bound (`11434`), or below the ephemeral floor with an explicit flag (`dashboard-adapter.ts` 4322, `rehearse-upgrade.ts` 8901). Left alone.

Branched from `main`, independent of #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)